### PR TITLE
PR-08 · Add docs/INDEX.md and GLOSSARY.md

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,99 @@
+---
+id: glossary
+type: glossary
+status: accepted
+owns: [backend/proto/, backend/crates/crypto/src/, backend/crates/common/src/]
+read_when: [naming anything, writing a document, reviewing a proto change]
+tokens: 1591
+supersedes: []
+---
+
+# Glossary
+
+The ubiquitous language. **Every term here was read out of the code** — proto messages,
+proto enums, and public Rust types — never invented. If a term and its code symbol
+disagree, the code is right and this file is stale: fix it here.
+
+`forbidden_aliases` is enforced. `docs-verify` check #3 fails when a document uses one of
+them in place of the canonical term, which is how `User`/`Player`-class naming drift dies.
+
+## Identity
+
+| Term | Code symbol | Meaning | forbidden_aliases |
+|---|---|---|---|
+| **User** | `UserId`, `UserProfile` (`common.proto`, `auth.proto`) | A human account. The unit of identity. | Account, Customer, Player |
+| **Device** | `DeviceId`, `DeviceInfo` (`common.proto`, `auth.proto`) | One installation belonging to a User. Keys are per-device, not per-user. | Endpoint, Terminal |
+| **Contact** | `Contact` (`auth.proto`) | Another User a User has added. | Friend, Buddy |
+| **BlockedUser** | `BlockedUser` (`auth.proto`) | A User whose messages are refused. | Banned, Muted |
+
+`Client` is *not* a synonym for Device — `ClientCapabilities` describes the software, not
+the installation record.
+
+## Messaging
+
+| Term | Code symbol | Meaning | forbidden_aliases |
+|---|---|---|---|
+| **Message** | `Message`, `MessageType` (`messaging.proto`) | One addressed payload. Always ciphertext on the wire. | Msg, Note |
+| **Conversation** | `Conversation` (`messaging.proto`) | A 1-to-1 or group exchange. The container for Messages. | Chat, Room, Dialog |
+| **Group** | `GroupInfo`, `GroupMemberInfo`, `GroupMessage` | A multi-party Conversation with membership and roles. | Channel, Team |
+| **Thread** | `ThreadReference` (`messaging.proto`) | A reply chain *inside* a Conversation. Not a synonym for Conversation. | — |
+| **Reaction** | `Reaction`, `ReactionSummary` | An emoji response attached to a Message. | Like, Emoji |
+| **ReadReceipt** | `ReadReceipt` (`messaging.proto`) | Proof a Message was read. | Seen, Ack |
+| **DeliveryStatus** | `DeliveryStatus` enum | Where a Message is in transit. | State, Progress |
+| **DisappearingConfig** | `DisappearingConfig` | Per-Conversation self-destruct timing. | Ephemeral, TTL |
+| **ForwardInfo** | `ForwardInfo`, `MessageEdit` | Provenance of a forwarded Message; an edit record. | — |
+
+## Cryptography
+
+| Term | Code symbol | Meaning | forbidden_aliases |
+|---|---|---|---|
+| **KeyBundle** | `KeyBundle` (`common.proto`), `X3DHKeyBundle`, `HybridKeyBundle` | The published public key material a peer needs to start a session. | PreKeyBundle |
+| **IdentityKeyPair** | `IdentityKeyPair` (`crypto`) | A Device's long-term key pair. Never leaves the Device. | MasterKey |
+| **SignedPreKey** | `SignedPreKey` (`crypto`) | Medium-term key, signed by the identity key. | — |
+| **OneTimePreKey** | `OneTimePreKey`, `OneTimePreKeyPublic` | Single-use key consumed by one session handshake. | OTK |
+| **X3DH** | `X3DHProtocol`, `X3DHKeyMaterial`, `X3DHPrekeyMessage` | The asynchronous handshake establishing a shared secret. | Handshake |
+| **PQXDH** | `HybridKeyBundle`, `HybridSharedSecret`, `HybridPrivateKeys` | X3DH extended with ML-KEM-768. **Implemented, not yet enabled** — see I-3. | PostQuantumX3DH |
+| **DoubleRatchet** | `DoubleRatchet`, `MessageHeader` | Per-message forward-secret key evolution after the handshake. | Ratchet |
+| **MLS** | `MlsGroupManager`, `MlsGroupState`, `MlsKeyPackage` | OpenMLS group encryption. The Group counterpart to Double Ratchet. | GroupCrypto |
+| **SealedSender** | `SealedSender`, `SealedSenderEnvelope`, `SenderCertificate` | Hides sender identity from the server. | AnonymousSender |
+| **EncryptedMessage** | `EncryptedMessage` (`crypto`) | Ciphertext plus the header needed to decrypt it. | Blob, Payload |
+| **SFrame** | `SFrameKeyRotated`, `ExchangeSFrameKey*` | Frame-level media encryption for calls. | MediaCrypto |
+
+**Never** write "encrypted payload" where `EncryptedMessage` is meant, and never let any of
+these appear in a log — see [`.claude/rules/30-zk-logging.md`](../.claude/rules/30-zk-logging.md).
+
+## Calls and presence
+
+| Term | Code symbol | Meaning | forbidden_aliases |
+|---|---|---|---|
+| **Call** | `CallState`, `CallType`, `CallEndReason`, `CallQuality` | A voice or video session. | Ring, Session |
+| **CallParticipant** | `CallParticipant`, `ParticipantKeyPackage` | One Device in a Call. | Attendee, Peer |
+| **SdpMessage** | `SdpMessage`, `SdpType` | WebRTC session description exchanged during setup. | Offer, Answer |
+| **IceCandidate** | `IceCandidate`, `IceServer` | WebRTC connectivity candidate. | Candidate |
+| **Presence** | `UserPresence`, `PresenceUpdate`, `UserStatus` | Whether a User is reachable. | Online, Activity |
+
+`Status` alone is ambiguous — `Status` is the health enum in `common.proto`, `UserStatus`
+is presence, and `DeliveryStatus` is message transit. Always qualify it.
+
+## Platform
+
+| Term | Code symbol | Meaning | forbidden_aliases |
+|---|---|---|---|
+| **MediaMetadata** | `MediaMetadata`, `MediaType`, `UploadStatus` | Descriptor for an uploaded blob. The blob itself is ciphertext. | Attachment, File |
+| **ErrorCode** | `ErrorCode` enum (`common.proto`) | The canonical error taxonomy. Read the proto — never invent a variant. | Errno |
+| **HealthStatus** | `HealthStatus`, `Status` (`common.proto`) | Service liveness, reported per service. | Heartbeat |
+| **EventEnvelope** | `EventEnvelope` (`common`) | The durable-log wrapper carried over Redpanda. | Payload, Record |
+| **RateLimiter** | `RateLimiter`, `RateLimitConfig` | Per-process request throttle. **Not** distributed — see PR-41. | Throttle |
+
+## Datastores and buses
+
+| Term | Role | forbidden_aliases |
+|---|---|---|
+| **TiKV** | Metadata, auth and MLS state. Deliberately not PostgreSQL. | DB, Database |
+| **ScyllaDB** | Message, call and notification history. | Cassandra |
+| **MinIO** | Encrypted media blobs. | S3 |
+| **NATS** | Ephemeral signalling. | Queue |
+| **Redpanda** | Durable event log. | Kafka |
+| **Envoy** | gRPC-Web gateway at the edge. | Proxy, Gateway |
+
+NATS and Redpanda **coexist by design** with separated roles. Neither is "the bus".

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,82 @@
+---
+id: index
+type: index
+status: accepted
+owns: [docs/]
+read_when: [starting any session]
+tokens: 1107
+supersedes: []
+---
+
+# Documentation index
+
+**This is the only file an agent must read cold.** Everything else is reached through the
+`read_when` column: match your task, load those documents, ignore the rest. A typical
+session loads two or three files instead of the whole corpus — that is the point.
+
+This file and `tokens:` counts are **generated** by `just docs-verify` (PR-15). Do not
+hand-edit; change the frontmatter of the document itself.
+
+## Read first, always
+
+| Path | Purpose | read_when |
+|---|---|---|
+| [`AGENTS.md`](../AGENTS.md) | The agent constitution. Invariants, git workflow, language, logging, code standards. | starting any session, before any commit, before any PR |
+| [`.claude/rules/00-invariants.md`](../.claude/rules/00-invariants.md) | I-1…I-4 as runnable predicates. | starting any session, touching crypto, changing configuration |
+| [`GLOSSARY.md`](GLOSSARY.md) | Ubiquitous language; every domain term and its code symbol. | naming anything, writing a document, reviewing a proto change |
+
+## Rules — the executable projection of AGENTS.md
+
+| Path | Purpose | read_when |
+|---|---|---|
+| [`.claude/rules/10-git-workflow.md`](../.claude/rules/10-git-workflow.md) | Branch, budget and gate predicates. | before any commit, before opening a PR |
+| [`.claude/rules/20-code-style.md`](../.claude/rules/20-code-style.md) | Rust, proto, language, naming and layout predicates. | writing Rust, changing a proto, adding a file |
+| [`.claude/rules/30-zk-logging.md`](../.claude/rules/30-zk-logging.md) | I-1 enforcement in detail. | adding a log line, touching observability |
+| [`.claude/rules/40-doc-sync.md`](../.claude/rules/40-doc-sync.md) | The documentation auto-maintenance algorithm. | changing any source file, adding a document |
+
+## Specifications
+
+| Path | Purpose | read_when |
+|---|---|---|
+| [`spec/SAD.md`](spec/SAD.md) | Architecture: crates, topology, data flow, store-per-concern. | changing service boundaries, adding a dependency between crates |
+| [`spec/SRS.md`](spec/SRS.md) | The algorithmic source of truth: rules, edge cases, invariants. | implementing a handler, changing behaviour |
+| [`spec/PRD.md`](spec/PRD.md) | Product features as they exist, in user-story form. | adding a feature, questioning whether something is in scope |
+| [`api/INDEX.md`](api/INDEX.md) | Generated proto → service → RPC map. | calling an RPC, changing the wire contract |
+
+## Decisions
+
+| Path | Purpose | read_when |
+|---|---|---|
+| [`adr/index.md`](adr/index.md) | Every architectural decision, with status. | proposing a change to a decided thing |
+| [`adr/ADR-0000-template.md`](adr/ADR-0000-template.md) | The template. Copy it; do not invent a shape. | writing an ADR |
+
+An ADR records a decision **already embodied in the code**. Adding, replacing or removing a
+datastore, bus or major dependency requires an accepted ADR *and* explicit user approval.
+
+## Operations
+
+| Path | Purpose | read_when |
+|---|---|---|
+| [`ops/DEPLOYMENT.md`](ops/DEPLOYMENT.md) | k3d and Kubernetes deployment, Kustomize overlays. | deploying, changing a manifest |
+| [`ops/RUNBOOK.md`](ops/RUNBOOK.md) | Incident playbooks and on-call procedure. | an incident, a failing service |
+| [`ops/OBSERVABILITY.md`](ops/OBSERVABILITY.md) | Tracing, metrics, logs and the ZK-logging rules. | adding a metric or span, debugging in production |
+
+## Roadmap
+
+| Path | Purpose | read_when |
+|---|---|---|
+| [`roadmap/ROADMAP.md`](roadmap/ROADMAP.md) | Narrative phases. | planning, answering "when" |
+| [`roadmap/roadmap.yaml`](roadmap/roadmap.yaml) | **Machine source of truth**; drives issues and the project board. | changing scope or sequencing |
+| [`roadmap/STATE.md`](roadmap/STATE.md) | Generated progress telemetry: current phase, gate, step. | asking where the work is |
+
+## Security — retained, not rewritten
+
+`docs/security/` predates this documentation base and is externally cited. It is kept in
+place: `SECURITY_AUDIT.md`, `HARDENING_REVIEW.md`, `PENETRATION_TESTING.md`,
+`RATE_LIMITING.md`, `SEALED_SENDER.md`, `RUST_FFI_SECURITY_AUDIT.md`, and `pgp/`.
+
+## Not documentation
+
+`_local/` is gitignored working material — grant applications and personal notes. It is
+never deleted, never moved, and **never linked to from a tracked file**: cloners cannot see
+it, so such a link is dead on arrival.


