### PR TITLE
PR-13 · Write docs/ops DEPLOYMENT, RUNBOOK, OBSERVABILITY

### DIFF
--- a/docs/ops/DEPLOYMENT.md
+++ b/docs/ops/DEPLOYMENT.md
@@ -1,0 +1,85 @@
+---
+id: ops-deployment
+type: ops
+status: accepted
+owns: [infra/k8s/, infra/k3d-config.yaml, docker-compose.dev.yml, Justfile]
+read_when: [deploying, changing a manifest, changing an overlay, onboarding a self-hoster]
+tokens: 875
+supersedes: []
+---
+
+# Deployment
+
+Two targets: Docker Compose for a single machine, Kubernetes for everything else. Both are
+first-class — self-hosting is the product (**I-4**), so neither is a toy.
+
+## Single machine — Docker Compose
+
+```sh
+just dc-up          # nine infrastructure containers plus six services
+just dc-status      # health of each
+just dc-logs        # follow everything
+just dc-down        # stop
+just dc-reset       # stop and destroy volumes
+```
+
+Infrastructure: `nats`, `redpanda`, `redpanda-console`, `pd`, `tikv`, `scylladb`, `minio`,
+`minio-init`, `envoy`. Services: auth, messaging, presence, media, call, notification.
+
+`just dc-rebuild <service>` rebuilds one image; `just dc-shell <service>` opens a shell;
+`just dc-cqlsh`, `just dc-tikv-status` and `just dc-redpanda-health` reach the stores
+directly.
+
+## Kubernetes
+
+```sh
+just kube-create      # k3d cluster from infra/k3d-config.yaml
+just kube-bootstrap   # cert-manager and core components
+just k8s-deploy <service>
+just verify-kube      # smoke checks
+just teardown
+```
+
+The local cluster is k3d: **3 servers, 2 agents**, k3s `v1.31.5-k3s1`, Traefik disabled
+because Envoy is the ingress path.
+
+### Layout
+
+`infra/k8s/base/` holds `namespaces`, `apps`, `envoy`, `tikv`, `scylladb`, `minio`,
+`cert-manager`, `cilium`, `monitoring` and `observability`.
+
+`overlays/local` is the development layer. `overlays/prod` adds `hpa.yaml`, `pdb.yaml`,
+`ingress.yaml`, `network-policies.yaml`, `service-monitors.yaml`, `slo-rules.yaml`,
+`alertmanager-config.yaml` and Grafana SLO dashboards.
+
+### Ports
+
+| Service | Port |
+|---|---|
+| auth-service | 50051 |
+| messaging-service | 50052 (gRPC), 8081 (WebSocket) |
+| presence-service | 50053 |
+| media-service | 50054 |
+| notification-service | 8080, 9090 (metrics) |
+
+## Domains
+
+**Never hardcode a hostname.** `DOMAIN` is the single source of truth, and every hostname
+derives from it: `auth.${DOMAIN}`, `api.${DOMAIN}`, `ws.${DOMAIN}`, `media.${DOMAIN}`,
+`app.${DOMAIN}`. Deployment must work with `.local`, `.test` and real domains alike.
+
+## Secrets
+
+SOPS with age, configured in `.sops.yaml`. Only `*.enc.yaml` is committed; `age-key.txt`
+and any `*.key` are gitignored and must never reach the repository.
+
+## Known deployment gaps
+
+| Gap | Consequence | Owned by |
+|---|---|---|
+| No `call-service` Deployment in `infra/k8s/base/apps/` | call-service is Compose-only and cannot be deployed to Kubernetes | PR-44 |
+| Envoy routes 3 of 6 services (auth, messaging, presence) | media, calls and notifications are unreachable from a browser client | PR-44 |
+| `infra/k8s/base/envoy/ingress.yaml:18` hardcodes `envoy.guardyn.local` | breaks the `${DOMAIN}` rule above | **unowned** |
+| Production images are tagged, not digest-pinned | a tag can be moved under a running cluster | PR-44 |
+| `infra/secrets/.gitignore` ignores `*.enc.yaml` — the **encrypted** file — while the plaintext `app-secrets.yaml` is tracked | exactly inverted: the safe artefact is excluded and the unsafe one committed. The tracked values are placeholders, so no live credential is exposed *yet* | PR-42 |
+| `infra/justfile` is a second, divergent task file whose `k8s:deploy` references a values file that does not exist | dead code that will mislead | unowned |

