### PR TITLE
PR-05 · Add .claude/rules ruleset

### DIFF
--- a/.claude/rules/00-invariants.md
+++ b/.claude/rules/00-invariants.md
@@ -1,0 +1,60 @@
+---
+id: rules-invariants
+type: rules
+status: accepted
+owns: [backend/crates/crypto/, backend/proto/, docker-compose.dev.yml]
+read_when: [starting any session, touching crypto, changing configuration]
+---
+
+# 00 · Invariants
+
+Predicates for [`AGENTS.md`](../../AGENTS.md) §1. AGENTS.md states the law; this file
+states how to **test** it. Where the two disagree, AGENTS.md wins.
+
+**Read this first, every session.** Flipping a predicate from PASS to FAIL is forbidden.
+If a task appears to require it, stop and ask the user.
+
+**Convention: every check prints its violations. Empty output means PASS.**
+
+| ID | Invariant | Predicate | Today | Owned by |
+|---|---|---|---|---|
+| `ZK-INIT` | I-1 | Tracing is initialised only via `guardyn_common::observability::init_tracing` | FAIL (2) | PR-26 |
+| `ZK-PII` | I-1 | No log macro is passed a raw IP, email or phone number | FAIL (2) | **none — open an issue** |
+| `E2EE-FLAG` | I-2 | No configuration key can turn encryption off | FAIL (4) | PR-32 |
+| `E2EE-DUP` | I-2 | No handler has a non-E2EE twin | FAIL (2) | PR-32 |
+| `PQ-DEFAULT` | I-3 | The `pq` feature is on by default in the crypto crate | FAIL | PR-38 |
+| `PQ-WIRE` | I-3 | The wire contract carries ML-KEM key material | FAIL | PR-36 |
+| `SOV-DOMAIN` | I-4 | Every hostname derives from `${DOMAIN}` | FAIL (1) | **none — open an issue** |
+| `SOV-STORE` | I-4 | No datastore added, replaced or removed without an accepted ADR | PASS | reviewer |
+
+Run from the repository root:
+
+```sh
+echo "ZK-INIT";    grep -rln --include='*.rs' -e FmtSubscriber -e 'tracing_subscriber::fmt()' backend/crates/*/src
+echo "ZK-PII";     grep -rnE '(trace|debug|info|warn|error)!\(' --include='*.rs' backend/crates/*/src \
+                     | grep -iE '"[^"]*\b(ip|email|phone)\b[^"]*"[^)]*,'
+echo "E2EE-FLAG";  grep -rln 'GUARDYN_E2EE_ENABLED\|GUARDYN_MLS_ENABLED' backend infra docker-compose.dev.yml
+echo "E2EE-DUP";   ls backend/crates/messaging-service/src/handlers/*_e2ee.rs 2>/dev/null
+echo "PQ-DEFAULT"; grep -E '^default = ' backend/crates/crypto/Cargo.toml | grep -v '"pq"'
+echo "PQ-WIRE";    grep -rL 'ml_kem' backend/proto/common.proto
+echo "SOV-DOMAIN"; grep -rn 'host:' infra/k8s --include='*.yaml' | grep -v DOMAIN
+```
+
+## Reading the failures
+
+`E2EE-DUP` is inverted on purpose: a `*_e2ee.rs` file existing *proves* a non-E2EE
+original still sits beside it. After PR-32 there is one handler, unsuffixed. Note that
+[`AGENTS.md`](../../AGENTS.md) §1 says four such pairs exist; the measured count is **two**
+(`send_message`, `receive_messages`).
+
+`PQ-WIRE` fails while `crypto/src/pqxdh.rs` is a complete hybrid X25519 + ML-KEM-768
+implementation. It is unreached, not absent — no proto field can carry the public key.
+
+**A known failure is not licence to patch it.** Six of these have an owned step; fixing one
+outside that step breaks the micro-step contract. The two marked *none* were found while
+writing this file and need an issue opened before any fix.
+
+## Detail
+
+Logging rules: [`30-zk-logging.md`](30-zk-logging.md).
+Datastore, proto and Rust rules: [`20-code-style.md`](20-code-style.md).