### PR DESCRIPTION
Closes #19

## INDEX.md — the router
The only file an agent must read cold. Everything else is reached through its `read_when`
column, so a session loads two or three documents instead of the whole corpus. That is the
token-economy mechanism the entire documentation base exists to serve.

It links documents that PR-09…PR-14 create. **Forward references are deliberate** — the
router describes the target state, and the link checker does not exist until PR-16, by
which time every target has landed.

`INDEX.md` and all `tokens:` counts are marked **generated**. PR-15 ships the generator,
and `docs-verify` will fail if this hand-written version and the generated one disagree.

## GLOSSARY.md — mined, not written
Every term came out of `backend/proto` messages and enums, or out of public types in
`crates/crypto` and `crates/common`. **All 67 code symbols it cites were verified to exist
before commit.** A glossary that invents a term is worse than none: it teaches drift
instead of catching it.

`forbidden_aliases` are filled in where the code is unambiguous and left empty where it is
not. Three ambiguities are called out rather than papered over:

- **Thread** is a reply chain *inside* a Conversation (`ThreadReference`), not a synonym
  for it. Both words are load-bearing.
- **Client** is not a synonym for Device. `ClientCapabilities` describes software;
  `DeviceId` identifies an installation.
- **Status** is ambiguous three ways — `Status` is service health, `UserStatus` is
  presence, `DeliveryStatus` is message transit. It must always be qualified.

**PQXDH** is recorded as *implemented but not enabled*, matching I-3, so the glossary
cannot be read as a claim that the product ships post-quantum key agreement today.

## Out of scope
`docs/api/INDEX.md` (generated from protos — a later step). The `forbidden_aliases` are not
yet enforced; that is `docs-verify` check #3 in PR-15.

## Budget
181 added lines across 2 files — within the ≤400 / ≤8 contract.