### PR TITLE
PR-12 · Write ADR-0001 through ADR-0009

### DIFF
--- a/docs/adr/ADR-0000-template.md
+++ b/docs/adr/ADR-0000-template.md
@@ -1,0 +1,36 @@
+---
+id: adr-0000
+type: adr
+status: draft
+owns: []
+read_when: [writing an ADR]
+tokens: 221
+supersedes: []
+---
+
+# ADR-0000 · Template
+
+Copy this file, take the next free number, and fill it in. Do not invent a different shape.
+
+## Status
+
+`draft` | `accepted` | `superseded` | `deprecated`. If superseded, name the ADR that
+replaces it in `supersedes`.
+
+## Context
+
+What forced a decision. Constraints, the invariants in play, what was already true.
+Written so a reader in two years understands the pressure without archaeology.
+
+## Decision
+
+What was decided, in one or two sentences, in the active voice.
+
+## Consequences
+
+What this makes easy, what it makes hard, and what it forecloses. Include the costs — an
+ADR that lists only benefits is advocacy, not a record.
+
+## Alternatives rejected
+
+Each with the reason. "We did not consider it" is a valid reason and better than silence.

--- a/docs/adr/ADR-0001-tikv-metadata-store.md
+++ b/docs/adr/ADR-0001-tikv-metadata-store.md
@@ -1,0 +1,44 @@
+---
+id: adr-0001
+type: adr
+status: accepted
+owns: [backend/crates/auth-service/src/db.rs, backend/crates/presence-service/src/db.rs]
+read_when: [changing the metadata store, adding a table]
+tokens: 368
+supersedes: []
+---
+
+# ADR-0001 · TiKV as the metadata, auth and MLS-state store
+
+## Status
+
+`accepted`
+
+## Context
+
+The project brief specified PostgreSQL. The implementation uses TiKV, and every service
+that stores metadata — auth records, device registry, contacts, key bundles, MLS group
+state — talks to it. The divergence is deliberate and predates this documentation base.
+
+Guardyn must be self-hostable on anything from one machine to a cluster (**I-4**), and the
+access pattern is overwhelmingly key-by-id with occasional range scans, not relational
+joins.
+
+## Decision
+
+TiKV is the metadata, auth and MLS-state store. PostgreSQL is not used.
+
+## Consequences
+
+Horizontal scaling and transactional key-value semantics without an operational relational
+tier. No joins, no ad-hoc SQL, no migration tooling that assumes a schema — data shape is
+enforced in Rust, not by the database. Range-scan design becomes a modelling concern rather
+than an afterthought.
+
+Anyone reading the brief will believe PostgreSQL is intended. **It is not.** Do not "fix"
+this.
+
+## Alternatives rejected
+
+**PostgreSQL** — relational guarantees the workload does not need, and a scaling story that
+would force sharding later. **etcd** — sized for configuration, not for user data.

--- a/docs/adr/ADR-0002-scylladb-history.md
+++ b/docs/adr/ADR-0002-scylladb-history.md
@@ -1,0 +1,41 @@
+---
+id: adr-0002
+type: adr
+status: accepted
+owns: [backend/crates/messaging-service/src/db.rs, backend/crates/call-service/src, backend/crates/notification-service/src]
+read_when: [changing history storage, adding a time-series table]
+tokens: 346
+supersedes: []
+---
+
+# ADR-0002 · ScyllaDB for message, call and notification history
+
+## Status
+
+`accepted`
+
+## Context
+
+History is append-heavy, read in time order, partitioned naturally by conversation, and
+never joined. It is also the largest data set in the system and grows without bound.
+
+Message bodies are ciphertext the server cannot read, so the store needs no query
+capability over content — only "give me this partition, newest first, paged".
+
+## Decision
+
+ScyllaDB stores message, call and notification history. TiKV (ADR-0001) keeps metadata.
+
+## Consequences
+
+Wide-column partitions match the access pattern exactly, and writes stay cheap as history
+grows. Two datastores must be operated instead of one, and a write that spans both is not
+atomic — services must tolerate partial failure rather than assume a transaction.
+
+Content search must happen on the client (see `PRD.md`); no server-side index is possible
+over ciphertext.
+
+## Alternatives rejected
+
+**TiKV for everything** — the range-scan pattern for long histories degrades. **Cassandra**
+— same data model, heavier operational footprint for a self-hoster.

