### PR TITLE
PR-16 · Add .github/workflows/docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: docs
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+      - 'infra/scripts/docs-verify.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-verify:
+    name: docs-verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Check 2 diffs the branch against its base, so the history must be present.
+          fetch-depth: 0
+
+      - name: Resolve base ref
+        id: base
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run docs-verify
+        env:
+          DOCS_VERIFY_BASE: ${{ steps.base.outputs.ref }}
+          # Check 2 is waived only when the PR carries docs-impact:none, which the
+          # contributor must justify in the PR body.
+          DOCS_IMPACT_NONE: ${{ contains(github.event.pull_request.labels.*.name, 'docs-impact:none') && '1' || '0' }}
+        run: bash infra/scripts/docs-verify.sh


### PR DESCRIPTION
Closes #27

Wires `just docs-verify` into CI on every pull request — the step that turns the checker
from something a contributor *may* run into something the build enforces.

## Ordering mattered
PR-15 shipped the checker and it **failed on `main`**: 26 broken relative links, most
pointing at documentation PR-01 deleted. Landing this workflow then would have made the job
red on arrival, which is the surest way to train people to ignore a check.

PR-15b repaired the links first. `docs-verify` is green on `main` as of `ff62008b`, and only
now does enforcing it mean anything.

## Two details worth stating
**`fetch-depth: 0` is required, not cautious.** Check 2 diffs the branch against its base, so
the base ref must be in the history. A shallow clone would silently produce an empty
changed-file set and the impact check would pass by *knowing nothing* — the worst kind of
green.

**`DOCS_IMPACT_NONE` is derived from the PR's labels**, so the only way to waive check 2 is
to label the PR `docs-impact:none` — and the contract is that the reason goes in the PR
body. The waiver is deliberately visible, not a flag someone can pass quietly.

The `push` trigger is path-filtered to `docs/**`, the workflow and the script. The
`pull_request` trigger is **not** filtered, because check 2 exists precisely to catch a
source change that forgot its documentation.

## Out of scope
Making `docs-verify` a *required* status check on the `main` ruleset — that is a repository
setting, not a file, and belongs with the P-2 hardening decision. The job runs and blocks
nothing until you add it.

## Budget
43 added lines in 1 file — within the ≤400 / ≤8 contract.