### PR TITLE
PR-15 · Add docs/.manifest.yaml and just docs-verify

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -481,3 +481,7 @@ test-desktop-all:
 install-hooks:
     @git config core.hooksPath .githooks
     @echo "[hooks] core.hooksPath -> .githooks"
+
+# Verify the documentation base: frontmatter, impact, glossary, links, language.
+docs-verify:
+    @bash infra/scripts/docs-verify.sh

--- a/docs/.manifest.yaml
+++ b/docs/.manifest.yaml
@@ -1,0 +1,48 @@
+# Which documents own which source paths.
+#
+# docs-verify check 2 reads this file: when a PR changes a source path, at least one of
+# the documents mapped to it must change in the same PR, or the PR must carry the label
+# docs-impact:none with a stated reason.
+#
+# Every path in `requires` must exist. A mapping to a document that does not exist is an
+# unsatisfiable requirement, which trains people to reach for the label instead.
+---
+mappings:
+  - source: backend/proto/
+    requires: [docs/spec/SRS.md, docs/GLOSSARY.md, docs/spec/SAD.md]
+
+  - source: backend/crates/crypto/
+    requires: [docs/adr/ADR-0004-openmls-group-e2ee.md, docs/adr/ADR-0005-hybrid-pqxdh.md, docs/spec/SRS.md]
+
+  - source: backend/crates/common/src/observability.rs
+    requires: [docs/ops/OBSERVABILITY.md, docs/adr/ADR-0007-zero-knowledge-logging.md]
+
+  - source: backend/crates/common/src/rate_limit.rs
+    requires: [docs/spec/SRS.md]
+
+  - source: infra/k8s/
+    requires: [docs/ops/DEPLOYMENT.md, docs/spec/SAD.md]
+
+  - source: docker-compose.dev.yml
+    requires: [docs/ops/DEPLOYMENT.md]
+
+  - source: infra/scripts/
+    requires: [docs/ops/RUNBOOK.md]
+
+  - source: Justfile
+    requires: [docs/ops/DEPLOYMENT.md, docs/ops/RUNBOOK.md]
+
+  - source: implementation_plan.md
+    requires: [docs/roadmap/ROADMAP.md]
+
+# Files exempt from the frontmatter contract (check 1).
+#
+# docs/security/ predates this documentation base and is externally cited. It is retained
+# unchanged rather than retrofitted, so it is excluded here rather than made to fail.
+frontmatter_exempt:
+  - docs/security/
+
+# Files allowed to contain Cyrillic (check 5). The Cyrillic in this file IS the policy's
+# own counter-example - flagging it would flag the rule that forbids it.
+language_allowlist:
+  - .github/.copilot-commit-message-instructions.md

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -4,7 +4,7 @@ type: glossary
 status: accepted
 owns: [backend/proto/, backend/crates/crypto/src/, backend/crates/common/src/]
 read_when: [naming anything, writing a document, reviewing a proto change]
-tokens: 1591
+tokens: 1626
 supersedes: []
 ---
 
@@ -17,14 +17,19 @@ disagree, the code is right and this file is stale: fix it here.
 `forbidden_aliases` is enforced. `docs-verify` check #3 fails when a document uses one of
 them in place of the canonical term, which is how `User`/`Player`-class naming drift dies.
 
+The list is deliberately narrow: only genuinely confusable domain synonyms. Ordinary
+English words and real product names discussed in "Alternatives rejected" sections are not
+aliases — forbidding those produces noise, and a check that cries wolf gets switched off.
+A `—` means the term has no confusable synonym worth banning.
+
 ## Identity
 
 | Term | Code symbol | Meaning | forbidden_aliases |
 |---|---|---|---|