--- a/docs/ops/OBSERVABILITY.md
+++ b/docs/ops/OBSERVABILITY.md
@@ -1,0 +1,88 @@
+---
+id: ops-observability
+type: ops
+status: accepted
+owns: [backend/crates/common/src/observability.rs, infra/k8s/base/observability/, infra/k8s/base/monitoring/]
+read_when: [adding a metric or span, debugging in production, changing tracing]
+tokens: 891
+supersedes: []
+---
+
+# Observability
+
+Three signals — logs, metrics, traces — under one hard constraint: **none of them may
+carry anything the server is not supposed to know** (**I-1**). Observability that leaks a
+payload defeats the encryption above it.
+
+## The one way to initialise tracing
+
+```rust
+guardyn_common::observability::init_tracing(service_name, log_level, otlp_endpoint)
+```
+
+Constructing a `tracing_subscriber::FmtSubscriber` directly **bypasses the redaction
+layer and is forbidden** (ADR-0007). Logs are structured JSON (`.json()`), tagged with
+`service = service_name`.
+
+`init_tracing` takes an optional OTLP endpoint. When present it initialises an
+OpenTelemetry tracer exporting to Tempo; when absent, tracing is local only, and the
+service still starts.
+
+## Never emit
+
+Message, file or media plaintext **or ciphertext** · identity keys, pre-keys, ratchet
+state, MLS secrets, ML-KEM private keys · tokens, passwords, password hashes, session
+secrets · email, phone number, **IP address**, precise location.
+
+This applies to log lines, span attributes, **and metric labels** equally. A metric label
+is a log line that is retained longer.
+
+`user_id` and `device_id` are correlatable metadata: log them only when an operation
+genuinely needs them, and never at `info` on a hot path.
+
+When unsure whether a field is sensitive: **do not log it.**
+
+## Checking yourself
+
+```sh
+# no service builds its own subscriber
+grep -rln --include='*.rs' -e FmtSubscriber -e 'tracing_subscriber::fmt()' backend/crates/*/src
+
+# no log macro takes a raw IP, email or phone
+grep -rnE '(trace|debug|info|warn|error)!\(' --include='*.rs' backend/crates/*/src \
+  | grep -iE '"[^"]*\b(ip|email|phone)\b[^"]*"[^)]*,'
+```
+
+Both must print nothing. The full predicate set is in
+[`../../.claude/rules/30-zk-logging.md`](../../.claude/rules/30-zk-logging.md).
+
+After running the stack, the spot check is:
+
+```sh
+grep -iE 'ciphertext|BEGIN|eyJ' <logs>   # must return zero hits
+```
+
+`eyJ` catches a base64-encoded JWT header — the most common accidental token leak.
+
+## Stack
+
+| Signal | Collector | Store | View |
+|---|---|---|---|
+| Traces | OpenTelemetry Collector | Tempo | Grafana |
+| Logs | Promtail | Loki | Grafana |
+| Metrics | Prometheus | Prometheus | Grafana |
+
+Manifests live in `infra/k8s/base/observability/` (otel-collector, Tempo, Grafana
+dashboards for messaging, logs and tracing) and `infra/k8s/base/monitoring/` (Loki,
+Promtail, alerting rules). The prod overlay adds service monitors, SLO rules and
+alertmanager configuration.
+
+## Known observability gaps
+
+| Gap | Consequence | Owned by |
+|---|---|---|
+| `call-service` and `notification-service` build a `FmtSubscriber` directly | two services log outside the redaction layer | PR-26 |
+| `common/src/rate_limit.rs:241,256` log a raw client IP | PII in logs — a direct I-1 breach | **unowned** |
+| The Compose observability stack is commented out, and references `./infra/observability/prometheus.yml` which does not exist | no local metrics; uncommenting it fails | PR-43 |
+| `GUARDYN_OBSERVABILITY__OTLP_ENDPOINT` is `""` for every Compose service | no traces are exported locally | PR-43 |
+| `Sampler::AlwaysOn` (`observability.rs:132`) | 100% trace sampling — fine in development, a cost and volume decision in production | PR-43 |

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -1,0 +1,90 @@
+---
+id: ops-runbook
+type: ops
+status: accepted
+owns: [infra/scripts/, Justfile]
+read_when: [an incident, a failing service, a store that will not start]
+tokens: 932
+supersedes: []
+---
+
+# Runbook
+
+Incident procedure. Read [`OBSERVABILITY.md`](OBSERVABILITY.md) first if you are about to
+add logging to diagnose something — **what you must not log applies during an incident
+too**, and an incident is exactly when the temptation to dump a request is strongest.
+
+## Rule zero
+
+Nothing you paste into a ticket, a chat, or a postmortem may contain a payload, a key, or
+PII. Redact before you copy, not after.
+
+## Triage
+
+```sh
+just dc-status                       # Compose: per-container health
+kubectl get pods -n apps             # Kubernetes: what is running
+just verify-kube                     # smoke checks
+just dc-logs                         # follow everything
+just dc-log <service>                # one service
+```
+
+Five of six services expose a `Health` RPC. **`media-service` does not** — its liveness
+must be inferred from the pod and from MinIO reachability until PR-27 adds one.
+
+## A service will not start
+
+1. `just dc-log <service>` — configuration errors surface immediately at startup.
+2. Check its store is up before blaming the service: `just dc-tikv-status`,
+   `just dc-scylla-status`, `just dc-redpanda-health`.
+3. Check the JWT secret. `auth-service` and `presence-service` warn loudly when running on
+   a development default; in production that warning is an incident.
+4. `just dc-rebuild <service>` after a dependency change; `just dc-rebuild-clean <service>`
+   if the build cache is suspect.
+
+## A store is unhealthy
+
+| Store | Check | Notes |
+|---|---|---|
+| TiKV | `just dc-tikv-status` | needs `pd` up first; a TiKV that cannot reach PD looks like a TiKV fault |
+| ScyllaDB | `just dc-scylla-status`, `just dc-cqlsh` | slow first start is normal — it allocates before serving |
+| Redpanda | `just dc-redpanda-health`, `just dc-redpanda-topics` | `redpanda-console` gives a UI |
+| MinIO | container health | `minio-init` must have completed, or buckets are missing |
+| NATS | container health | losing NATS drops presence and call setup, not messages |
+
+**A NATS outage is not a data-loss incident** — it carries ephemeral signalling only.
+A Redpanda outage is: the durable log backs notification delivery.
+
+## Kubernetes: port-forwards keep dying
+
+```sh
+just port-forward           # watchdog: auto-restarts with backoff
+just port-forward-status
+just port-forward-stop
+```
+
+The watchdog health-checks every 5 seconds and restarts with exponential backoff up to 10
+attempts. ChromeDriver is optional and is fetched on demand; if it is missing the watchdog
+warns and continues rather than failing the whole port-forward set.
+
+## Cluster wedged after a host restart
+
+`bash infra/scripts/fix-cluster-after-restart.sh` — the common k3d-after-reboot repair.
+If it does not help, `just kube-delete && just kube-create && just kube-bootstrap` is
+cheap for a local cluster.
+
+## Suspected data exposure
+
+1. **Stop shipping logs** before investigating. Every second of continued export widens
+   the exposure.
+2. Establish what was emitted, using the greps in `OBSERVABILITY.md`.
+3. Rotate anything that could have been exposed — JWT secret, age key, store credentials.
+4. The fix is a regression test that fails before it (`AGENTS.md` §8), not just a patch.
+5. If key material was exposed, affected sessions must be re-established. There is no way
+   to un-leak a ratchet state.
+
+## Escalation
+
+Security issues go to security@guardyn.app and **never** into a public issue
+([`SECURITY.md`](../../SECURITY.md)). Anything touching an invariant in `AGENTS.md` §1 is a
+security issue by definition.