--- a/.claude/rules/10-git-workflow.md
+++ b/.claude/rules/10-git-workflow.md
@@ -1,0 +1,61 @@
+---
+id: rules-git-workflow
+type: rules
+status: accepted
+owns: [.github/, CONTRIBUTING.md]
+read_when: [before any commit, before opening a PR, starting a micro-step]
+---
+
+# 10 · Git workflow
+
+Predicates for [`AGENTS.md`](../../AGENTS.md) §2 and `implementation_plan.md` §3.
+
+**Convention: every check prints its violations. Empty output means PASS.**
+
+| ID | Predicate |
+|---|---|
+| `GIT-NOTMAIN` | `HEAD` is not `main` or `master` |
+| `GIT-BRANCH` | Branch is `<type>/<issue>-<slug>`, `<type>` ∈ `feat fix docs refactor chore security` |
+| `GIT-BUDGET` | The branch changes ≤400 lines **or** ≤8 files against `origin/main` |
+| `GIT-CLOSES` | The PR body contains exactly one `Closes #N` |
+| `GIT-SCOPE` | The PR body states what was deliberately left out of scope |
+
+```sh
+echo "GIT-NOTMAIN"; git branch --show-current | grep -xE 'main|master'
+echo "GIT-BRANCH";  git branch --show-current \
+                      | grep -vE '^(feat|fix|docs|refactor|chore|security)/[0-9]+-[a-z0-9-]+$'
+echo "GIT-BUDGET";  git diff --numstat origin/main...HEAD \
+                      | awk '{a+=$1; d+=$2; f++} END {if (f>8 && a+d>400)
+                              printf "over budget: %d files, %d lines\n", f, a+d}'
+```
+
+`GIT-CLOSES` and `GIT-SCOPE` are read off the PR body, not the tree.
+
+## The budget is a ceiling on *hand-written* work
+
+Bulk deletions and generated or vendored files do not count — but a PR that invokes that
+exemption must contain **nothing else**. If the exemption is not needed, do not invoke it:
+state the real numbers in the PR body instead.
+
+`GIT-BUDGET` prints only when *both* limits are exceeded, because the contract is
+"≤400 lines **or** ≤8 files". A 12-file, 90-line documentation PR is inside budget; a
+2-file, 900-line one is not.
+
+## Splitting
+
+A step that will exceed budget is split **before** the branch is opened, not after the diff
+grows. Each half gets its own issue: one micro-step is one branch, one PR, one issue. Never
+retro-fit a second step onto an existing issue.
+
+## Gates
+
+Phases end at **G1–G4**. At a gate: stop, post the phase report, and wait for explicit user
+approval. Never begin the next phase unprompted — not even the first "obviously safe" step
+of it.
+
+## What must never happen
+
+- A commit directly on `main` or `master`.
+- A force-push to `main` (blocked by the `main-protection` ruleset, but do not test it).
+- A history rewrite of any kind without explicit user approval ([`AGENTS.md`](../../AGENTS.md) §10).
+- A test weakened or deleted to turn CI green ([`AGENTS.md`](../../AGENTS.md) §8).

