### PR TITLE
Convert Ed25519 identity keys before PQXDH Diffie-Hellman

### DIFF
--- a/backend/crates/crypto/src/pqxdh.rs
+++ b/backend/crates/crypto/src/pqxdh.rs
@@ -10,6 +10,7 @@
 //! Reference: https://signal.org/docs/specifications/pqxdh/
 #![allow(unused_assignments)]
 
+use crate::x3dh::{ed25519_public_to_x25519, ed25519_secret_to_x25519};
 use crate::{CryptoError, Result};
 use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
 use hkdf::Hkdf;
@@ -285,11 +286,13 @@ pub fn derive_sender_shared_secret(
     sender_ephemeral_secret: &[u8; 32],
     recipient_bundle: &HybridKeyBundle,
 ) -> Result<(HybridSharedSecret, Vec<u8>)> {
-    // Classical X25519 DH operations (X3DH)
-    let sender_identity_secret = X25519Secret::from(*sender_identity_key);
+    // Classical X25519 DH operations (X3DH).
+    // Identity keys are Ed25519 on both sides and must be mapped onto Curve25519 before any
+    // Diffie-Hellman; the signed and one-time prekeys are already X25519.
+    let sender_identity_secret = ed25519_secret_to_x25519(sender_identity_key);
     let sender_ephemeral = X25519Secret::from(*sender_ephemeral_secret);
 
-    let recipient_identity = X25519PublicKey::from(recipient_bundle.identity_key);
+    let recipient_identity = ed25519_public_to_x25519(&recipient_bundle.identity_key)?;
     let recipient_spk = X25519PublicKey::from(recipient_bundle.signed_prekey);
 
     // DH1 = DH(IK_A, SPK_B)
@@ -370,10 +373,12 @@ pub fn derive_recipient_shared_secret(
     sender_ephemeral_key: &[u8; 32],
     #[allow(unused_variables)] pq_ciphertext: Option<&[u8]>,
 ) -> Result<HybridSharedSecret> {
-    let recipient_identity = X25519Secret::from(recipient_private_keys.identity_key);
+    // Mirror of the sender: the Ed25519 identity keys on both sides are mapped onto
+    // Curve25519 before any Diffie-Hellman.
+    let recipient_identity = ed25519_secret_to_x25519(&recipient_private_keys.identity_key);
     let recipient_spk = X25519Secret::from(recipient_private_keys.signed_prekey);
 
-    let sender_identity = X25519PublicKey::from(*sender_identity_key);
+    let sender_identity = ed25519_public_to_x25519(sender_identity_key)?;
     let sender_ephemeral = X25519PublicKey::from(*sender_ephemeral_key);
 
     // DH1 = DH(SPK_B, IK_A)

--- a/backend/crates/crypto/src/x3dh.rs
+++ b/backend/crates/crypto/src/x3dh.rs
@@ -104,11 +104,7 @@ impl IdentityKeyPair {
     /// Note: We use clamp_integer() which applies ONLY clamping without mod l reduction.
     /// This matches TweetNaCl exactly, unlike to_scalar() which also reduces mod l.
     pub fn to_x25519_secret(&self) -> StaticSecret {
-        // Get raw SHA512(seed)[0:32] bytes
-        let raw_scalar_bytes = self.secret.to_scalar_bytes();
-        // Apply clamping (matches TweetNaCl's crypto_sign_ed25519_sk_to_x25519_sk)
-        let clamped_bytes = clamp_integer(raw_scalar_bytes);
-        StaticSecret::from(clamped_bytes)
+        signing_key_to_x25519_secret(&self.secret)
     }
 }
 
@@ -470,11 +466,33 @@ impl X3DHProtocol {
     }
 }
 
-/// Helper: Convert Ed25519 public key bytes to X25519 public key
+/// Convert an Ed25519 signing key to the matching X25519 secret.
+///
+/// The conversion process (matching TweetNaCl's `crypto_sign_ed25519_sk_to_x25519_sk`):
+/// 1. Compute `SHA512(seed)[0:32]` via `to_scalar_bytes()`
+/// 2. Apply X25519 clamping via `clamp_integer`, which does not reduce mod l - unlike
+///    `to_scalar()`, which does, and would not match TweetNaCl
+pub(crate) fn signing_key_to_x25519_secret(signing_key: &SigningKey) -> StaticSecret {
+    let raw_scalar_bytes = signing_key.to_scalar_bytes();
+    let clamped_bytes = clamp_integer(raw_scalar_bytes);
+    StaticSecret::from(clamped_bytes)
+}
+
+/// Convert Ed25519 signing key bytes (the 32-byte seed) to the matching X25519 secret.
+///
+/// Shared with `pqxdh`, whose bundles store the identity key as an Ed25519 seed.
+pub(crate) fn ed25519_secret_to_x25519(seed: &[u8; 32]) -> StaticSecret {
+    signing_key_to_x25519_secret(&SigningKey::from_bytes(seed))
+}
+
+/// Convert Ed25519 public key bytes to an X25519 public key.
 ///
 /// Uses birational equivalence mapping between twisted Edwards curve (Ed25519)
 /// and Montgomery curve (X25519). This is the standard approach used by Signal Protocol.
-fn ed25519_public_to_x25519(ed25519_bytes: &[u8]) -> Result<X25519PublicKey> {
+///
+/// Shared with `pqxdh`, which performs the same four Diffie-Hellman operations over the same
+/// Ed25519 identity keys and must convert them identically.
+pub(crate) fn ed25519_public_to_x25519(ed25519_bytes: &[u8]) -> Result<X25519PublicKey> {
     if ed25519_bytes.len() != 32 {
         return Err(CryptoError::InvalidKey(
             "Ed25519 public key must be 32 bytes".into(),

--- a/docs/adr/ADR-0005-hybrid-pqxdh.md
+++ b/docs/adr/ADR-0005-hybrid-pqxdh.md
@@ -37,10 +37,22 @@ ciphertext, 32-byte shared secret.
 A break of either primitive alone leaves the session secure. Key bundles get materially
 larger, and every wire structure carrying key material must have room for an ML-KEM key.
 
-**The gap.** `crates/crypto/src/pqxdh.rs` is a complete implementation, but the `pq`
-feature is off by default, no backend service enables it, and — decisively —
-`backend/proto/` contains **zero** ML-KEM fields, so a server cannot publish a PQ public
-key at all. The implementation is unreached, not absent.
+**Identity keys are Ed25519 and must be converted before any Diffie-Hellman.** The bundle
+stores an Ed25519 identity key because it also signs the pre-keys; the classical half of the
+agreement needs the Curve25519 form. The public side maps through `to_montgomery()`, the
+secret side through SHA-512 then X25519 clamping. PQXDH shares one implementation of both
+with X3DH (`x3dh.rs`) rather than carrying its own — an Ed25519 verifying key is not the
+X25519 public point of the same seed, and treating it as one produces two sides that silently
+derive different secrets.
+
+**The gap.** The `pq` feature is off by default, no backend service enables it, and —
+decisively — `backend/proto/` contains **zero** ML-KEM fields, so a server cannot publish a
+PQ public key at all. The implementation is unreached, not absent.
+
+This ADR previously described `pqxdh.rs` as a complete implementation. That was measured
+against the code compiling, not against it agreeing: the identity-key conversion above was
+missing on both sides, so `test_classical_key_exchange` and `test_hybrid_key_exchange` had
+never passed. Being unreachable end to end is what kept that invisible.
 
 Repair is owned by PR-36 (proto fields) through PR-40 (fuzz, proptest, bench). Until then,
 **do not describe the product as post-quantum protected.**


### PR DESCRIPTION
## What

`pqxdh` treated Ed25519 identity keys as X25519 keys, symmetrically wrong on both sides:

```rust
// sender
let sender_identity_secret = X25519Secret::from(*sender_identity_key);          // Ed25519 seed
let recipient_identity = X25519PublicKey::from(recipient_bundle.identity_key);  // Ed25519 pubkey
// recipient
let recipient_identity = X25519Secret::from(recipient_private_keys.identity_key);
let sender_identity   = X25519PublicKey::from(*sender_identity_key);
```

The bundle genuinely stores Ed25519 keys. An Ed25519 verifying key is not the X25519 public
point of the same seed - the mapping needs the birational map, and the secret needs
SHA-512 then clamping. So DH1 and DH2 could never agree and the two sides always derived
different shared secrets.

The rest of the protocol was already sound: the four DH operations are structurally symmetric
and the HKDF combination is identical on both sides. Only the key types were wrong.

## Reusing x3dh rather than duplicating it

`x3dh` performs the same four DH operations over the same Ed25519 identity keys and already
converts them correctly. Rather than write a second implementation:

- `ed25519_public_to_x25519` becomes `pub(crate)`.
- The secret-side conversion is lifted out of `IdentityKeyPair::to_x25519_secret` into
  `signing_key_to_x25519_secret` / `ed25519_secret_to_x25519`, and the method now routes
  through it.

That last part matters: the TweetNaCl-compatibility suite in `x3dh_conversion_tests.rs`
exercises `to_x25519_secret`, so it now covers the function `pqxdh` uses. One implementation,
one set of test vectors, no chance of the two drifting.

## Tests

```
test pqxdh::tests::test_classical_key_exchange ... ok
test pqxdh::tests::test_hybrid_key_exchange ... ok   # --features pq
```

`guardyn-crypto` goes from 15 failures to 14 on this branch. The remaining 14 are the Double
Ratchet defect (#102, PR #109) and the nine MLS failures (#42). `guardyn-crypto-ffi` still
builds with `--all-features`.

## Deliberately out of scope

- Enabling the `pq` feature by default (PR-38, #49) and adding ML-KEM fields to
  `backend/proto` (PR-36, #47). **Invariant I-3 is unchanged by this PR** - it repairs code
  that remains unreachable end to end, exactly as `AGENTS.md` §1 records.
- The MLS failures from #87, owned by #42.
- Property-based coverage of X3DH and PQXDH agreement symmetry, which is PR-34 (#45). A
  proptest asserting sender and recipient always agree would have caught this class of bug
  and is worth having.

Closes #103