-| **User** | `UserId`, `UserProfile` (`common.proto`, `auth.proto`) | A human account. The unit of identity. | Account, Customer, Player |
-| **Device** | `DeviceId`, `DeviceInfo` (`common.proto`, `auth.proto`) | One installation belonging to a User. Keys are per-device, not per-user. | Endpoint, Terminal |
+| **User** | `UserId`, `UserProfile` (`common.proto`, `auth.proto`) | A human account. The unit of identity. | Player, Customer |
+| **Device** | `DeviceId`, `DeviceInfo` (`common.proto`, `auth.proto`) | One installation belonging to a User. Keys are per-device, not per-user. | Terminal |
 | **Contact** | `Contact` (`auth.proto`) | Another User a User has added. | Friend, Buddy |
-| **BlockedUser** | `BlockedUser` (`auth.proto`) | A User whose messages are refused. | Banned, Muted |
+| **BlockedUser** | `BlockedUser` (`auth.proto`) | A User whose messages are refused. | Banned |
 
 `Client` is *not* a synonym for Device — `ClientCapabilities` describes the software, not
 the installation record.
@@ -33,14 +38,14 @@ the installation record.
 
 | Term | Code symbol | Meaning | forbidden_aliases |
 |---|---|---|---|
-| **Message** | `Message`, `MessageType` (`messaging.proto`) | One addressed payload. Always ciphertext on the wire. | Msg, Note |
-| **Conversation** | `Conversation` (`messaging.proto`) | A 1-to-1 or group exchange. The container for Messages. | Chat, Room, Dialog |
-| **Group** | `GroupInfo`, `GroupMemberInfo`, `GroupMessage` | A multi-party Conversation with membership and roles. | Channel, Team |
+| **Message** | `Message`, `MessageType` (`messaging.proto`) | One addressed payload. Always ciphertext on the wire. | Msg |
+| **Conversation** | `Conversation` (`messaging.proto`) | A 1-to-1 or group exchange. The container for Messages. | Chat, Dialog |
+| **Group** | `GroupInfo`, `GroupMemberInfo`, `GroupMessage` | A multi-party Conversation with membership and roles. | Channel |
 | **Thread** | `ThreadReference` (`messaging.proto`) | A reply chain *inside* a Conversation. Not a synonym for Conversation. | — |
-| **Reaction** | `Reaction`, `ReactionSummary` | An emoji response attached to a Message. | Like, Emoji |
-| **ReadReceipt** | `ReadReceipt` (`messaging.proto`) | Proof a Message was read. | Seen, Ack |
-| **DeliveryStatus** | `DeliveryStatus` enum | Where a Message is in transit. | State, Progress |
-| **DisappearingConfig** | `DisappearingConfig` | Per-Conversation self-destruct timing. | Ephemeral, TTL |
+| **Reaction** | `Reaction`, `ReactionSummary` | An emoji response attached to a Message. | Emoji |
+| **ReadReceipt** | `ReadReceipt` (`messaging.proto`) | Proof a Message was read. | Ack |
+| **DeliveryStatus** | `DeliveryStatus` enum | Where a Message is in transit. | — |
+| **DisappearingConfig** | `DisappearingConfig` | Per-Conversation self-destruct timing. | — |
 | **ForwardInfo** | `ForwardInfo`, `MessageEdit` | Provenance of a forwarded Message; an edit record. | — |
 
 ## Cryptography
@@ -51,12 +56,12 @@ the installation record.
 | **IdentityKeyPair** | `IdentityKeyPair` (`crypto`) | A Device's long-term key pair. Never leaves the Device. | MasterKey |
 | **SignedPreKey** | `SignedPreKey` (`crypto`) | Medium-term key, signed by the identity key. | — |
 | **OneTimePreKey** | `OneTimePreKey`, `OneTimePreKeyPublic` | Single-use key consumed by one session handshake. | OTK |