--- a/.claude/rules/20-code-style.md
+++ b/.claude/rules/20-code-style.md
@@ -1,0 +1,70 @@
+---
+id: rules-code-style
+type: rules
+status: accepted
+owns: [backend/crates/, backend/proto/, infra/scripts/, .github/copilot-instructions.md]
+read_when: [writing Rust, changing a proto, adding a file, naming anything]
+---
+
+# 20 · Code style
+
+Predicates for [`AGENTS.md`](../../AGENTS.md) §3 (language), §5 (code), §6 (domain) and
+§7 (file organization). AGENTS.md carries the prose and the `ErrorCode` table; this file
+carries only what a machine can check.
+
+**Convention: every check prints its violations. Empty output means PASS.**
+
+| ID | Predicate | Today |
+|---|---|---|
+| `RS-UNWRAP` | No `unwrap()` / `expect()` in non-test Rust | FAIL — 52 in 25 files, PR-22 |
+| `RS-UNSAFE` | No `unsafe` outside an FFI crate | PASS |
+| `RS-FMT` | `cargo fmt` is clean | see `build.yml` |
+| `RS-CLIPPY` | `cargo clippy -- -D warnings` is clean | masked until PR-17 |
+| `PROTO-EDIT` | Generated protobuf is never hand-edited | PASS |
+| `LANG-MD` | No Cyrillic in Markdown outside the one allowlisted file | PASS |
+| `NAME-SH` | Scripts are `kebab-case.sh` | FAIL — 5 files |
+| `NAME-RS` | Rust files are `snake_case.rs` | PASS |
+| `ORG-ROOT` | Only the 8 permitted root Markdown files exist | PASS |
+| `ORG-LOCAL` | No tracked file links into `_local/` | FAIL — `CHANGELOG.md:55` |
+
+```sh
+echo "RS-UNWRAP";  git ls-files 'backend/crates/*/src/*.rs' 'backend/crates/*/src/**/*.rs' \
+                     | grep -v '/generated/' | while read -r f; do
+                         sed '/#\[cfg(test)\]/,$d' "$f" \
+                           | grep -nE '\.(unwrap|expect)\(' | sed "s|^|$f:|"
+                       done
+echo "RS-UNSAFE";  grep -rln 'unsafe ' --include='*.rs' backend/crates/*/src | grep -vE 'crypto-ffi|/ffi'
+echo "RS-FMT";     cargo fmt --all --manifest-path backend/Cargo.toml -- --check
+echo "PROTO-EDIT"; git diff --name-only origin/main...HEAD | grep -E '/(generated|proto)/.*\.rs$'
+echo "LANG-MD";    git grep -lIP '[\x{0400}-\x{04FF}]' -- '*.md' | grep -v 'copilot-commit-message'
+echo "NAME-SH";    git ls-files '*.sh' | xargs -n1 basename | grep -vE '^[a-z0-9-]+\.sh$'
+echo "NAME-RS";    git ls-files '*.rs' | grep -vE '/(generated|proto)/' \
+                     | xargs -n1 basename | grep -vE '^[a-z0-9_]+\.rs$'
+echo "ORG-ROOT";   git ls-files -- '*.md' | grep -v / \
+                     | grep -vE '^(README|AGENTS|CLAUDE|CONTRIBUTING|CHANGELOG|SECURITY|CODE_OF_CONDUCT|implementation_plan)\.md$'
+echo "ORG-LOCAL";  git grep -lI '](.*_local/' -- '*.md'
+```
+
+## Exceptions that are not violations
+
+- **Cyrillic test fixtures are legitimate.** `auth-service/src/handlers/update_profile.rs`
+  and `e2e-tests/tests/e2e_production_readiness.rs` carry Cyrillic *test data* — a messaging
+  product must prove non-Latin names round-trip. `LANG-MD` therefore scopes to Markdown.
+  The language policy governs prose, comments, identifiers and log strings, not fixtures.
+- **ADR filenames** are `ADR-NNNN-kebab-slug.md`, not `SCREAMING_SNAKE_CASE.md`. The
+  sequence number is what makes them sortable and citable.
+- **Generated protobuf** lives in two places — `backend/crates/*/src/generated/` (13 files)
+  and `client-desktop/src-tauri/src/proto/` (8 files). Both are excluded from `NAME-RS`,
+  and both are in scope for PR-23's unification; the plan names only the first.
+
+## Rules a grep cannot check
+
+- Errors use `thiserror` over `guardyn_common::error`. No stringly-typed errors.
+- Every public item carries a doc comment.
+- One gRPC handler per file under `handlers/`.
+- `backend/proto/*.proto` is the canonical wire contract: change the proto, then
+  regenerate. Never invent an enum variant — read the proto and use the converted name
+  ([`AGENTS.md`](../../AGENTS.md) §5.2 has the real mistakes table).
+- No new datastore, bus or major dependency without an accepted ADR **and** user approval.
+- Never hardcode a domain. `${DOMAIN}` is the single source; see `SOV-DOMAIN` in
+  [`00-invariants.md`](00-invariants.md).

