### PR TITLE
Create MLS groups under the caller's group_id, and mark the self-decrypt tests ignored

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "sha2",
  "subtle",
  "thiserror 1.0.69",
+ "tls_codec",
  "tokio",
  "x25519-dalek",
  "zeroize",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -45,6 +45,7 @@ openmls = "0.6"  # MLS for group chat encryption (0.6 for stability)
 openmls_rust_crypto = "0.3"  # Cryptographic backend for OpenMLS (matching openmls 0.6)
 openmls_traits = "0.3"  # Traits for OpenMLS (matching openmls 0.6)
 openmls_basic_credential = "0.3"  # Basic credential support (matching openmls 0.6)
+tls_codec = "0.4"  # TLS wire codec used by the OpenMLS message types
 x25519-dalek = "2.0"
 ed25519-dalek = "2.1"
 

--- a/backend/crates/crypto/Cargo.toml
+++ b/backend/crates/crypto/Cargo.toml
@@ -30,6 +30,9 @@ openmls.workspace = true
 openmls_rust_crypto.workspace = true
 openmls_traits.workspace = true
 openmls_basic_credential.workspace = true
+# Used directly by mls.rs for Welcome/message (de)serialization. Declared explicitly rather
+# than relied on via `openmls::prelude::*`, which happens to re-export it.
+tls_codec.workspace = true
 
 # Curve25519 for key exchange
 x25519-dalek.workspace = true

