### PR TITLE
Release the DashMap guard before evicting the oldest connection

### DIFF
--- a/backend/crates/messaging-service/src/websocket/connection.rs
+++ b/backend/crates/messaging-service/src/websocket/connection.rs
@@ -106,26 +106,38 @@ impl ConnectionManager {
             return Err("Connection not found");
         }
 
-        // Add to user connections mapping
-        let mut user_conns = self
-            .user_connections
-            .entry(user_id.clone())
-            .or_insert_with(Vec::new);
+        // Decide whether the oldest connection has to go, then drop the guard before acting
+        // on it. `remove_connection` re-enters `user_connections` for this same key, and
+        // DashMap locks per shard: evicting while holding the entry guard deadlocks the
+        // caller permanently.
+        let oldest_to_evict = {
+            let user_conns = self
+                .user_connections
+                .entry(user_id.clone())
+                .or_insert_with(Vec::new);
 
-        // Check max connections per user
-        if user_conns.len() >= self.max_connections_per_user {
-            // Remove oldest connection
-            if let Some(oldest_conn_id) = user_conns.first().cloned() {
-                warn!(
-                    user_id = %user_id,
-                    oldest_connection = %oldest_conn_id,
-                    "Max connections reached, disconnecting oldest"
-                );
-                self.remove_connection(&oldest_conn_id);
+            if user_conns.len() >= self.max_connections_per_user {
+                user_conns.first().cloned()
+            } else {
+                None
             }
+        };
+
+        if let Some(oldest_conn_id) = oldest_to_evict {
+            warn!(
+                user_id = %user_id,
+                oldest_connection = %oldest_conn_id,
+                "Max connections reached, disconnecting oldest"
+            );
+            self.remove_connection(&oldest_conn_id);
         }
 
-        user_conns.push(connection_id.to_string());
+        // Re-acquire to append. The entry may have been removed entirely by the eviction
+        // above if it held the user's last connection, so `entry` rather than `get_mut`.
+        self.user_connections
+            .entry(user_id.clone())
+            .or_insert_with(Vec::new)
+            .push(connection_id.to_string());
 
         info!(
             connection_id = %connection_id,

--- a/backend/crates/messaging-service/src/websocket/server.rs
+++ b/backend/crates/messaging-service/src/websocket/server.rs
@@ -446,7 +446,10 @@ mod tests {
     #[test]
     fn test_config_defaults() {
         let config = WebSocketServerConfig::default();
-        assert_eq!(config.port, 8080);
+        // 8081, not 8080: docker-compose.dev.yml publishes 8081:8081 and sets
+        // WEBSOCKET_PORT=8081, and docs/spec/SAD.md documents the WebSocket on :8081.
+        // 8080 is Envoy's gRPC-Web listener.
+        assert_eq!(config.port, 8081);
         assert_eq!(config.max_connections_per_user, 5);
         assert_eq!(config.heartbeat_interval, 30);
         assert_eq!(config.connection_timeout, 90);


### PR DESCRIPTION
## This is a remotely reachable DoS, not a flaky test

`authenticate_connection` held a DashMap entry guard and then re-entered the same map for the
same key:

```rust
let mut user_conns = self.user_connections.entry(user_id.clone()).or_insert_with(Vec::new);
if user_conns.len() >= self.max_connections_per_user {
    if let Some(oldest_conn_id) = user_conns.first().cloned() {
        self.remove_connection(&oldest_conn_id);   // -> user_connections.get_mut(&user_id)
```

DashMap locks per shard, so `remove_connection` waited on a lock the same thread already held.
It never returns.

The branch is reached whenever a user opens **one more connection than
`max_connections_per_user`** - default **5**. Any client can trigger it deliberately, and the
wedged task keeps holding the shard lock, so every later operation hashing to that shard hangs
behind it. Cheap to trigger, permanent, and it takes out other users' connections too.

## Why nobody had noticed

`cargo test --workspace` aborts at the first failing target. `guardyn-crypto` fails first, so
the run never reached `messaging-service`. `build.yml` additionally marks the test step
`continue-on-error: true`. The suite has been hanging on `test_max_connections_per_user` the
whole time, invisibly.

**`cargo test -p guardyn-messaging-service` now terminates for the first time.**

```
test result: ok. 19 passed; 0 failed; 3 ignored
```

## The fix

Compute the eviction target in a short scope, drop the guard, evict, then re-acquire to
append. Re-acquired with `entry` rather than `get_mut`, because evicting a user's last
connection removes the entry entirely.

`test_max_connections_per_user` is **unchanged** - it was correct all along and is the
regression test.

## The second failure was a stale test

`test_config_defaults` asserted `port == 8080` against a default of **8081**. The default is
right: `docker-compose.dev.yml` publishes `8081:8081` and sets `WEBSOCKET_PORT=8081`, and
`docs/spec/SAD.md` documents the WebSocket on `:8081`. 8080 is Envoy's gRPC-Web listener.

Per `AGENTS.md` §8 this is stated rather than quietly adjusted: **the test was wrong**, the
code was right, so the test is corrected and the reasoning recorded inline.

## Why this blocks PR-17

PR-17 (#28) removes `continue-on-error` from the test step. Once the crypto failures are
fixed, the workspace run proceeds into `messaging-service` and hangs until the job times
out - `main` would go red, slowly. This PR clears that.

The remaining PR-17 prerequisite is `build.yml:64`, which passes `--exclude e2e-tests` while
the package is named `guardyn-e2e-tests`; the exclusion matches nothing, so the e2e suite
would start running without a cluster. That is fixed in PR-17 itself.

## Deliberately out of scope

- The orphaned `crypto_tests.rs` in this crate (#108) - never declared as a module, and no
  longer compiles against the current `guardyn-crypto` API.
- `desktop-build.yml`'s test job, which has never passed on any branch.
- Auditing the rest of the codebase for the same DashMap re-entrancy pattern. Worth doing;
  this PR fixes the one instance that is provably reachable.

Closes #107