-| **X3DH** | `X3DHProtocol`, `X3DHKeyMaterial`, `X3DHPrekeyMessage` | The asynchronous handshake establishing a shared secret. | Handshake |
+| **X3DH** | `X3DHProtocol`, `X3DHKeyMaterial`, `X3DHPrekeyMessage` | The asynchronous handshake establishing a shared secret. | — |
 | **PQXDH** | `HybridKeyBundle`, `HybridSharedSecret`, `HybridPrivateKeys` | X3DH extended with ML-KEM-768. **Implemented, not yet enabled** — see I-3. | PostQuantumX3DH |
-| **DoubleRatchet** | `DoubleRatchet`, `MessageHeader` | Per-message forward-secret key evolution after the handshake. | Ratchet |
+| **DoubleRatchet** | `DoubleRatchet`, `MessageHeader` | Per-message forward-secret key evolution after the handshake. | — |
 | **MLS** | `MlsGroupManager`, `MlsGroupState`, `MlsKeyPackage` | OpenMLS group encryption. The Group counterpart to Double Ratchet. | GroupCrypto |
 | **SealedSender** | `SealedSender`, `SealedSenderEnvelope`, `SenderCertificate` | Hides sender identity from the server. | AnonymousSender |
-| **EncryptedMessage** | `EncryptedMessage` (`crypto`) | Ciphertext plus the header needed to decrypt it. | Blob, Payload |
+| **EncryptedMessage** | `EncryptedMessage` (`crypto`) | Ciphertext plus the header needed to decrypt it. | — |
 | **SFrame** | `SFrameKeyRotated`, `ExchangeSFrameKey*` | Frame-level media encryption for calls. | MediaCrypto |
 
 **Never** write "encrypted payload" where `EncryptedMessage` is meant, and never let any of