--- a/backend/crates/crypto/src/mls.rs
+++ b/backend/crates/crypto/src/mls.rs
@@ -71,7 +71,6 @@ impl MlsGroupManager {
         signature_keypair: SignatureKeyPair,
     ) -> Result<Self> {
         let crypto_backend = OpenMlsRustCrypto::default();
-        let _group_id_bytes = group_id.as_bytes().to_vec();
 
         // Create credential (OpenMLS 0.7 API: credential_type first, then identity)
         let credential = Credential::new(CredentialType::Basic, creator_identity.to_vec());
@@ -88,11 +87,14 @@ impl MlsGroupManager {
             .use_ratchet_tree_extension(true)
             .build();
 
-        // Create MLS group (OpenMLS 0.7 API: provider, signer, group_config, group_id, credential)
-        let mls_group = MlsGroup::new(
+        // Create the MLS group under the caller's group_id.
+        // `MlsGroup::new` ignores any identifier and assigns a random one, so the caller's
+        // group_id has to be passed explicitly or it is silently discarded.
+        let mls_group = MlsGroup::new_with_group_id(
             &crypto_backend,
             &signature_keypair,
             &group_config,
+            GroupId::from_slice(group_id.as_bytes()),
             credential_with_key.clone(),
         )
         .map_err(|e| CryptoError::Protocol(format!("Failed to create MLS group: {:?}", e)))?;
@@ -546,6 +548,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "MLS forbids decrypting your own message: the sender's application ratchet is consumed on encrypt, so OpenMLS returns SecretTreeError(RatchetTypeError). A correct test needs a second member joined via Welcome, which needs the KeyPackage and provider plumbing fixed first - see #42 (PR-31)"]
     fn test_encrypt_decrypt_message() {
         // Create group with Alice
         let alice_keypair = create_test_keypair().unwrap();

--- a/backend/crates/crypto/src/mls_tests.rs
+++ b/backend/crates/crypto/src/mls_tests.rs
@@ -110,6 +110,7 @@ mod mls_integration_tests {
     }
 
     #[test]
+    #[ignore = "MLS forbids decrypting your own message: the sender's application ratchet is consumed on encrypt, so OpenMLS returns SecretTreeError(RatchetTypeError). A correct test needs a second member joined via Welcome, which needs the KeyPackage and provider plumbing fixed first - see #42 (PR-31)"]
     fn test_encrypt_decrypt_message() {
         // Alice creates a group
         let alice_keypair = create_test_keypair().unwrap();
@@ -155,6 +156,7 @@ mod mls_integration_tests {
     }
 
     #[test]
+    #[ignore = "MLS forbids decrypting your own message: the sender's application ratchet is consumed on encrypt, so OpenMLS returns SecretTreeError(RatchetTypeError). A correct test needs a second member joined via Welcome, which needs the KeyPackage and provider plumbing fixed first - see #42 (PR-31)"]
     fn test_encrypt_after_adding_member() {
         // Alice creates a group
         let alice_keypair = create_test_keypair().unwrap();
@@ -226,6 +228,7 @@ mod mls_integration_tests {
     }
 
     #[test]
+    #[ignore = "MLS forbids decrypting your own message: the sender's application ratchet is consumed on encrypt, so OpenMLS returns SecretTreeError(RatchetTypeError). A correct test needs a second member joined via Welcome, which needs the KeyPackage and provider plumbing fixed first - see #42 (PR-31)"]
     fn test_multiple_messages() {
         // Alice creates a group
         let alice_keypair = create_test_keypair().unwrap();
@@ -264,6 +267,7 @@ mod mls_integration_tests {
     }
 
     #[test]
+    #[ignore = "MLS forbids decrypting your own message: the sender's application ratchet is consumed on encrypt, so OpenMLS returns SecretTreeError(RatchetTypeError). A correct test needs a second member joined via Welcome, which needs the KeyPackage and provider plumbing fixed first - see #42 (PR-31)"]
     fn test_empty_message() {
         // Alice creates a group
         let alice_keypair = create_test_keypair().unwrap();
@@ -284,6 +288,7 @@ mod mls_integration_tests {
     }
 
     #[test]
+    #[ignore = "MLS forbids decrypting your own message: the sender's application ratchet is consumed on encrypt, so OpenMLS returns SecretTreeError(RatchetTypeError). A correct test needs a second member joined via Welcome, which needs the KeyPackage and provider plumbing fixed first - see #42 (PR-31)"]
     fn test_large_message() {
         // Alice creates a group
         let alice_keypair = create_test_keypair().unwrap();

--- a/docs/adr/ADR-0004-openmls-group-e2ee.md
+++ b/docs/adr/ADR-0004-openmls-group-e2ee.md
@@ -38,8 +38,25 @@ property tests and fuzz targets on every attacker-reachable parser are mandatory
 (`AGENTS.md` §8), not optional.
 
 OpenMLS 0.6 constrains the ciphersuite to `MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519`
-— there is no AES-256-GCM option. Group state serialization currently fails to round-trip
-(`SecretTreeError(RatchetTypeError)`); PR-31 owns the repair.
+— there is no AES-256-GCM option.
+
+**Groups are created under a caller-supplied `GroupId`.** `MlsGroup::new` assigns a random
+identifier and silently ignores any the caller had in mind, so creation goes through
+`new_with_group_id`. A group whose identifier the caller cannot predict cannot be looked up.
+
+**A member cannot decrypt its own message.** The sender's application ratchet is consumed on
+encrypt, so OpenMLS answers `SecretTreeError(RatchetTypeError)`. This is MLS behaving
+correctly; any test or handler that expects a self round-trip is wrong.
+
+**Group state is not serialized at all.** `serialize_state` exports a 32-byte MLS exporter
+secret rather than the group, and there is no deserialization counterpart. A two-party
+exchange is also not yet possible: `generate_key_package` drops the provider and signature
+keypair it creates, and `join_group` builds a fresh empty provider with no init keys, so no
+Welcome can be processed. PR-31 (#42) owns all of it.
+
+This ADR previously recorded the defect as "group state serialization fails to round-trip
+(`SecretTreeError(RatchetTypeError)`)". That conflated two unrelated things: the error comes
+from self-decryption, and the round-trip does not fail so much as never happen.
 
 ## Alternatives rejected
 

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -84,10 +84,17 @@ more than `MAX_SKIP` ahead is rejected, not accommodated.
 ## Groups (MLS)
 
 Group encryption is OpenMLS 0.6, not sender keys. Group state is persisted to TiKV and
-**must round-trip**: serialize, store, load, decrypt. That round-trip is currently broken —
-`ValidationError(UnableToDecrypt(SecretTreeError(RatchetTypeError)))` after
-deserialization — and is repaired by PR-31. Adding a member must not break decryption for
+**must round-trip**: serialize, store, load, decrypt. Groups are created under the
+caller-supplied `GroupId`, never a random one. Adding a member must not break decryption for
 members already in the group.
+
+A member **cannot** decrypt a message it sent itself: the sender's application ratchet is
+consumed on encrypt and OpenMLS answers `SecretTreeError(RatchetTypeError)`. That is correct
+MLS behaviour, not a defect.
+
+The round-trip above is not implemented — `serialize_state` exports a 32-byte exporter secret
+rather than the group, with no deserialization counterpart, and no two-party exchange is
+possible until the KeyPackage and provider lifetimes are fixed. PR-31 owns the repair.
 
 ## Errors
 


### PR DESCRIPTION
Carved out of #42 (PR-31) so PR-17 (#28) is not blocked by the full MLS repair.
**#42 stays open** - see "What is left" below.

## The nine MLS failures were two different problems

### Three were a real bug: `group_id` was silently discarded

`create_group` computed `_group_id_bytes` and never used it, and `MlsGroup::new` assigns a
**random** `GroupId` rather than taking one. Every group therefore came back under an identity
the caller never asked for. `MlsGroup::new_with_group_id` takes it.

Fixes `test_create_group`, `test_group_state_serialization`, `test_serialize_group_state`.

### Six were wrong tests, and cannot yet be made right

They call `encrypt_message` then `decrypt_message` on the **same** `MlsGroupManager`. MLS
forbids this by construction: the sender's application ratchet is consumed on encrypt, which
is precisely what `SecretTreeError(RatchetTypeError)` reports. Not a library bug.

They are marked `#[ignore]` with the reason inline, pointing at #42. Nothing is deleted and no
assertion is weakened - per `AGENTS.md` §8, a wrong test is called wrong rather than quietly
adjusted until it passes.

**Why not just rewrite them as two-party exchanges?** Because that is currently impossible:

- `generate_key_package` (`mls.rs:185,191`) builds a throwaway `OpenMlsRustCrypto` provider and
  a throwaway `SignatureKeyPair`, both dropped when the function returns - so nobody can ever
  join with the package it produces.
- `join_group` (`mls.rs:124`) builds a *fresh* empty provider with no init or encryption keys,
  so processing a Welcome cannot succeed.

That is why no test in the suite has ever done a real two-party MLS exchange, and it is
squarely PR-31's scope.

## Also

`tls_codec` is now an explicit dependency. `mls.rs:11` imports it directly, but it resolved
only because `openmls::prelude::*` happens to re-export it - which would break on an openmls
point release, with a confusing error.

## Result

```
test result: 67 passed; 6 failed; 6 ignored
```

The six remaining failures on this branch are the Double Ratchet (#102, PR #109) and PQXDH
(#103, PR #110) defects. **With all three merged, `guardyn-crypto` has zero failures.**

## What is left in #42, deliberately not done here

1. Provider and `SignatureKeyPair` lifetime, so `generate_key_package` produces a usable
   package and `join_group` can process a Welcome.
2. Real group state serialization. `serialize_state` (`mls.rs:422`) calls
   `export_secret(provider, "group_state", &[], 32)` and returns 32 bytes - that is an MLS
   exporter secret, not group state, and there is no deserialization counterpart at all.
3. `send_group_message_mls.rs:179,213` and `add_group_member_mls.rs:258,285`, which rebuild the
   group from scratch on membership change.
4. Rewriting the six ignored tests as genuine Alice-to-Bob exchanges once (1) lands, and
   removing the `#[ignore]`s.

Doing any of that here would have pushed this well past the §2.3 budget and pulled a Phase 3
step across two gates.

Closes #113