### PR TITLE
Seed the Double Ratchet responder with Bob's signed pre-key

### DIFF
--- a/backend/crates/crypto/src/double_ratchet.rs
+++ b/backend/crates/crypto/src/double_ratchet.rs
@@ -282,8 +282,13 @@ impl DoubleRatchet {
     }
 
     /// Initialize Double Ratchet as receiver (Bob)
-    pub fn init_bob(shared_secret: &[u8]) -> Result<Self> {
-        let dh_self = StaticSecret::random_from_rng(OsRng);
+    ///
+    /// `dh_key_pair` must be the X25519 secret whose public half the initiator ran X3DH
+    /// against - in practice Bob's signed pre-key. The Double Ratchet specification makes
+    /// Bob's signed pre-key his initial ratchet key; generating a fresh key here instead
+    /// would leave both sides with different DH outputs, so no message would ever decrypt.
+    pub fn init_bob(shared_secret: &[u8], dh_key_pair: StaticSecret) -> Result<Self> {
+        let dh_self = dh_key_pair;
 
         let mut root_key_bytes = [0u8; 32];
         if shared_secret.len() != 32 {
@@ -752,7 +757,7 @@ mod tests {
             DoubleRatchet::init_alice(&shared_secret, bob_public).expect("Alice init failed");
 
         // Bob initializes
-        let mut bob = DoubleRatchet::init_bob(&shared_secret).expect("Bob init failed");
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_dh).expect("Bob init failed");
 
         // Alice sends first message
         let plaintext1 = b"Hello from Alice!";
@@ -784,7 +789,7 @@ mod tests {
         let bob_public = X25519PublicKey::from(&bob_dh);
 
         let mut alice = DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
-        let mut bob = DoubleRatchet::init_bob(&shared_secret).unwrap();
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
 
         // Send multiple messages in sequence
         for i in 0..5 {
@@ -802,7 +807,7 @@ mod tests {
         let bob_public = X25519PublicKey::from(&bob_dh);
 
         let mut alice = DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
-        let mut bob = DoubleRatchet::init_bob(&shared_secret).unwrap();
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
 
         // Alice sends 3 messages
         let msg1 = alice.encrypt(b"First", b"1").unwrap();
@@ -830,7 +835,7 @@ mod tests {
         let bob_public = X25519PublicKey::from(&bob_dh);
 
         let mut alice = DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
-        let mut bob = DoubleRatchet::init_bob(&shared_secret).unwrap();
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
 
         // Send messages back and forth to trigger DH ratchet
         for i in 0..10 {
@@ -853,7 +858,7 @@ mod tests {
         let bob_public = X25519PublicKey::from(&bob_dh);
 
         let mut alice = DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
-        let mut bob = DoubleRatchet::init_bob(&shared_secret).unwrap();
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
 
         // Exchange some messages to build state
         let msg1 = alice.encrypt(b"Test message 1", b"ad1").unwrap();

--- a/backend/crates/crypto/src/lib.rs
+++ b/backend/crates/crypto/src/lib.rs
@@ -41,6 +41,10 @@ pub use x3dh::{
     X3DHPrekeyMessage, X3DHProtocol,
 };
 
+// `DoubleRatchet::init_alice` and `init_bob` take these in their signatures, so callers must
+// be able to name them without depending on x25519-dalek directly.
+pub use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/backend/crates/crypto/src/x3dh.rs
+++ b/backend/crates/crypto/src/x3dh.rs
@@ -155,6 +155,16 @@ impl SignedPreKey {
         let shared = self.secret.diffie_hellman(other_public);
         shared.as_bytes().to_vec()
     }
+
+    /// The X25519 secret backing this pre-key, for use as the initial Double Ratchet key.
+    ///
+    /// The responder's signed pre-key is his initial ratchet key: it is the public half the
+    /// initiator ran X3DH against, so both sides must derive the first root key from it.
+    /// This is the only reason to take the secret out of the struct - do not use it to
+    /// re-implement `dh`, and never log or serialize the returned value.
+    pub fn ratchet_secret(&self) -> StaticSecret {
+        self.secret.clone()
+    }
 }
 
 /// One-time pre-key (X25519)

--- a/backend/crates/messaging-service/src/crypto.rs
+++ b/backend/crates/messaging-service/src/crypto.rs
@@ -287,9 +287,14 @@ impl CryptoManager {
             shared_secret.len()
         );
 
-        // Initialize Double Ratchet as Bob (receiver of first message)
-        let ratchet = DoubleRatchet::init_bob(&shared_secret)
-            .context("Failed to initialize Double Ratchet as receiver")?;
+        // Initialize Double Ratchet as Bob (receiver of first message).
+        // The initiator ran X3DH against our published signed pre-key, so that same key must
+        // seed our ratchet - see guardyn_crypto::x3dh::SignedPreKey::ratchet_secret.
+        let ratchet = DoubleRatchet::init_bob(
+            &shared_secret,
+            local_key_material.signed_pre_key.ratchet_secret(),
+        )
+        .context("Failed to initialize Double Ratchet as receiver")?;
 
         tracing::info!(
             "E2EE session established: {} -> {} (receiver)",

--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -481,15 +481,17 @@ pub async fn respond_x3dh(
 
 /// Initialize a Double Ratchet session with a peer
 ///
-/// Both initiator and responder start with init_bob - the DH ratchet step
-/// is performed automatically when the first message is exchanged.
-/// The initiator should send their public key with the first message header.
+/// The initiator (Alice) ratchets against the peer's signed pre-key, so `peer_public_key`
+/// is required and must be that key. The responder (Bob) must seed his ratchet with his own
+/// signed pre-key secret - the one whose public half the initiator used - which this command
+/// cannot reach, so the responder path is refused rather than silently producing a session
+/// that can never decrypt.
 #[tauri::command]
 pub async fn init_session(
     peer_id: String,
     shared_secret: String,
     is_initiator: bool,
-    _peer_public_key: Option<String>,
+    peer_public_key: Option<String>,
 ) -> Result<SessionInfo, String> {
     tracing::info!("Initializing Double Ratchet session with peer: {} (initiator: {})", peer_id, is_initiator);
 
@@ -500,9 +502,29 @@ pub async fn init_session(
         return Err("Shared secret must be 32 bytes".to_string());
     }
 
-    // Initialize Double Ratchet
-    // Both roles start with init_bob - the DH ratchet is performed on first message
-    let ratchet = guardyn_crypto::DoubleRatchet::init_bob(&secret_bytes)
+    // Initialize Double Ratchet.
+    // Alice derives her first root key from DH(her fresh key, Bob's signed pre-key); Bob must
+    // use the matching secret. Using init_bob for both roles leaves the two sides with
+    // different DH outputs, so nothing decrypts.
+    if !is_initiator {
+        return Err(
+            "Responder sessions are not supported by this command: Bob's ratchet must be \
+             seeded with his signed pre-key secret from key storage"
+                .to_string(),
+        );
+    }
+
+    let peer_public_key = peer_public_key.ok_or_else(|| {
+        "peer_public_key is required to initialize an initiator session".to_string()
+    })?;
+    let peer_public_bytes =
+        hex::decode(&peer_public_key).map_err(|e| format!("Invalid peer public key: {}", e))?;
+    let peer_public_bytes: [u8; 32] = peer_public_bytes
+        .try_into()
+        .map_err(|_| "Peer public key must be 32 bytes".to_string())?;
+    let peer_public = guardyn_crypto::X25519PublicKey::from(peer_public_bytes);
+
+    let ratchet = guardyn_crypto::DoubleRatchet::init_alice(&secret_bytes, peer_public)
         .map_err(|e| format!("Failed to init Double Ratchet: {}", e))?;
 
     // Serialize ratchet state for persistence
@@ -969,9 +991,10 @@ mod tests {
         // Test basic Double Ratchet encrypt/decrypt cycle
         let shared_secret = [42u8; 32];
 
-        // Bob initializes first
-        let mut bob = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret).unwrap();
-        let bob_public = bob.public_key();
+        // Bob's signed pre-key doubles as his initial ratchet key
+        let bob_dh = guardyn_crypto::StaticSecret::from([7u8; 32]);
+        let bob_public = guardyn_crypto::X25519PublicKey::from(&bob_dh);
+        let mut bob = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
 
         // Alice initializes with Bob's public key
         let mut alice = guardyn_crypto::DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
@@ -993,9 +1016,10 @@ mod tests {
         // Test bidirectional message exchange
         let shared_secret = [99u8; 32];
 
-        // Bob initializes first
-        let mut bob = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret).unwrap();
-        let bob_public = bob.public_key();
+        // Bob's signed pre-key doubles as his initial ratchet key
+        let bob_dh = guardyn_crypto::StaticSecret::from([7u8; 32]);
+        let bob_public = guardyn_crypto::X25519PublicKey::from(&bob_dh);
+        let mut bob = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
 
         // Alice initializes with Bob's public key
         let mut alice = guardyn_crypto::DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
@@ -1022,8 +1046,9 @@ mod tests {
         let shared_secret = [123u8; 32];
 
         // Create ratchet as Bob first, then as Alice
-        let bob = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret).unwrap();
-        let bob_public = bob.public_key();
+        let bob_dh = guardyn_crypto::StaticSecret::from([7u8; 32]);
+        let bob_public = guardyn_crypto::X25519PublicKey::from(&bob_dh);
+        let _bob = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
         let alice = guardyn_crypto::DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
 
         // Serialize Alice's ratchet

--- a/client-desktop/src/api/crypto.ts
+++ b/client-desktop/src/api/crypto.ts
@@ -210,7 +210,8 @@ export async function performX3DH(
 export async function initSession(
   peerId: string,
   sharedSecret: string,
-  isInitiator: boolean
+  isInitiator: boolean,
+  peerPublicKey: string
 ): Promise<SessionInfo> {
   const result = await invoke<{
     peer_id: string;
@@ -218,7 +219,7 @@ export async function initSession(
     messages_sent: number;
     messages_received: number;
     is_active: boolean;
-  }>('init_session', { peerId, sharedSecret, isInitiator });
+  }>('init_session', { peerId, sharedSecret, isInitiator, peerPublicKey });
   return {
     peerId: result.peer_id,
     establishedAt: result.established_at,
@@ -378,8 +379,14 @@ export class EncryptionService {
     // Perform X3DH key agreement
     const x3dhResult = await performX3DH(peerBundle, peerId);
 
-    // Initialize Double Ratchet session
-    const session = await initSession(peerId, x3dhResult.sharedSecret, true);
+    // Initialize Double Ratchet session. The initiator ratchets against the peer's signed
+    // pre-key - the same key X3DH just ran against - so it has to be passed through.
+    const session = await initSession(
+      peerId,
+      x3dhResult.sharedSecret,
+      true,
+      peerBundle.signedPrekey
+    );
 
     return session;
   }

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -67,6 +67,11 @@ A replayed prekey message fails because the one-time key is already consumed.
 
 ## Message encryption (Double Ratchet)
 
+0. **Both sides seed the ratchet from the responder's signed pre-key.** The initiator
+   ratchets against the signed pre-key it just ran X3DH against; the responder must supply
+   the matching secret rather than generating a fresh key. This is not an implementation
+   detail - if the responder invents its own key the two sides derive different root and
+   chain keys, and every AEAD tag check fails while both sides appear healthy.
 1. Plaintext is padded with PADMÉ before encryption, so ciphertext length leaks at most
    about 10% of the plaintext length.
 2. A message key is derived per message and discarded after use: compromise of one key must
@@ -80,6 +85,11 @@ A replayed prekey message fails because the one-time key is already consumed.
 **Edge cases.** A padded length below `MIN_PADDED_LENGTH` (32) is invalid. Plaintext above
 `MAX_MESSAGE_LENGTH` (16 MiB) is rejected before encryption. A header claiming a counter
 more than `MAX_SKIP` ahead is rejected, not accommodated.
+
+**Known gaps.** The ratchet header is not covered by the AEAD associated data, so an attacker
+may rewrite the sender's public key and counters without invalidating the tag (#105) - the
+specification requires it to be bound. Skipped-key derivation also advances the receiving
+chain before the tag is verified, so a forged header can poison a session (#106).
 
 ## Groups (MLS)
 


### PR DESCRIPTION
## What

`DoubleRatchet::init_bob` generated a **fresh random** `dh_self` instead of taking Bob's key
pair, so the two sides of every session derived different root and chain keys and no message
ever decrypted. `init_bob` now takes the responder's X25519 secret, which per the Double
Ratchet specification is his signed pre-key - the key whose public half the initiator ran X3DH
against.

This was reaching production, not just tests:

- `messaging-service/src/crypto.rs` `init_receiver_session` already received
  `local_key_material` holding Bob's signed pre-key and discarded it. A real responder session
  could never decrypt the initiator's first message.
- `client-desktop` called `init_bob` for **both** roles, guided by a comment claiming that was
  correct. The front end only ever calls it as the initiator, so that path is now `init_alice`
  with the peer's signed pre-key threaded through from `startSession`.

Supporting changes:

- `SignedPreKey::ratchet_secret()` - the responder needs its own pre-key secret to seed the
  ratchet, and the field was private. Documented as the only legitimate reason to take it out.
- `guardyn_crypto` re-exports `X25519PublicKey` and `StaticSecret`, since they now appear in a
  public signature and callers should not have to depend on `x25519-dalek` directly.

## Tests

The five failing round-trip tests were **correct as written** - they generate `bob_dh`, hand
`bob_public` to Alice and expect Bob to use the matching secret. They are unmodified apart from
passing that secret, and they are the regression tests for this fix:

```
test_double_ratchet_basic_exchange       ok
test_double_ratchet_key_rotation         ok
test_double_ratchet_multiple_messages    ok
test_double_ratchet_out_of_order         ok
test_double_ratchet_serialization        ok
```

`guardyn-crypto` goes from 16 failures to 10 (issue #87); the remaining 10 are the MLS and
PQXDH defects, which have their own issues.

## Behaviour change

`init_session` on the desktop now **refuses** responder sessions rather than returning a
session that can never decrypt, and requires `peer_public_key` for initiator sessions. The
front end only calls the initiator path, so no user-visible flow changes; the refusal replaces
a silent failure with a loud one.

## Deliberately out of scope

- The MLS failures from #87 - owned by #42 (PR-31).
- The PQXDH failure from #87 - #103.
- The unauthenticated message header (#105) and the pre-authentication ratchet state mutation
  (#106), both found in the same read. #105 is a non-additive wire-format change and needs its
  own step and sign-off.
- Giving the desktop a real responder path, which needs the signed pre-key secret out of key
  storage. That is `KeyStorage` work, owned by #41 (PR-30).
- Reformatting `client-desktop/src-tauri` - it is already unformatted on `main` and no CI step
  enforces `cargo fmt` there. Only the lines this PR adds are rustfmt-clean.

Closes #102
