### PR TITLE
Address Compose dependencies by container name, not localhost

### DIFF
--- a/backend/crates/common/src/kafka.rs
+++ b/backend/crates/common/src/kafka.rs
@@ -87,10 +87,20 @@ pub struct KafkaConfig {
     pub compression: String,
 }
 
+/// The fallback broker address.
+///
+/// This is Redpanda's *external* listener, published to the host by
+/// `docker-compose.dev.yml`. It is correct only for a client running on the host - inside a
+/// container `localhost` is the container itself, and port 9092 is not published at all.
+/// Every deployment must therefore set `REDPANDA_BROKERS`; both Compose and the Kubernetes
+/// manifests now do. Reaching this constant in a containerised service means the address is
+/// missing, and the producer will degrade silently (see #39 / PR-28, which makes that loud).
+const DEFAULT_BROKERS: &str = "localhost:19092";
+
 impl Default for KafkaConfig {
     fn default() -> Self {
         Self {
-            brokers: "localhost:19092".to_string(),
+            brokers: DEFAULT_BROKERS.to_string(),
             group_id: "guardyn-default".to_string(),
             client_id: "guardyn-client".to_string(),
             sasl_enabled: false,
@@ -110,7 +120,7 @@ impl KafkaConfig {
         Self {
             brokers: std::env::var("REDPANDA_BROKERS")
                 .or_else(|_| std::env::var("KAFKA_BROKERS"))
-                .unwrap_or_else(|_| "localhost:19092".to_string()),
+                .unwrap_or_else(|_| DEFAULT_BROKERS.to_string()),
             group_id: std::env::var("KAFKA_GROUP_ID")
                 .unwrap_or_else(|_| "guardyn-default".to_string()),
             client_id: std::env::var("KAFKA_CLIENT_ID")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -207,6 +207,9 @@ services:
       GUARDYN_DATABASE__TIKV_PD_ENDPOINTS: pd:2379
       GUARDYN_DATABASE__SCYLLADB_NODES: scylladb:9042
       GUARDYN_MESSAGING__NATS_URL: nats://nats:4222
+      # Redpanda's internal listener. localhost:19092 is the external listener, reachable
+      # only from the host - inside a container it resolves to the container itself.
+      REDPANDA_BROKERS: redpanda:9092
       GUARDYN_OBSERVABILITY__OTLP_ENDPOINT: ""
       GUARDYN_OBSERVABILITY__LOG_LEVEL: debug
     ports:
@@ -232,6 +235,8 @@ services:
       GUARDYN_DATABASE__TIKV_PD_ENDPOINTS: pd:2379
       GUARDYN_DATABASE__SCYLLADB_NODES: scylladb:9042
       GUARDYN_MESSAGING__NATS_URL: nats://nats:4222
+      # Consumed by event_consumer.rs; see the note on auth-service.
+      REDPANDA_BROKERS: redpanda:9092
       GUARDYN_OBSERVABILITY__OTLP_ENDPOINT: ""
       GUARDYN_OBSERVABILITY__LOG_LEVEL: debug
       # E2EE Configuration - disabled for local development (easier debugging)
@@ -252,6 +257,8 @@ services:
       scylladb:
         condition: service_healthy
       nats:
+        condition: service_healthy
+      redpanda:
         condition: service_healthy
 
   presence-service:
@@ -359,12 +366,19 @@ services:
       GUARDYN_MESSAGING__NATS_URL: nats://nats:4222
       GUARDYN_OBSERVABILITY__OTLP_ENDPOINT: ""
       GUARDYN_OBSERVABILITY__LOG_LEVEL: debug
+      # This service does not use the GUARDYN_* config loader - main.rs reads these two
+      # directly. Without them it binds 50054 and dials the Kubernetes ScyllaDB FQDN,
+      # which is why it failed to start under Compose.
+      LISTEN_ADDR: "0.0.0.0:50055"
+      SCYLLA_HOSTS: scylladb:9042
     ports:
       - "50055:50055"
     depends_on:
       pd:
         condition: service_healthy
       nats:
+        condition: service_healthy
+      scylladb:
         condition: service_healthy
 
   # ═══════════════════════════════════════════════════════════════

--- a/docs/ops/DEPLOYMENT.md
+++ b/docs/ops/DEPLOYMENT.md
@@ -30,6 +30,27 @@ Infrastructure: `nats`, `redpanda`, `redpanda-console`, `pd`, `tikv`, `scylladb`
 `just dc-cqlsh`, `just dc-tikv-status` and `just dc-redpanda-health` reach the stores
 directly.
 
+### Service addresses are container names, never `localhost`
+
+Every service reaches its dependencies by Compose DNS name — `pd:2379`, `scylladb:9042`,
+`nats://nats:4222`, `minio:9000`, **`redpanda:9092`**. Inside a container `localhost` is that
+container itself, so a `localhost` address is always wrong here.
+
+Redpanda advertises two listeners: `internal://redpanda:9092` for clients on the Compose
+network, and `external://localhost:19092` for clients on the host. Only 19092 is published, so
+in-container clients must use the internal one. `auth-service` (producer) and
+`messaging-service` (consumer) are the only services using Kafka; both are given
+`REDPANDA_BROKERS`. Host-side tooling such as `infra/scripts/init-redpanda-topics.sh`
+correctly uses `localhost:19092`.
+
+### Two services bypass the `GUARDYN_*` config loader
+
+`notification-service` and `call-service` read plain environment variables in `main.rs`
+rather than going through `guardyn_common::config`. `notification-service` reads `LISTEN_ADDR`
+and `SCYLLA_HOSTS`; setting only `GUARDYN_PORT` and `GUARDYN_DATABASE__SCYLLADB_NODES` leaves
+it binding the wrong port and dialling the Kubernetes ScyllaDB FQDN. Compose now sets both
+forms. Unifying this is tracked separately.
+
 ## Kubernetes
 
 ```sh
@@ -60,7 +81,8 @@ because Envoy is the ingress path.
 | messaging-service | 50052 (gRPC), 8081 (WebSocket) |
 | presence-service | 50053 |
 | media-service | 50054 |
-| notification-service | 8080, 9090 (metrics) |
+| call-service | 50056 (gRPC), 8085 |
+| notification-service | 50055 |
 
 ## Domains
 

--- a/docs/spec/SAD.md
+++ b/docs/spec/SAD.md
@@ -91,6 +91,12 @@ introduce a cache layer to "fix" a latency observation.
 They are not redundant and must not be consolidated. A presence beat that is lost is
 correct behaviour; a message event that is lost is data loss.
 
+Only `auth-service` (producer) and `messaging-service` (consumer) compile the Kafka client -
+the other services depend on `guardyn-common` without its `kafka` feature. Both read the
+broker address from `REDPANDA_BROKERS`, which resolves to `redpanda:9092` under Compose and
+`redpanda.messaging.svc.cluster.local:9092` in Kubernetes. Redpanda's `localhost:19092`
+listener is for host-side clients only.
+
 ## Edge
 
 Envoy terminates gRPC-Web and routes to `guardyn.auth.AuthService`,
@@ -125,7 +131,9 @@ enum variant.
 3. Recipient key material is fetched from `auth-service` (TiKV) if no session exists.
 4. Ciphertext is written to ScyllaDB and an `EventEnvelope` is produced to Redpanda.
 5. Live delivery goes out over NATS, or the WebSocket on `:8081` for a connected client.
-6. `notification-service` consumes the durable event and pushes to offline devices.
+6. Offline devices are the intended consumer of the durable event. **`notification-service`
+   does not consume it today** - it has no Kafka client at all, and depends on
+   `guardyn-common` without the `kafka` feature. Step 6 is the design, not shipped behaviour.
 
 At no point does a payload, a key, or decrypted metadata reach a log, a span, or a metric
 label.

--- a/infra/k8s/base/apps/auth-service.yaml
+++ b/infra/k8s/base/apps/auth-service.yaml
@@ -36,7 +36,9 @@ spec:
           value: "pd.data.svc.cluster.local:2379"
         - name: GUARDYN_DATABASE__SCYLLADB_NODES
           value: "scylla-0.data.svc.cluster.local:9042,scylla-1.data.svc.cluster.local:9042,scylla-2.data.svc.cluster.local:9042"
-        - name: GUARDYN_MESSAGING__REDPANDA_BROKERS
+        # KafkaConfig::from_env reads REDPANDA_BROKERS or KAFKA_BROKERS; the GUARDYN_ config
+        # loader has no redpanda_brokers field, so the prefixed name was never read.
+        - name: REDPANDA_BROKERS
           value: "redpanda.messaging.svc.cluster.local:9092"
         - name: GUARDYN_OBSERVABILITY__OTLP_ENDPOINT
           value: "http://tempo.observability.svc.cluster.local:4317"

--- a/infra/k8s/base/apps/messaging-service.yaml
+++ b/infra/k8s/base/apps/messaging-service.yaml
@@ -48,7 +48,9 @@ spec:
           value: "one"
         - name: SCYLLA_REPLICATION_FACTOR
           value: "1"
-        - name: GUARDYN_MESSAGING__REDPANDA_BROKERS
+        # KafkaConfig::from_env reads REDPANDA_BROKERS or KAFKA_BROKERS; the GUARDYN_ config
+        # loader has no redpanda_brokers field, so the prefixed name was never read.
+        - name: REDPANDA_BROKERS
           value: "redpanda.messaging.svc.cluster.local:9092"
         - name: GUARDYN_OBSERVABILITY__OTLP_ENDPOINT
           value: "http://tempo.observability.svc.cluster.local:4317"


### PR DESCRIPTION
## The headline failure was not Kafka

#99 reports `notification-service` panicking with `Failed to connect to ScyllaDB`, and
separately notes `localhost:19092` Kafka errors. Those are two unrelated bugs, and the second
one does not involve `notification-service` at all - it has **no Kafka client**, and depends on
`guardyn-common` without the `kafka` feature.

### 1. `notification-service` does not use the `GUARDYN_*` config loader

`main.rs` reads plain environment variables directly, which compose never set:

| Compose set | `main.rs` reads | Consequence |
|---|---|---|
| `GUARDYN_DATABASE__SCYLLADB_NODES: scylladb:9042` | `SCYLLA_HOSTS` (`main.rs:87`) | fell back to the Kubernetes FQDN `scylla.data.svc.cluster.local:9042` - **this is the reported failure** |
| `GUARDYN_PORT: "50055"`, published `50055:50055` | `LISTEN_ADDR` (`main.rs:86`) | bound **50054**; the published port mapped to nothing |
| - | - | `depends_on` omitted `scylladb` entirely |

Compose now sets both forms. Fixing compose rather than renaming the binary's variables is
deliberate: renaming would invalidate the Kubernetes manifests, which already use
`SCYLLA_HOSTS`.

### 2. The Kafka bootstrap really was `localhost`, for two other services

No compose service set a broker address, so `auth-service` (producer) and `messaging-service`
(consumer) fell back to `KafkaConfig`'s `localhost:19092`. That is Redpanda's **external**
listener, published only to the host - inside a container `localhost` is the container itself,
and `9092` is not published at all, so there is no accidental fallback.

Both now get `REDPANDA_BROKERS: redpanda:9092`, which is what `redpanda-console` already used
(`docker-compose.dev.yml:409`). `messaging-service` also gains the `depends_on: redpanda` it
never had, despite being the consumer.

### 3. Kubernetes carried the mirror image of the same bug

`auth-service` and `messaging-service` set `GUARDYN_MESSAGING__REDPANDA_BROKERS`, which
**nothing reads**: `KafkaConfig::from_env` looks for `REDPANDA_BROKERS` or `KAFKA_BROKERS`, and
`MessagingConfig` has no `redpanda_brokers` field at all. Renamed. (`notification-service` and
`presence-service` used the correct name but have no Kafka code - left alone.)

### 4. The `localhost:19092` default is kept, named and documented

It is correct for a host-run client, and host tooling such as
`infra/scripts/init-redpanda-topics.sh` relies on it. It is now `DEFAULT_BROKERS` with a
comment explaining that reaching it from inside a container means the address is missing.
Making that loud rather than silent is PR-28's job, not this PR's.

## Documentation

Both mapped documents were wrong about shipped behaviour, so this is a correction, not an
addition:

- `docs/ops/DEPLOYMENT.md` listed `notification-service` as ports `8080, 9090`, matching neither
  compose nor the binary, and omitted `call-service` entirely. Also documents the
  container-name addressing rule and the two services that bypass the config loader.
- `docs/spec/SAD.md` stated that `notification-service` consumes the durable Redpanda event.
  It has no Kafka client, so that step is now marked as design rather than shipped behaviour.

`just docs-verify` passes: `impact: 2 mapped source path(s) changed, all documented`.

## Deliberately out of scope

- Making the silent Kafka degradation fatal and alertable - **PR-28 (#39)**. Both the producer
  and the consumer still log `warn!` and continue on an unreachable broker.
- Making `just dc-status` probe `Health` rather than trust container state - **PR-27 (#38)**.
  #99 rightly calls this the worst part: the dev image's supervisor keeps the container alive
  after the binary exits, so `ps` reports `Up` for a dead service and `RUNBOOK.md`'s triage
  procedure is blind. This PR removes the cause of that particular death but not the blindness.
- Unifying `notification-service` and `call-service` onto `guardyn_common::config` so they stop
  needing a second set of environment variables.

Closes #99