--- a/docs/adr/ADR-0003-dual-bus.md
+++ b/docs/adr/ADR-0003-dual-bus.md
@@ -1,0 +1,46 @@
+---
+id: adr-0003
+type: adr
+status: accepted
+owns: [backend/crates/common/src/kafka.rs, backend/crates/common/src/events.rs]
+read_when: [adding an event, choosing a transport]
+tokens: 367
+supersedes: []
+---
+
+# ADR-0003 · Dual bus — NATS for signalling, Redpanda for the durable log
+
+## Status
+
+`accepted`
+
+## Context
+
+Two traffic classes with opposite requirements coexist. Presence beats, typing indicators
+and call setup are worthless a second late and must never block. Message events must
+survive a broker restart, replay in order, and drive downstream consumers such as push
+notification delivery.
+
+One bus tuned for both would be tuned for neither.
+
+## Decision
+
+NATS carries ephemeral signalling. Redpanda carries the durable event log, via
+`EventEnvelope`. Both are intentional and neither is redundant.
+
+## Consequences
+
+Each transport is matched to its traffic, and a lost presence beat is correct behaviour
+while a lost message event is data loss. The cost is two brokers to deploy, monitor and
+understand, and a standing question at every new event: which bus?
+
+The rule: if losing it is acceptable, NATS; if it must be replayable, Redpanda.
+
+**Do not consolidate them.** A future reader will see two message buses and assume
+redundancy.
+
+## Alternatives rejected
+
+**NATS JetStream for both** — durable, but the operational model for long retention is
+weaker than Redpanda's. **Kafka** — same protocol as Redpanda, with a JVM a self-hoster
+must then run.

--- a/docs/adr/ADR-0004-openmls-group-e2ee.md
+++ b/docs/adr/ADR-0004-openmls-group-e2ee.md
@@ -1,0 +1,47 @@
+---
+id: adr-0004
+type: adr
+status: accepted
+owns: [backend/crates/crypto/src/mls.rs, backend/crates/crypto/src/x3dh.rs, backend/crates/crypto/src/double_ratchet.rs]
+read_when: [touching crypto, changing group encryption]
+tokens: 447
+supersedes: []
+---
+
+# ADR-0004 · OpenMLS 0.6 for groups; own X3DH and Double Ratchet rather than libsignal
+
+## Status
+
+`accepted`
+
+## Context
+
+Group encryption by sender keys scales poorly in the membership-change case and has no
+standard. MLS (RFC 9420) is the standard, and OpenMLS is the mature Rust implementation.
+
+For one-to-one, libsignal exists but is C-heavy, awkward to build for the platform matrix
+here (iOS, Android, three desktop targets via `crypto-ffi`), and hard to extend with a
+post-quantum KEM — which **I-3** requires.
+
+## Decision
+
+Group encryption uses OpenMLS 0.6. One-to-one uses an in-repo X3DH and Double Ratchet in
+`crates/crypto`, shared with every client through `crypto-ffi`.
+
+## Consequences
+
+One cryptographic implementation serves all platforms, and extending the handshake with
+ML-KEM-768 (ADR-0005) is possible at all — which it would not be with an opaque upstream.
+
+The cost is real: hand-rolled protocol code carries the burden of proof. This is why
+property tests and fuzz targets on every attacker-reachable parser are mandatory
+(`AGENTS.md` §8), not optional.
+
+OpenMLS 0.6 constrains the ciphersuite to `MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519`
+— there is no AES-256-GCM option. Group state serialization currently fails to round-trip
+(`SecretTreeError(RatchetTypeError)`); PR-31 owns the repair.
+
+## Alternatives rejected
+
+**libsignal** — proven, but a hard build across five targets and effectively closed to a
+PQ extension. **Sender keys** — no standard, worse membership-change behaviour.

