### PR TITLE
PR-06 · Add .claude/settings.json guard hooks and pre-commit hook

### DIFF
--- a/.claude/hooks/guard-main.sh
+++ b/.claude/hooks/guard-main.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# PreToolUse guard: refuse `git commit` and `git push` while HEAD is on a protected
+# branch. Belt-and-braces for AGENTS.md §2.1 - the `main-protection` ruleset is the
+# real enforcement; this catches the mistake locally, before it costs a round trip.
+#
+# Contract: the tool call arrives as JSON on stdin. Exit 2 blocks the call and shows
+# stderr to the agent; exit 0 allows it.
+#
+# The payload is matched as raw text rather than parsed. A JSON parser would mean a
+# dependency this repository does not otherwise carry, and the only cost of the crude
+# match is blocking a command that merely mentions "git commit" while HEAD is already
+# on a protected branch - where nothing should be committing anyway.
+#
+# Fails OPEN by design: a bug here would otherwise brick every git operation for every
+# agent, and the server-side ruleset still holds the line.
+
+set -uo pipefail
+
+PROTECTED_BRANCHES="main master"
+
+payload="$(cat 2>/dev/null || true)"
+
+case "$payload" in
+  *"git commit"* | *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+branch="$(git branch --show-current 2>/dev/null || true)"
+[ -n "$branch" ] || exit 0
+
+for protected in $PROTECTED_BRANCHES; do
+  if [ "$branch" = "$protected" ]; then
+    cat >&2 <<MSG
+Blocked: HEAD is on '$branch', which is protected (AGENTS.md §2.1).
+
+One micro-step = one branch = one PR = one issue. Create the step's branch first:
+
+    git checkout -b <type>/<issue>-<slug> origin/main
+
+<type> is one of: feat fix docs refactor chore security
+MSG
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git filter-repo:*)",
+      "Read(./infra/secrets/age-key.txt)",
+      "Read(./infra/secrets/*.key)",
+      "Read(./infra/secrets/*.asc)"
+    ],
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(cargo fmt --check:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(just --list:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guard-main.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Refuse a commit on a protected branch (AGENTS.md §2.1).
+#
+# Install with `just install-hooks`, which sets core.hooksPath to this directory.
+# This is a local convenience, not the enforcement: `main` is protected by the
+# `main-protection` ruleset, and `git commit --no-verify` bypasses any git hook.
+
+set -euo pipefail
+
+branch="$(git branch --show-current 2>/dev/null || true)"
+
+case "$branch" in
+  main | master)
+    cat >&2 <<MSG
+Refusing to commit on '$branch' (AGENTS.md §2.1).
+
+One micro-step = one branch = one PR = one issue:
+
+    git checkout -b <type>/<issue>-<slug> origin/main
+
+<type> is one of: feat fix docs refactor chore security
+MSG
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/Justfile
+++ b/Justfile
@@ -476,3 +476,8 @@ test-desktop-all:
     @echo ""
     @echo "==> E2E tests"
     client-desktop/scripts/run-auth-tests.sh
+
+# Install the repository git hooks (protected-branch guard). Run once per clone.
+install-hooks:
+    @git config core.hooksPath .githooks
+    @echo "[hooks] core.hooksPath -> .githooks"


### PR DESCRIPTION
Closes #17

P-2 is resolved server-side — the `main-protection` ruleset now requires a pull request.
But the first feedback that ruleset gives is a **rejected push**, after the work is already
committed on the wrong branch. These hooks move the feedback to before the mistake.

| File | Role |
|---|---|
| `.claude/hooks/guard-main.sh` | `PreToolUse` hook — exits 2 (block) when a Bash call mentions `git commit`/`git push` while HEAD is `main`/`master` |
| `.githooks/pre-commit` | Same rule for humans and non-Claude tooling |
| `.claude/settings.json` | Wires the hook; denies force-push, `git filter-repo`, and reads of private key material |
| `Justfile` | `just install-hooks` → `core.hooksPath=.githooks` |

`.git/hooks` is untracked, so a tracked directory plus an opt-in recipe is the only way to
ship a git hook at all.

## Two deliberate choices

**The PreToolUse hook matches raw text, it does not parse the JSON.** A parser means `jq`
or `python3`, neither of which this repository depends on. The only cost of the crude match
is blocking a command that merely *mentions* `git commit` while HEAD is already on a
protected branch — where nothing should be committing anyway.

**It fails open.** A hook that failed closed on a parsing bug would brick every git
operation for every agent in the repository, and the ruleset still holds the line
server-side. A local guard is worth having; it is not worth that risk.

## Verified
In a throwaway repo, all four hook paths: `git commit` on `main` → blocked with exit 2 and
the branch recipe on stderr; an unrelated command on `main` → allowed; `git push` on a
feature branch → allowed; empty stdin → allowed. `pre-commit` returns 1 on `main` and 0 on a
feature branch, and a real `git commit` on `main` was refused with the commit **not**
landing. `just install-hooks` sets `core.hooksPath`; it is installed in this working copy,
so this very commit went through the hook.

## Not enforcement
`git commit --no-verify` bypasses any git hook, and a `PreToolUse` hook only binds Claude
Code. The ruleset is the enforcement; these are the fast local signal. The PR body for
PR-06 in the plan calls this "belt-and-braces", and that is exactly the claim being made.

## Out of scope
Hardening the ruleset itself (required status checks, approvals) is a human action under
P-1/P-2. No CI job is added here.

## Budget
115 lines across 4 files — within the ≤400 / ≤8 contract.