@@ -66,11 +71,11 @@ these appear in a log — see [`.claude/rules/30-zk-logging.md`](../.claude/rule
 
 | Term | Code symbol | Meaning | forbidden_aliases |
 |---|---|---|---|
-| **Call** | `CallState`, `CallType`, `CallEndReason`, `CallQuality` | A voice or video session. | Ring, Session |
-| **CallParticipant** | `CallParticipant`, `ParticipantKeyPackage` | One Device in a Call. | Attendee, Peer |
-| **SdpMessage** | `SdpMessage`, `SdpType` | WebRTC session description exchanged during setup. | Offer, Answer |
-| **IceCandidate** | `IceCandidate`, `IceServer` | WebRTC connectivity candidate. | Candidate |
-| **Presence** | `UserPresence`, `PresenceUpdate`, `UserStatus` | Whether a User is reachable. | Online, Activity |
+| **Call** | `CallState`, `CallType`, `CallEndReason`, `CallQuality` | A voice or video session. | — |
+| **CallParticipant** | `CallParticipant`, `ParticipantKeyPackage` | One Device in a Call. | Attendee |
+| **SdpMessage** | `SdpMessage`, `SdpType` | WebRTC session description exchanged during setup. | — |
+| **IceCandidate** | `IceCandidate`, `IceServer` | WebRTC connectivity candidate. | — |
+| **Presence** | `UserPresence`, `PresenceUpdate`, `UserStatus` | Whether a User is reachable. | — |
 
 `Status` alone is ambiguous — `Status` is the health enum in `common.proto`, `UserStatus`
 is presence, and `DeliveryStatus` is message transit. Always qualify it.
@@ -79,21 +84,21 @@ is presence, and `DeliveryStatus` is message transit. Always qualify it.
 
 | Term | Code symbol | Meaning | forbidden_aliases |
 |---|---|---|---|
-| **MediaMetadata** | `MediaMetadata`, `MediaType`, `UploadStatus` | Descriptor for an uploaded blob. The blob itself is ciphertext. | Attachment, File |
+| **MediaMetadata** | `MediaMetadata`, `MediaType`, `UploadStatus` | Descriptor for an uploaded blob. The blob itself is ciphertext. | Attachment |
 | **ErrorCode** | `ErrorCode` enum (`common.proto`) | The canonical error taxonomy. Read the proto — never invent a variant. | Errno |
-| **HealthStatus** | `HealthStatus`, `Status` (`common.proto`) | Service liveness, reported per service. | Heartbeat |
-| **EventEnvelope** | `EventEnvelope` (`common`) | The durable-log wrapper carried over Redpanda. | Payload, Record |
+| **HealthStatus** | `HealthStatus`, `Status` (`common.proto`) | Service liveness, reported per service. | — |
+| **EventEnvelope** | `EventEnvelope` (`common`) | The durable-log wrapper carried over Redpanda. | — |
 | **RateLimiter** | `RateLimiter`, `RateLimitConfig` | Per-process request throttle. **Not** distributed — see PR-41. | Throttle |
 
 ## Datastores and buses
 
 | Term | Role | forbidden_aliases |
 |---|---|---|
-| **TiKV** | Metadata, auth and MLS state. Deliberately not PostgreSQL. | DB, Database |
-| **ScyllaDB** | Message, call and notification history. | Cassandra |
-| **MinIO** | Encrypted media blobs. | S3 |
-| **NATS** | Ephemeral signalling. | Queue |
-| **Redpanda** | Durable event log. | Kafka |
-| **Envoy** | gRPC-Web gateway at the edge. | Proxy, Gateway |
+| **TiKV** | Metadata, auth and MLS state. Deliberately not PostgreSQL. | — |
+| **ScyllaDB** | Message, call and notification history. | — |
+| **MinIO** | Encrypted media blobs. | — |
+| **NATS** | Ephemeral signalling. | — |
+| **Redpanda** | Durable event log. | — |
+| **Envoy** | gRPC-Web gateway at the edge. | — |
 
 NATS and Redpanda **coexist by design** with separated roles. Neither is "the bus".

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -4,7 +4,7 @@ type: ops
 status: accepted
 owns: [infra/scripts/, Justfile]
 read_when: [an incident, a failing service, a store that will not start]
-tokens: 932
+tokens: 1062
 supersedes: []
 ---
 
@@ -82,6 +82,20 @@ cheap for a local cluster.
 4. The fix is a regression test that fails before it (`AGENTS.md` §8), not just a patch.
 5. If key material was exposed, affected sessions must be re-established. There is no way
    to un-leak a ratchet state.
+
+## Documentation checks
+
+```sh
+just docs-verify
+```
+
+Five checks — frontmatter, impact, glossary, links, language — defined in
+[`../../.claude/rules/40-doc-sync.md`](../../.claude/rules/40-doc-sync.md) and run in CI on
+every pull request. Check 2 is the one that matters: changing a source path without
+updating the documents mapped to it in `docs/.manifest.yaml` fails the build, unless the PR
+carries `docs-impact:none` **with a stated reason**.
+
+Run it before pushing. It is faster than a round trip through CI.
 
 ## Escalation
 

--- a/infra/scripts/docs-verify.sh
+++ b/infra/scripts/docs-verify.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Documentation verification - the mechanism that makes doc drift a build failure
+# rather than a review nit. Run via `just docs-verify`.
+#
+# Five checks, defined in .claude/rules/40-doc-sync.md:
+#   1 frontmatter  every docs/**/*.md parses; id unique; status within enum
+#   2 impact       a changed source path's mapped docs changed too, or the PR is labelled
+#   3 glossary     no forbidden alias used in place of a canonical term
+#   4 links        every relative link resolves; no tracked doc links into _local/
+#   5 language     no Cyrillic in docs/ outside the allowlist
+#
+# Bash, awk and git only. Adding a YAML or Markdown parser would mean a runtime this
+# repository does not otherwise depend on, and I-4 makes every added dependency a cost.
+#
+# Environment:
+#   DOCS_VERIFY_BASE   base ref for the changed-file set (default: origin/main)
+#   DOCS_IMPACT_NONE   set to 1 when the PR carries the docs-impact:none label
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+MANIFEST="docs/.manifest.yaml"
+BASE="${DOCS_VERIFY_BASE:-origin/main}"
+STATUS_ENUM="draft accepted superseded deprecated"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+failures=0
+
+fail() { printf "${RED}FAIL${NC} %s\n" "$1"; failures=$((failures + 1)); }
+pass() { printf "${GREEN}ok${NC}   %s\n" "$1"; }
+warn() { printf "${YELLOW}warn${NC} %s\n" "$1"; }
+
+[ -f "$MANIFEST" ] || { fail "missing $MANIFEST"; exit 1; }
+
+# Values of a simple YAML list under a top-level key, e.g. frontmatter_exempt.
+manifest_list() {
+  awk -v key="$1" '
+    $0 ~ "^" key ":" { inlist = 1; next }
+    inlist && /^[[:space:]]*-[[:space:]]/ { sub(/^[[:space:]]*-[[:space:]]*/, ""); print; next }
+    inlist && /^[^[:space:]#]/ { inlist = 0 }
+  ' "$MANIFEST"
+}
+
+docs_files() {
+  local exempt f keep
+  exempt="$(manifest_list frontmatter_exempt)"
+  while IFS= read -r f; do
+    keep=1
+    while IFS= read -r e; do
+      [ -n "$e" ] && case "$f" in "$e"*) keep=0 ;; esac
+    done <<< "$exempt"
+    [ "$keep" = 1 ] && printf '%s\n' "$f"
+  done < <(git ls-files 'docs/*.md' 'docs/**/*.md')
+}
+
+# ---------------------------------------------------------------- 1. frontmatter
+check_frontmatter() {
+  local f ids dupes bad=0
+  ids=""
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    if [ "$(head -1 "$f")" != "---" ]; then
+      fail "frontmatter: $f does not start with ---"; bad=1; continue
+    fi
+    local id status
+    id="$(awk 'NR>1 && /^---$/{exit} /^id:/{sub(/^id:[[:space:]]*/,""); print; exit}' "$f")"
+    status="$(awk 'NR>1 && /^---$/{exit} /^status:/{sub(/^status:[[:space:]]*/,""); print; exit}' "$f")"
+    [ -n "$id" ] || { fail "frontmatter: $f has no id"; bad=1; }
+    if [ -z "$status" ]; then
+      fail "frontmatter: $f has no status"; bad=1
+    elif ! printf '%s' " $STATUS_ENUM " | grep -q " $status "; then
+      fail "frontmatter: $f status '$status' is outside {$STATUS_ENUM}"; bad=1
+    fi
+    [ -n "$id" ] && ids="$ids$id"$'\n'
+  done < <(docs_files)
+
+  dupes="$(printf '%s' "$ids" | grep -v '^$' | sort | uniq -d)"
+  if [ -n "$dupes" ]; then
+    fail "frontmatter: duplicate id(s): $(printf '%s' "$dupes" | tr '\n' ' ')"; bad=1
+  fi
+  [ "$bad" = 0 ] && pass "frontmatter: $(docs_files | wc -l | tr -d ' ') documents, ids unique, status within enum"
+}
+
+# ---------------------------------------------------------------- 2. impact
+check_impact() {
+  local changed src reqs hit bad=0 checked=0
+  if ! git rev-parse --verify --quiet "$BASE" > /dev/null; then
+    warn "impact: base ref '$BASE' not found - skipped"; return
+  fi
+  changed="$(git diff --name-only "$BASE"...HEAD 2>/dev/null)"
+  [ -n "$changed" ] || { pass "impact: no changes against $BASE"; return; }
+
+  # Each mapping is "- source: X" followed by "requires: [a, b]".
+  while IFS='|' read -r src reqs; do
+    [ -n "$src" ] || continue
+    printf '%s\n' "$changed" | grep -q "^$src" || continue
+    checked=$((checked + 1))
+    hit=0
+    for r in ${reqs//,/ }; do
+      printf '%s\n' "$changed" | grep -qx "$r" && { hit=1; break; }
+    done
+    if [ "$hit" = 0 ]; then
+      if [ "${DOCS_IMPACT_NONE:-0}" = "1" ]; then
+        warn "impact: '$src' changed with no mapped doc - allowed by docs-impact:none"
+      else
+        fail "impact: '$src' changed but none of its documents did: ${reqs//,/ }"
+        bad=1
+      fi
+    fi
+  done < <(awk '
+    /^[[:space:]]*-[[:space:]]*source:/ { sub(/.*source:[[:space:]]*/, ""); src = $0; next }
+    /^[[:space:]]*requires:/ && src != "" {
+      sub(/.*requires:[[:space:]]*\[/, ""); sub(/\][[:space:]]*$/, "");
+      gsub(/[[:space:]]/, ""); print src "|" $0; src = ""
+    }
+  ' "$MANIFEST")
+
+  [ "$bad" = 0 ] && pass "impact: $checked mapped source path(s) changed, all documented"
+}
+
+# ---------------------------------------------------------------- 3. glossary
+check_glossary() {
+  local g="docs/GLOSSARY.md" bad=0 term aliases a hits
+  [ -f "$g" ] || { warn "glossary: $g not found - skipped"; return; }
+
+  while IFS='|' read -r term aliases; do
+    [ -n "$aliases" ] || continue
+    for a in ${aliases//,/ }; do
+      [ -n "$a" ] || continue
+      # A forbidden alias only counts as a capitalised standalone word in prose:
+      # lowercase use ("my account") is English, and CamelCase use (ClearChat) is a symbol.
+      hits="$(grep -rnE "(^|[^A-Za-z\`_])${a}([^A-Za-z\`_]|$)" --include='*.md' docs \
+                | grep -v '^docs/security/' | grep -v "^$g:" | grep -v '`' || true)"
+      if [ -n "$hits" ]; then
+        fail "glossary: forbidden alias '$a' (use '$term') at: $(printf '%s' "$hits" | head -2 | cut -d: -f1,2 | tr '\n' ' ')"
+        bad=1
+      fi
+    done
+  done < <(awk -F'|' '
+    /^\|[[:space:]]*\*\*/ {
+      t = $2; gsub(/[[:space:]]|\*/, "", t);
+      al = $(NF-1); gsub(/^[[:space:]]+|[[:space:]]+$/, "", al);
+      if (al == "" || al == "—" || al ~ /^-+$/) next;
+      print t "|" al;
+    }
+  ' "$g")
+
+  [ "$bad" = 0 ] && pass "glossary: no forbidden alias used in place of a canonical term"
+}
+
+# ---------------------------------------------------------------- 4. links
+check_links() {
+  local f link target bad=0 count=0
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    local dir; dir="$(dirname "$f")"
+    while IFS= read -r link; do
+      [ -n "$link" ] || continue
+      case "$link" in http*|mailto:*|'#'*) continue ;; esac
+      target="${link%%#*}"
+      [ -n "$target" ] || continue
+      count=$((count + 1))
+      if [ ! -e "$dir/$target" ]; then
+        fail "links: $f -> $target does not resolve"; bad=1
+      fi
+    done < <(grep -oE '\]\([^)]+\)' "$f" | sed 's/^](//; s/)$//')
+  done < <(git ls-files '*.md')
+
+  local locals
+  locals="$(git grep -lI '](\(\./\)\?/\?_local/' -- '*.md' 2>/dev/null || true)"
+  if [ -n "$locals" ]; then
+    fail "links: tracked document(s) link into gitignored _local/: $(printf '%s' "$locals" | tr '\n' ' ')"
+    bad=1
+  fi
+  [ "$bad" = 0 ] && pass "links: $count relative link(s) resolve, none into _local/"
+}
+
+# ---------------------------------------------------------------- 5. language
+check_language() {
+  local allow hits bad=0
+  # git must be built with PCRE for \x{...}. Without it the grep would error and the
+  # check would silently pass - a fail-open on a policy check is worse than a loud skip.
+  if ! echo "x" | git grep -qP 'x' -- 2> /dev/null; then
+    if ! printf 'x' | grep -qP 'x' 2> /dev/null; then
+      warn "language: git grep has no PCRE support - check skipped"; return
+    fi
+  fi
+  allow="$(manifest_list language_allowlist)"
+  hits="$(git grep -lIP '[\x{0400}-\x{04FF}]' -- 'docs/*.md' 'docs/**/*.md' '*.md' 2>/dev/null || true)"
+  while IFS= read -r a; do
+    [ -n "$a" ] && hits="$(printf '%s\n' "$hits" | grep -vFx "$a" || true)"
+  done <<< "$allow"
+  hits="$(printf '%s\n' "$hits" | grep -v '^$' || true)"
+  if [ -n "$hits" ]; then
+    fail "language: Cyrillic outside the allowlist: $(printf '%s' "$hits" | tr '\n' ' ')"
+    bad=1
+  fi
+  [ "$bad" = 0 ] && pass "language: no Cyrillic in tracked Markdown outside the allowlist"
+}
+
+echo "docs-verify (base: $BASE)"
+check_frontmatter
+check_impact
+check_glossary
+check_links
+check_language
+
+if [ "$failures" -gt 0 ]; then
+  printf "\n${RED}%d check(s) failed${NC}\n" "$failures"
+  exit 1
+fi
+printf "\n${GREEN}all checks passed${NC}\n"


### PR DESCRIPTION
Closes #26

The mechanism that turns documentation drift from a review nit into a **build failure**.

Five checks — frontmatter, impact, glossary, links, language — in **bash, awk and git
only**. Adding a YAML or Markdown parser would mean a runtime this repository does not
otherwise depend on, and I-4 makes every added dependency a cost.

## Check 2 is the one that matters
The others catch mistakes; check 2 catches **neglect**. Tested three ways before commit:

| Scenario | Result |
|---|---|
| `observability.rs` changed alone | **FAIL**, naming both mapped documents |
| Same change with `DOCS_IMPACT_NONE=1` | warns instead of failing |
| `observability.rs` **and** `OBSERVABILITY.md` changed | pass |

## Two corrections made while building it
**The glossary aliases were far too broad.** The first pass forbade ordinary English —
`State`, `Session`, `Progress`, `Ephemeral` — and real product names used legitimately in
ADR *Alternatives rejected* sections, so `Kafka` and `Cassandra` were flagged **inside the
very paragraphs explaining why they were rejected**. Eight false positives on our own
documents. Now narrowed to genuinely confusable domain synonyms: a check that cries wolf
gets switched off.

**The language check now refuses to run rather than silently pass** when git lacks PCRE
support. A fail-open on a policy check is worse than a loud skip.

## Deliberate exemption
`docs/security/` is exempt from the frontmatter contract, declared in the manifest **with
its reason**: it predates this base, is externally cited, and is retained unchanged rather
than retrofitted.

`RUNBOOK.md` gains a *Documentation checks* section because the manifest maps
`infra/scripts/` and `Justfile` to it — this step has to satisfy its own check 2, and does.

## ⚠️ docs-verify does not pass on `main` yet
Check 4 reports **25 broken relative links across 10 files**, most pointing at
documentation PR-01 deleted. That is **#74**, deliberately split out: this step ships the
checker, #74 fixes what it finds.

**#74 must land before PR-16** wires this into CI, or the job is red the moment it arrives.
The repairs are already written and verified green on an integration branch.

## Out of scope
The CI workflow (PR-16). Regenerating `INDEX.md` / `STATE.md` / `tokens:` — the staleness
check is described in `40-doc-sync.md` but the generator is not part of this step.

## Budget
315 added lines across 5 files — within the ≤400 / ≤8 contract.