### PR TITLE
Scope an allow for result_large_err in the rate limit interceptor

### DIFF
--- a/backend/crates/common/src/rate_limit_middleware.rs
+++ b/backend/crates/common/src/rate_limit_middleware.rs
@@ -224,6 +224,12 @@ where
 
 /// Interceptor for tonic that applies rate limiting
 /// Use this for simpler integration with tonic services
+///
+/// `clippy::result_large_err` fires because `tonic::Status` is ~176 bytes. The lint's remedy -
+/// boxing the error - is not available here: tonic's `Interceptor` trait requires exactly
+/// `Result<Request<()>, Status>`, so `Box<Status>` would no longer satisfy it. The allow is
+/// scoped to this function rather than the crate.
+#[allow(clippy::result_large_err)]
 pub fn rate_limit_interceptor(
     limiter: Arc<RateLimiter>,
 ) -> impl Fn(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> + Clone {


### PR DESCRIPTION
## What

```
error: the `Err`-variant returned from this closure is very large
   --> crates/common/src/rate_limit_middleware.rs:230:5
    | the `Err`-variant is at least 176 bytes
```

This was the **only** clippy error in the workspace - and because compilation of
`guardyn-common` stopped there, it was masking every crate downstream. Nobody could know
whether the other nine crates were clean.

## Why an allow rather than the lint's suggested fix

The lint suggests boxing: `Result<_, Box<tonic::Status>>`. That is not available here.
`rate_limit_interceptor` returns

```rust
impl Fn(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> + Clone
```

and that shape is dictated by tonic's `Interceptor` trait. A boxed error would no longer
satisfy it. The allow is scoped to the single function with the reason recorded in the doc
comment - not a crate-level allow, which would silence future genuine instances.

## Result

With this cleared, the full workspace passes:

```
$ cargo clippy --all-targets --all-features -- -D warnings
Finished `dev` profile
```

All nine service crates - auth, call, common, crypto, crypto-ffi, media, messaging,
notification, presence - now check clean, which was not previously verifiable. **The clippy
half of PR-17 (#28) is unblocked by this PR alone**, independently of the crypto work.

## Deliberately out of scope

- The `unwrap()` at `rate_limit_middleware.rs:203`, which is a genuine `RS-UNWRAP` violation
  under `.claude/rules/20-code-style.md` and belongs to PR-22 (#33).
- The raw client IP logged at `rate_limit.rs:241,256` - an I-1 breach tracked as #81.
- The test half of PR-17, which is still blocked: the crypto failures in #87 (PRs #109, #110
  and #42 in progress), the hanging `messaging-service` suite (#107), and `build.yml:64`
  excluding `e2e-tests` when the package is named `guardyn-e2e-tests`.

Closes #104