--- a/.claude/rules/30-zk-logging.md
+++ b/.claude/rules/30-zk-logging.md
@@ -1,0 +1,64 @@
+---
+id: rules-zk-logging
+type: rules
+status: accepted
+owns: [backend/crates/common/src/observability.rs, backend/crates/common/src/redact.rs]
+read_when: [adding a log line, touching observability, adding a metric or span]
+---
+
+# 30 · Zero-knowledge logging
+
+Predicates for [`AGENTS.md`](../../AGENTS.md) §4, enforcing invariant **I-1**. This is the
+invariant most easily broken by a one-line "helpful" debug statement, so it gets its own file.
+
+**Convention: every check prints its violations. Empty output means PASS.**
+
+| ID | Predicate | Today |
+|---|---|---|
+| `ZK-INIT` | Tracing is initialised only via `guardyn_common::observability::init_tracing` | FAIL — 2 services, PR-26 |
+| `ZK-PII` | No log macro is passed a raw IP, email or phone number | FAIL — 2 sites, no owner |
+| `ZK-PAYLOAD` | No log macro names ciphertext, plaintext, payload or key material | PASS |
+| `ZK-STRUCT` | No whole request or response struct is interpolated | PASS |
+| `ZK-DEBUG` | No `#[derive(Debug)]` on a crypto type that holds key material | review trigger |
+
+```sh
+echo "ZK-INIT";    grep -rln --include='*.rs' -e FmtSubscriber -e 'tracing_subscriber::fmt()' backend/crates/*/src
+echo "ZK-PII";     grep -rnE '(trace|debug|info|warn|error)!\(' --include='*.rs' backend/crates/*/src \
+                     | grep -iE '"[^"]*\b(ip|email|phone)\b[^"]*"[^)]*,'
+echo "ZK-PAYLOAD"; grep -rnE '(trace|debug|info|warn|error)!\(' --include='*.rs' backend/crates/*/src \
+                     | grep -v '/generated/' \
+                     | grep -iE '\b(ciphertext|plaintext|payload|secret_key|private_key|shared_secret)\b' \
+                     | grep -v '_id'
+echo "ZK-STRUCT";  grep -rnE '(trace|debug|info|warn|error)!\([^)]*(req|request|resp|response)[a-z_]*\)' \
+                     --include='*.rs' backend/crates/*/src | grep '{:?}'
+echo "ZK-DEBUG";   grep -rn 'derive(.*Debug' --include='*.rs' backend/crates/crypto/src | grep -v frb_generated
+```
+
+## Never emit — in a log, a span, a metric label, or on stdout
+
+Message, file or media **plaintext or ciphertext** · any key material (identity keys,
+pre-keys, ratchet state, MLS secrets, ML-KEM private keys) · tokens, passwords, password
+hashes, session secrets · PII: email, phone number, **IP address**, precise location.
+
+When unsure whether a field is sensitive: **do not log it.**
+
+## Why `ZK-DEBUG` is a review trigger, not a pass/fail
+
+`derive(Debug)` is not itself a breach — it is a breach the moment such a value reaches a
+`{:?}`. The crypto crate has 8 sites, several on types in `x3dh.rs`, `key_storage.rs` and
+`sealed_sender.rs` that plausibly hold key material. Each needs a human read, not a grep
+verdict. Implement `Debug` by hand to emit `[REDACTED]`, or wrap the field in `Redacted<T>`
+from `guardyn-common` once PR-24 lands.
+
+## Identifiers are metadata, not free
+
+`user_id` and `device_id` are correlatable. Log them only when an operation genuinely needs
+them, and never at `info` on a hot path. `ZK-PAYLOAD` deliberately excludes `*_id` matches —
+the four `ratchet session: {session_id}` lines in `messaging-service` are identifiers, not
+key material, and are allowed under that rule.
+
+## The two failures with no owned step
+
+`ZK-PII` fires on `common/src/rate_limit.rs:241` and `:256`, which log a raw client IP.
+`AGENTS.md` §4 lists IP address as PII. This was found while writing these predicates and
+has no step in `implementation_plan.md` — open an issue before fixing it.

