### PR TITLE
Remove continue-on-error from clippy and tests (PR-17)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,12 +57,13 @@ jobs:
       - name: Run Clippy
         working-directory: ./backend
         run: cargo clippy --all-targets --all-features -- -D warnings
-        continue-on-error: true
 
+      # The package is `guardyn-e2e-tests`; `--exclude e2e-tests` matched nothing, so the
+      # exclusion was inert. It only became load-bearing once this step could fail: the e2e
+      # suite needs a live k3d cluster and is covered by test.yml instead.
       - name: Run tests
         working-directory: ./backend
-        run: cargo test --workspace --exclude e2e-tests
-        continue-on-error: true
+        run: cargo test --workspace --exclude guardyn-e2e-tests
 
   security-audit:
     name: Security Audit


### PR DESCRIPTION
The last step of Phase 1, and the prerequisite for **G1**.

## What

`build.yml` marked clippy, tests **and** cargo-audit `continue-on-error: true`, so only
`cargo fmt` could fail the backend job. Per `implementation_plan.md` §4.5: *"without this, no
later gate means anything."*

- `continue-on-error` removed from **Run Clippy** and **Run tests**.
- Kept on **cargo audit** alone, as the plan specifies - advisory-DB churn is exogenous, and
  `deny.toml` already carries 7 reviewed RUSTSEC ignores.

## The `--exclude` correction is required, not a precaution

```diff
-        run: cargo test --workspace --exclude e2e-tests
+        run: cargo test --workspace --exclude guardyn-e2e-tests
```

The package is named `guardyn-e2e-tests`, so `--exclude e2e-tests` matched nothing. I first
described this as something that *would* start running the e2e suite once the mask came off.
That was wrong: the CI log for #119 shows it **already running and already failing**:

```
error: test failed, to rerun pass `-p guardyn-e2e-tests --test e2e_groups`
##[error]Process completed with exit code 101.
```

Every `build.yml` run has been doing this, with `continue-on-error` swallowing it. Those tests
need a live k3d cluster and are covered by `test.yml`. Without this line, removing the mask
turns `main` red on the first push.

## Why it is safe to unmask now

| Blocker | Resolved by |
|---|---|
| 5 Double Ratchet failures - responder discarded Bob's DH key | #109 (#102) |
| 1-2 PQXDH failures - Ed25519 keys used as X25519 | #110 (#103) |
| 9 MLS failures - `group_id` discarded, six self-decrypt tests | #112 (#113) |
| 1 clippy error masking every crate behind `guardyn-common` | #111 (#104) |
| `messaging-service` suite **hung forever** on a DashMap self-deadlock | #115 (#107) |
| Unpinned toolchain; 162 clippy errors on stable 1.98 | #119 (#118) |

The last three were not in #87. All were invisible for the same reason: `cargo test
--workspace` aborts at the first failing target and never reached `messaging-service`; the
clippy error stopped compilation of `guardyn-common` so nothing downstream was ever checked;
and nothing pinned the toolchain, so local and CI disagreed about what clippy even is.

Measured on `main` at `24a20ff7`, on the toolchain #119 pins, with every crate root touched
first to defeat the build cache:

```
cargo fmt --all -- --check                                clean
cargo clippy --all-targets --all-features -- -D warnings  0 errors, 10 crates re-checked
cargo test --workspace --exclude guardyn-e2e-tests        230 passed, 0 failed
```

The cache-busting is not ceremony. An earlier run in this session reported clean off a warm
cache on a different compiler and was reported as fact; #87 records the same precaution being
taken for the same reason.

## Known red this PR does not cover

`desktop-build.yml`'s `test` job fails on every branch, including ones predating this work: it
runs `cargo test` in `client-desktop/src-tauri` without building the frontend, so
`tauri::generate_context!()` panics on a missing `frontendDist`. Tracked as **#116**. Different
workflow, out of PR-17's scope, which is `build.yml` only.

So after this merges, "CI is green" means `build.yml`, `docs.yml`, `test.yml` and
`security.yml` are green - not the whole board.

## Deliberately out of scope

- The other `continue-on-error` uses across `test.yml`, `security.yml`, `desktop-ci.yml`,
  `desktop-build.yml` and `release.yml`. The plan scopes PR-17 to `build.yml`, and #116 shows
  why unmasking the rest needs its own step - some of those jobs cannot pass yet.
- Adding the `just verify` aggregate recipe that `implementation_plan.md:549` refers to but
  which does not exist.

Closes #28