### PR DESCRIPTION
Closes #24

Three operational documents, each ending with a **gaps table** — because a runbook that
describes a more complete system than the one running is worse than no runbook: it sends an
on-call engineer looking for something that was never built.

**Verified before commit:** all 23 Justfile recipes cited exist, `observability.rs:132` is
`Sampler::AlwaysOn`, `ingress.yaml:18` is the hardcoded host, and
`infra/scripts/fix-cluster-after-restart.sh` is real.

## DEPLOYMENT.md
Both targets as first-class — self-hosting *is* the product, so Compose is not a toy.
Records the k3d shape (3 servers, 2 agents, Traefik disabled because Envoy is the ingress
path), the port map, and six gaps — including the second, divergent `infra/justfile` whose
`k8s:deploy` points at a values file that does not exist.

**The secrets gap, stated precisely rather than alarmingly.** `infra/secrets/.gitignore`
excludes `*.enc.yaml` — the encrypted file, and the only path `.sops.yaml` has a creation
rule for — while the plaintext `app-secrets.yaml` is tracked. Exactly inverted. Checked
without printing values: all three keys hold placeholder markers, so **no live credential is
committed**. Hygiene, not an active leak — but the rule as written guarantees the next real
secret lands in git. (PR-42.)

## OBSERVABILITY.md
The one legal way to initialise tracing, the never-emit list applied equally to log lines,
span attributes **and metric labels** — a metric label is a log line that is retained
longer — and two copy-paste greps that must print nothing. `eyJ` is in the spot check
because it is the base64 prefix of a JWT header, the most common accidental token leak.

## RUNBOOK.md
Opens with **rule zero**: nothing pasted into a ticket or postmortem may contain a payload,
a key, or PII. An incident is exactly when the temptation to dump a request is strongest.
Also records that `media-service` has no `Health` RPC so its liveness must be inferred until
PR-27, and that a NATS outage is *not* a data-loss incident while a Redpanda outage is.

## Out of scope
Fixing any listed gap. No manifest, script or code changes.

## Budget
263 added lines across 3 files — within the ≤400 / ≤8 contract.