--- a/docs/adr/ADR-0005-hybrid-pqxdh.md
+++ b/docs/adr/ADR-0005-hybrid-pqxdh.md
@@ -1,0 +1,52 @@
+---
+id: adr-0005
+type: adr
+status: accepted
+owns: [backend/crates/crypto/src/pqxdh.rs, backend/proto/common.proto]
+read_when: [touching crypto, changing key bundles, enabling the pq feature]
+tokens: 509
+supersedes: []
+---
+
+# ADR-0005 · Hybrid PQXDH (X25519 + ML-KEM-768)
+
+## Status
+
+`accepted` as the target. **Not met by the running system** — the gap is documented below
+rather than hidden, because an ADR that reads as done when it is not is a lie with a
+version number.
+
+## Context
+
+**I-3** exists because of harvest-now-decrypt-later: traffic captured today can be stored
+until a cryptographically relevant quantum computer exists. For a messaging product whose
+value is confidentiality over decades, classical-only key agreement is a dated liability,
+not a present one.
+
+Pure post-quantum is the wrong answer — ML-KEM is younger than X25519 and its long-term
+cryptanalysis is thinner. Hybrid gives the maximum of both.
+
+## Decision
+
+Key agreement is hybrid: X25519 and ML-KEM-768, both secrets feeding the KDF. Classical
+strength is the floor, never the ceiling. Sizes are 1184-byte public key, 1088-byte
+ciphertext, 32-byte shared secret.
+
+## Consequences
+
+A break of either primitive alone leaves the session secure. Key bundles get materially
+larger, and every wire structure carrying key material must have room for an ML-KEM key.
+
+**The gap.** `crates/crypto/src/pqxdh.rs` is a complete implementation, but the `pq`
+feature is off by default, no backend service enables it, and — decisively —
+`backend/proto/` contains **zero** ML-KEM fields, so a server cannot publish a PQ public
+key at all. The implementation is unreached, not absent.
+
+Repair is owned by PR-36 (proto fields) through PR-40 (fuzz, proptest, bench). Until then,
+**do not describe the product as post-quantum protected.**
+
+## Alternatives rejected
+
+**Classical only** — fails I-3. **ML-KEM only** — discards decades of X25519 analysis for
+a younger primitive. **Waiting for libsignal** — see ADR-0004; the extension point does not
+exist there.

--- a/docs/adr/ADR-0006-no-cache-layer.md
+++ b/docs/adr/ADR-0006-no-cache-layer.md
@@ -1,0 +1,46 @@
+---
+id: adr-0006
+type: adr
+status: accepted
+owns: [docker-compose.dev.yml, infra/k8s/base/]
+read_when: [considering a cache, observing latency]
+tokens: 377
+supersedes: []
+---
+
+# ADR-0006 · No Dragonfly/Redis L1 cache before launch
+
+## Status
+
+`accepted`
+
+## Context
+
+The obvious reflex when a read path looks slow is to put a cache in front of it. Guardyn
+has no cache tier, and its absence is frequently read as an oversight.
+
+There is no measured latency problem. TiKV serves key-by-id reads directly, and the largest
+read volume — message history — is paged from ScyllaDB partitions that are already ordered
+for it.
+
+## Decision
+
+No Dragonfly, Redis, or other cache layer before launch. Revisit only with production
+measurements showing a specific hot path that a cache would fix.
+
+## Consequences
+
+One fewer component to deploy, secure, and keep consistent — and no cache-invalidation
+class of bug in a system whose correctness is security-relevant. A self-hoster's footprint
+stays smaller, which serves **I-4**.
+
+If a genuine hot path emerges, the change is additive and this ADR is superseded rather
+than quietly ignored.
+
+Note `presence-service/src/db.rs` carries a "would use Redis" comment. That is a leftover,
+not a plan; PR-29 replaces it with a TTL-correct TiKV implementation.
+
+## Alternatives rejected
+
+**Adding Redis now** — a cache added before a measurement is a guess with an uptime cost.
+**Dragonfly** — same argument; a better Redis is still a component nothing currently needs.

--- a/docs/adr/ADR-0007-zero-knowledge-logging.md
+++ b/docs/adr/ADR-0007-zero-knowledge-logging.md
@@ -1,0 +1,50 @@
+---
+id: adr-0007
+type: adr
+status: accepted
+owns: [backend/crates/common/src/observability.rs, backend/crates/common/src/redact.rs]
+read_when: [adding a log line, touching observability, adding a metric]
+tokens: 515
+supersedes: []
+---
+
+# ADR-0007 · Zero-knowledge logging and mandatory redaction
+
+## Status
+
+`accepted`. Two known violations, both named below.
+
+## Context
+
+End-to-end encryption is undone by a log line. A server that cannot decrypt a message but
+prints the plaintext during handling — or prints the key, or the user's IP — offers no more
+protection than one that never encrypted anything. Logs are also the artefact most likely
+to leave the trust boundary: shipped to aggregators, attached to tickets, seized.
+
+**I-1** therefore has to be enforced structurally. A convention that says "be careful" fails
+on the first debug statement written at 2 a.m.
+
+## Decision
+
+Tracing is initialised **only** through `guardyn_common::observability::init_tracing`, which
+installs the redaction layer. Constructing a `tracing_subscriber` directly is forbidden.
+Key- and payload-bearing types never `#[derive(Debug)]`; they implement `Debug` to emit
+`[REDACTED]`, or are wrapped in `Redacted<T>` (PR-24).
+
+## Consequences
+
+Redaction cannot be forgotten, because it is not a per-call-site decision. Every service
+must route through `common`, and a service that wants a bespoke subscriber cannot have one.
+
+Debugging is harder by design: correlating an incident means using `user_id`/`device_id`
+sparingly rather than dumping a request. That difficulty is the feature.
+
+**Known violations.** `call-service` and `notification-service` build a `FmtSubscriber`
+directly (PR-26). `common/src/rate_limit.rs:241,256` log a raw client IP — PII under this
+ADR — and have **no owned step**.
+
+## Alternatives rejected
+
+**Log-level discipline** — a `debug!` that never runs in production still gets enabled
+during an incident, which is exactly when the data is most sensitive. **Scrubbing at the
+aggregator** — too late; the data has already left the process.