--- a/.claude/rules/40-doc-sync.md
+++ b/.claude/rules/40-doc-sync.md
@@ -1,0 +1,71 @@
+---
+id: rules-doc-sync
+type: rules
+status: draft
+owns: [docs/]
+read_when: [changing any source file, adding a document, before opening a PR]
+---
+
+# 40 · Documentation sync
+
+The algorithm that keeps documentation from drifting. It is a **mechanism, not a
+convention**: once PR-15 and PR-16 land, drift is a build failure rather than a review nit.
+
+`status: draft` until PR-15 ships `docs/.manifest.yaml` and `just docs-verify`. The
+algorithm below is what an agent follows by hand in the meantime.
+
+## The loop, per micro-step
+
+1. List the source paths the step changes.
+2. Look each up in `docs/.manifest.yaml`. Every match yields a set of documents that
+   **own** that path.
+3. Update those documents in the **same PR**. Not a follow-up — the same PR.
+4. If a changed path genuinely has no documentation impact, label the PR
+   `docs-impact:none` **and state the reason in the body**. The label without a reason is
+   not acceptable.
+5. Run `just docs-verify` before pushing.
+
+## The five checks
+
+| # | Check | Fails when |
+|---|---|---|
+| 1 | Frontmatter | a `docs/**/*.md` file has unparseable frontmatter, a duplicate `id`, or a `status` outside the enum |
+| 2 | Impact | a changed source path's mapped documents are untouched and the PR carries no `docs-impact:none` |
+| 3 | Glossary | a term defined in `GLOSSARY.md` appears under one of its `forbidden_aliases` |
+| 4 | Links | a relative link does not resolve, **or** a tracked document links into `_local/` |
+| 5 | Language | Cyrillic appears in `docs/**` outside the allowlisted policy file |
+
+Check 2 is the one that matters. The rest catch mistakes; check 2 catches **neglect**.
+
+## Frontmatter contract
+
+Every file under `docs/` carries:
+
+```yaml
+---
+id: adr-0005              # unique across docs/
+type: adr                 # adr | spec | ops | roadmap | index | glossary | rules
+status: accepted          # draft | accepted | superseded | deprecated
+owns: [backend/crates/crypto/src/pqxdh.rs]
+read_when: [touching crypto, changing key bundles]
+tokens: 820               # measured, regenerated - never hand-edited
+supersedes: []
+---
+```
+
+## Regenerated, never hand-edited
+
+`docs/INDEX.md`, `docs/roadmap/STATE.md` and every `tokens:` value are **generated**.
+`docs-verify` fails if a generated file is stale. Editing one by hand will be reverted by
+the next generation run — change the generator or the source, not the output.
+
+## Why this exists
+
+`docs/INDEX.md` is the only file an agent must read cold. It routes to everything else via
+`read_when`, so a session loads two or three documents instead of the whole corpus. That
+only works while the routing is true — which is what checks 1, 2 and 4 defend.
+
+## Known defect this must catch
+
+`CHANGELOG.md:55` links into `_local/`, which is gitignored and invisible to every cloner.
+Check 4 exists so that class of defect cannot recur; the existing instance needs an issue.


### PR DESCRIPTION
Closes #16

`AGENTS.md` states the law in prose. Prose does not fail a build, and an agent that
half-remembers a rule cannot check itself. These five files are the **executable
projection** of it — no prose is duplicated, only made testable.

## One convention
Every check **prints its violations; empty output means PASS.** The first draft mixed
exit-status and output semantics, and `SOV-DOMAIN` silently reported PASS while a
hardcoded domain sat in the tree — `! cmd | grep -v x` negates the pipeline, not the
first stage. One convention removes that whole class of bug.

## Files
| File | Enforces |
|---|---|
| `00-invariants.md` | AGENTS.md §1 — 8 predicates across I-1…I-4 |
| `10-git-workflow.md` | AGENTS.md §2 — branch, budget, gates |
| `20-code-style.md` | AGENTS.md §3, §5, §6, §7 — Rust, proto, language, naming, layout |
| `30-zk-logging.md` | AGENTS.md §4 — I-1 enforcement in detail |
| `40-doc-sync.md` | The §4.4 auto-maintenance algorithm (`status: draft` until PR-15) |

## Every command was run before it was written down
The measured state is recorded beside each predicate rather than assumed. That surfaced
four things the plan did not have:

- **`ZK-PII` fails** — `common/src/rate_limit.rs:241,256` log a raw client IP.
  AGENTS.md §4 lists IP address as PII. **No step owns this.**
- **`SOV-DOMAIN` fails** — `infra/k8s/base/envoy/ingress.yaml:18` hardcodes
  `envoy.guardyn.local`; AGENTS.md §6 requires `${DOMAIN}`. **No step owns this.**
- **`ORG-LOCAL` fails** — `CHANGELOG.md:55` links into gitignored `_local/`, dead for
  every cloner. The plan expected this defect only in a file PR-01 deleted.
- **`RS-UNWRAP` is 52 occurrences in 25 files**, not the ~400 a naive grep reports. The
  rest sit inside `#[cfg(test)]` modules, which AGENTS.md explicitly permits. A predicate
  that flags legitimate code is worse than none, so the check stops at `#[cfg(test)]`.

Two corrections are recorded in the files: the non-E2EE handler pairs number **two**, not
the four AGENTS.md §1 claims; and committed generated protobuf lives in **two** directories
(`backend/crates/*/src/generated/`, `client-desktop/src-tauri/src/proto/`), not the one
PR-23 names.

## Honest about failure
Seven of the predicates fail today. Each names its owned step, and the file says plainly
that a known failure is **not** licence to patch it outside that step.

## Out of scope
Every violation listed above. This step writes the ruler, not the corrections — each needs
its own issue and micro-step. `20-code-style.md` is refined again by PR-22; CI enforcement
of these predicates is not part of this PR.

## Budget
326 lines across 5 files — within the ≤400 / ≤8 contract.