### PR TITLE
Pin the Rust toolchain and silence result_large_err on gRPC crates

### DIFF
--- a/backend/crates/auth-service/src/main.rs
+++ b/backend/crates/auth-service/src/main.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 mod db;
 /// Authentication Service
 ///

--- a/backend/crates/call-service/src/main.rs
+++ b/backend/crates/call-service/src/main.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! Call Service - Voice/Video Calls with WebRTC + SFrame E2EE
 //!
 //! Provides signaling for WebRTC calls with SFrame end-to-end encryption.

--- a/backend/crates/e2e-tests/tests/e2e_groups.rs
+++ b/backend/crates/e2e-tests/tests/e2e_groups.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! E2E Tests for Group Chat Functionality
 //!
 //! Comprehensive tests for group chat features:

--- a/backend/crates/e2e-tests/tests/e2e_media.rs
+++ b/backend/crates/e2e-tests/tests/e2e_media.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! E2E Tests for Media Service
 //!
 //! Tests media-related functionality:

--- a/backend/crates/e2e-tests/tests/e2e_mls_integration.rs
+++ b/backend/crates/e2e-tests/tests/e2e_mls_integration.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! MLS Integration Tests for Auth + Messaging Services
 //!
 //! Tests end-to-end MLS group encryption flow across services:

--- a/backend/crates/e2e-tests/tests/e2e_mvp_simplified.rs
+++ b/backend/crates/e2e-tests/tests/e2e_mvp_simplified.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! Simplified E2E Tests for Auth + Messaging Services (MVP - Without Cryptography)
 //!
 //! This is a simplified version without X3DH/Double Ratchet/MLS cryptography.

--- a/backend/crates/e2e-tests/tests/e2e_phase2_features.rs
+++ b/backend/crates/e2e-tests/tests/e2e_phase2_features.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! E2E Tests for Phase 2 Features
 //!
 //! This module contains integration tests for messenger features implemented in Phase 2:

--- a/backend/crates/e2e-tests/tests/e2e_presence.rs
+++ b/backend/crates/e2e-tests/tests/e2e_presence.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! E2E Tests for Presence Service
 //!
 //! Tests presence-related functionality:

--- a/backend/crates/e2e-tests/tests/e2e_production_readiness.rs
+++ b/backend/crates/e2e-tests/tests/e2e_production_readiness.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! Production Readiness E2E Tests
 //!
 //! Comprehensive tests for validating system production readiness:

--- a/backend/crates/media-service/src/handlers/presigned.rs
+++ b/backend/crates/media-service/src/handlers/presigned.rs
@@ -51,7 +51,7 @@ pub async fn get_upload_url(
     // Generate media ID and storage path
     let media_id = DatabaseClient::generate_media_id();
     let extension = req.filename.rsplit('.').next().unwrap_or("bin");
-    let storage_path = format!("{}/{}.{}", &user_id, &media_id, extension);
+    let storage_path = format!("{}/{}.{}", user_id, media_id, extension);
 
     // Determine content type
     let content_type = if req.mime_type.is_empty() {

--- a/backend/crates/media-service/src/handlers/thumbnail.rs
+++ b/backend/crates/media-service/src/handlers/thumbnail.rs
@@ -192,7 +192,7 @@ pub async fn handle(
 
     // Generate thumbnail ID and storage path
     let thumbnail_id = DatabaseClient::generate_media_id();
-    let storage_path = format!("{}/thumb_{}.{}", &user_id, &thumbnail_id, format);
+    let storage_path = format!("{}/thumb_{}.{}", user_id, thumbnail_id, format);
 
     // Upload thumbnail
     let mime_type = ThumbnailGenerator::format_to_mime(format);

--- a/backend/crates/media-service/src/handlers/upload.rs
+++ b/backend/crates/media-service/src/handlers/upload.rs
@@ -61,7 +61,7 @@ pub async fn handle(
     // Generate media ID and storage path
     let media_id = DatabaseClient::generate_media_id();
     let extension = header.filename.rsplit('.').next().unwrap_or("bin");
-    let storage_path = format!("{}/{}.{}", &user_id, &media_id, extension);
+    let storage_path = format!("{}/{}.{}", user_id, media_id, extension);
 
     tracing::info!(
         media_id = %media_id,

--- a/backend/crates/media-service/src/main.rs
+++ b/backend/crates/media-service/src/main.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! Media Service
 //!
 //! Handles:

--- a/backend/crates/messaging-service/src/main.rs
+++ b/backend/crates/messaging-service/src/main.rs
@@ -1,3 +1,10 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
 // Allow common development-time warnings for code under active development
 #![allow(unused_variables, unused_mut, dead_code, unused_imports)]
 

--- a/backend/crates/notification-service/src/main.rs
+++ b/backend/crates/notification-service/src/main.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 //! Notification Service - Push Notifications for Guardyn
 //!
 //! Handles device registration, notification settings, and push delivery

--- a/backend/crates/presence-service/src/main.rs
+++ b/backend/crates/presence-service/src/main.rs
@@ -1,3 +1,11 @@
+// tonic's generated service traits fix the handler signature as
+// `Result<Response<T>, Status>`, and `Status` is 176 bytes. clippy 1.98 extended
+// `result_large_err` from closures to functions, so every handler now trips it - as does
+// tonic's own generated code. The lint's remedy, `Box<Status>`, would no longer implement
+// the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
+// `common` still get the lint.
+#![allow(clippy::result_large_err)]
+
 /// Presence Service
 ///
 /// Handles:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+# Pin the toolchain so local checks and CI agree.
+#
+# Every workflow uses `dtolnay/rust-toolchain@stable`, which honours this file. Without it,
+# CI floats to whatever stable is on the day while contributors run whatever they have
+# installed: `cargo clippy -- -D warnings` was clean on 1.96.0 and produced 162 errors on
+# 1.98.1, because clippy 1.98 extended `result_large_err` from closures to functions.
+#
+# A gate that can fail without a change to this repository is not a signal, so bumping this
+# version is a deliberate, reviewable commit - never an accident of timing.
+[toolchain]
+channel = "1.98.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
**Blocks PR-17 (#28).** Found while landing it: `build.yml` went red on its first honest run.

## The toolchain was never pinned

No `rust-toolchain.toml` anywhere, and every workflow uses `dtolnay/rust-toolchain@stable`.
CI ran **1.98.1**; this machine ran **1.96.0**. A full workspace
`cargo clippy --all-targets --all-features -- -D warnings` was clean on 1.96 and produced
**162 errors** on 1.98.

That is the deeper problem, and it is not hypothetical: **a Rust release can turn `main` red
with no change to this repository.** PR-17's whole purpose is to make CI a signal; a gate that
fails for reasons unrelated to the commit is not one.

`rust-toolchain.toml` pins 1.98.1. rustup gives the file precedence over the default the
action sets (`rustup default stable`, not `rustup override set`), so CI honours it without
editing seven workflows, and bumping the version becomes a deliberate, reviewable commit.

## 156 of the 162 cannot be fixed, and that is not a shortcut

They are `result_large_err` on `tonic::Status` (176 bytes) returned from gRPC handlers.
clippy 1.98 extended the lint from closures to functions - which is why 1.96 saw only the
single closure already handled in #104.

The lint suggests `Box<tonic::Status>`. It is unavailable: the signature is dictated by the
service trait tonic generates from the proto.

```rust
async fn get_status(&self, request: Request<GetStatusRequest>)
    -> Result<Response<GetStatusResponse>, Status>;
```

The decisive evidence is where the `e2e-tests` failures land - inside
`target/debug/build/.../out/guardyn.{auth,media,messaging,presence}.rs`. **tonic's own
generated code does not pass the lint.** Nothing we write can change that.

So `#![allow(clippy::result_large_err)]` goes at crate level on the six services and the
seven e2e test binaries, with the reasoning recorded inline at each root.

**Deliberately not `[workspace.lints]`.** `crypto` and `common` do not speak gRPC, and the
lint is meaningful there - #104 was a real instance in `common`. Silencing it workspace-wide
would have removed the only reason that fix existed.

## The other 6 are real, and are fixed properly

`useless_borrows_in_formatting` in `media-service` - `format!("{}/{}.{}", &user_id, ...)`.
Three handlers, six sites, redundant `&` removed.

## Verification

Every crate root touched first to defeat the build cache, on the pinned toolchain:

```
cargo clippy --all-targets --all-features -- -D warnings   0 errors, 10 crates re-checked
cargo fmt --all -- --check                                 clean
cargo test --workspace --exclude guardyn-e2e-tests         230 passed, 0 failed
```

The cache-busting matters. An earlier clippy run in this session reported clean off a warm
cache and was reported as fact; #87 records the same precaution being taken for the same
reason.

## Budget

17 files, 121 lines. Within §2.3 by the line limit - the file count is high only because the
same one-line attribute lands at 13 crate roots.

## Deliberately out of scope

- Whether `tonic::Status` should be boxed at the API boundary. That is a tonic-wide design
  question, not something to decide while unblocking a CI gate.
- The other `continue-on-error` masks outside `build.yml`, and `desktop-build.yml`'s test job
  which cannot pass on any branch (#116).
- Bumping other pinned tool versions, or pinning the Node/Flutter toolchains the client
  workflows float on - same class of problem, different step.

Closes #118