--- a/docs/adr/ADR-0008-protobuf-codegen.md
+++ b/docs/adr/ADR-0008-protobuf-codegen.md
@@ -1,0 +1,50 @@
+---
+id: adr-0008
+type: adr
+status: accepted
+owns: [backend/proto/, backend/crates/*/src/generated/, client-desktop/src-tauri/src/proto/]
+read_when: [changing a proto, touching generated code]
+tokens: 454
+supersedes: []
+---
+
+# ADR-0008 · Generated protobuf lives in OUT_DIR, not in the tree
+
+## Status
+
+`accepted` as the target. **Three strategies coexist today**; PR-23 unifies them.
+
+## Context
+
+`backend/proto/*.proto` is the canonical wire contract. How the Rust for it is produced has
+drifted into three answers at once:
+
+- `messaging-service` uses `tonic::include_proto!`, compiling from `OUT_DIR` at build time.
+- Five services `include!` committed output under `src/generated/` — 13 files, ~12,100 lines.
+- `client-desktop/src-tauri/src/proto/` holds a **third** copy — 8 files, ~7,600 lines.
+
+Committed output invites two failures: it drifts silently from the `.proto` when someone
+forgets to regenerate, and it invites hand-editing, which the `.proto` then silently
+overwrites.
+
+## Decision
+
+Generated protobuf is produced at build time into `OUT_DIR` and included with
+`include_proto!`. No generated Rust is committed.
+
+## Consequences
+
+The `.proto` becomes the only thing that can be edited, so drift is structurally impossible
+and review diffs shrink by ~19,700 lines. `protoc` becomes a hard build dependency — it is
+already pinned in `flake.nix`.
+
+Deleting the committed copies is a large, single-purpose, trivially revertable change; CI
+must prove regeneration before the deletion lands.
+
+**The plan names only the backend copy.** The `client-desktop` copy is a third location and
+belongs in the same step.
+
+## Alternatives rejected
+
+**Commit generated code everywhere** — consistent, but keeps drift and hand-edits possible.
+**Leave it mixed** — three strategies means three ways to be wrong.

--- a/docs/adr/ADR-0009-micro-step-budget.md
+++ b/docs/adr/ADR-0009-micro-step-budget.md
@@ -1,0 +1,48 @@
+---
+id: adr-0009
+type: adr
+status: accepted
+owns: [AGENTS.md, .claude/rules/10-git-workflow.md]
+read_when: [planning work, splitting a change, opening a PR]
+tokens: 430
+supersedes: []
+---
+
+# ADR-0009 · Micro-step PR budget and branch isolation
+
+## Status
+
+`accepted`
+
+## Context
+
+Most of this repository is changed by AI agents, which have a finite context window. A
+change large enough to exceed it forces the agent to reconstruct lost context mid-task —
+the point at which it starts guessing, and where a security-critical system is least
+tolerant of guesses.
+
+Large pull requests are also harder to review and harder to revert, and those costs fall on
+humans.
+
+## Decision
+
+One micro-step = one branch = one pull request = one issue. Branch names are
+`<type>/<issue>-<slug>`. The budget is **≤400 hand-written changed lines, or ≤8 files**. A
+step that would exceed it is split *before* the branch is opened.
+
+## Consequences
+
+A whole step — diff, tests, and the documentation it touches — fits in one session, so no
+step needs its context rebuilt. Every PR is independently revertable and leaves `main`
+green. Review stays tractable.
+
+The cost is ceremony: an issue per step, and real work spread across many PRs, which makes
+a large refactor look slower than it is. Bulk deletions and generated files are exempt from
+the count, but such a PR must contain nothing else — otherwise the exemption becomes the
+loophole that swallows the rule.
+
+## Alternatives rejected
+
+**Feature branches** — accumulate context until nothing fits in a window and nothing is
+revertable. **Line limit only** — a 40-file, 300-line rename is inside a line budget and
+still unreviewable, which is why the file count is there.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,45 @@
+---
+id: adr-index
+type: index
+status: accepted
+owns: [docs/adr/]
+read_when: [proposing a change to a decided thing, writing an ADR]
+tokens: 618
+supersedes: []
+---
+
+# Architectural decisions
+
+An ADR records a decision **already embodied in the code**. It is a record, not a proposal:
+if the code does not do it, the ADR says so explicitly rather than describing intent as
+though it were fact.
+
+Adding, replacing or removing a datastore, message bus, or major dependency requires an
+accepted ADR **and** explicit user approval (`AGENTS.md` §5.3).
+
+| ADR | Decision | Status |
+|---|---|---|
+| [0001](ADR-0001-tikv-metadata-store.md) | TiKV as the metadata, auth and MLS-state store — deliberately not PostgreSQL | accepted |
+| [0002](ADR-0002-scylladb-history.md) | ScyllaDB for message, call and notification history | accepted |
+| [0003](ADR-0003-dual-bus.md) | Dual bus — NATS for signalling, Redpanda for the durable log | accepted |
+| [0004](ADR-0004-openmls-group-e2ee.md) | OpenMLS 0.6 for groups; own X3DH and Double Ratchet rather than libsignal | accepted |
+| [0005](ADR-0005-hybrid-pqxdh.md) | Hybrid PQXDH (X25519 + ML-KEM-768) | accepted — **target, not met** |
+| [0006](ADR-0006-no-cache-layer.md) | No Dragonfly/Redis cache layer before launch | accepted |
+| [0007](ADR-0007-zero-knowledge-logging.md) | Zero-knowledge logging and mandatory redaction | accepted — **2 known violations** |
+| [0008](ADR-0008-protobuf-codegen.md) | Generated protobuf in `OUT_DIR`, not committed | accepted — **3 strategies coexist** |
+| [0009](ADR-0009-micro-step-budget.md) | Micro-step PR budget and branch isolation | accepted |
+
+[`ADR-0000-template.md`](ADR-0000-template.md) is the shape. Copy it and take the next free
+number.
+
+## Decisions that are not yet met
+
+Three ADRs are accepted as the target while the code does something else. This is recorded
+deliberately — the alternative is an ADR set that reads as a description of the system and
+is quietly wrong.
+
+| ADR | Gap | Owned by |
+|---|---|---|
+| 0005 | `pq` feature off by default; **no ML-KEM field in any proto**, so no PQ key can be published | PR-36…PR-40 |
+| 0007 | `call-service` and `notification-service` build a `FmtSubscriber` directly; `rate_limit.rs:241,256` log a raw IP | PR-26; the IP leak is **unowned** |
+| 0008 | Committed generated protobuf in `backend/crates/*/src/generated/` **and** `client-desktop/src-tauri/src/proto/`, while `messaging-service` uses `include_proto!` | PR-23 |


### PR DESCRIPTION
Closes #23

Nine decisions already embodied in the code, plus `ADR-0000-template.md` and `index.md`.

## The governing rule for the set
**An ADR is a record, not a proposal.** Where the code does not do what the decision says,
the ADR says so — rather than describing intent as though it were fact. Three are in that
state, and the index lists them in a separate table so the set cannot be misread as a
description of the running system.

| ADR | Gap | Owner |
|---|---|---|
| **0005** Hybrid PQXDH | `pq` off by default and **zero ML-KEM fields in any proto**, so no server can publish a PQ key. Ends with: *do not describe the product as post-quantum protected.* | PR-36…PR-40 |
| **0007** ZK logging | Two services build a `FmtSubscriber` directly; `rate_limit.rs:241,256` log a raw client IP | PR-26; the IP leak is **unowned** |
| **0008** Protobuf codegen | Three strategies coexist, and the third copy is in `client-desktop/src-tauri/src/proto/` — a location the plan does not name. Removing both committed copies drops ~19,700 lines. | PR-23 |

## Written to survive a future reader
Each ADR has an **Alternatives rejected** section with reasons, and a **Consequences**
section that states costs, not only benefits — an ADR listing only benefits is advocacy.

ADR-0001 exists specifically to stop someone "fixing" TiKV back to the PostgreSQL the
original brief specified. ADR-0003 exists to stop someone consolidating NATS and Redpanda
on sight of "two message buses". ADR-0006 exists to stop a cache being added without a
measurement.

## Verified
All 11 files carry complete frontmatter; every `id` is unique; every `status` is inside the
enum; every relative link in `index.md` resolves.

## Budget — exemption invoked
505 lines across 11 files, over both limits. `implementation_plan.md` declares PR-12
**budget-exempt** as single-purpose and template-driven, and this PR contains nothing but
the ADR set — which is the condition the exemption attaches to.