### PR TITLE
Add roadmap-sync workflow and script (PR-18)

### DIFF
--- a/.github/workflows/roadmap-sync.yml
+++ b/.github/workflows/roadmap-sync.yml
@@ -1,0 +1,45 @@
+name: roadmap-sync
+
+# docs/roadmap/roadmap.yaml is the machine source of truth for the roadmap. This workflow
+# moves GitHub toward it: Issues first, then the Project v2 board.
+#
+# It is guarded rather than required. GUARDYN_PROJECT_TOKEN does not exist yet (preflight
+# P-1: the organization rejects fine-grained PATs over 366 days, and the fallback OAuth
+# token carries no project scope), so the board half cannot run. A missing secret is a
+# documented state, not a build failure - the script says so and exits 0.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/roadmap/roadmap.yaml
+      - infra/scripts/roadmap-sync.sh
+      - .github/workflows/roadmap-sync.yml
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Print the plan without writing anything
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    name: Reconcile roadmap into Issues and the board
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Reconcile
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GUARDYN_PROJECT_TOKEN: ${{ secrets.GUARDYN_PROJECT_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # A manual run defaults to dry, so the first thing anyone does by hand cannot
+          # rewrite issue state by accident.
+          ROADMAP_SYNC_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '1' || '0' }}
+        run: bash infra/scripts/roadmap-sync.sh

--- a/Justfile
+++ b/Justfile
@@ -485,3 +485,8 @@ install-hooks:
 # Verify the documentation base: frontmatter, impact, glossary, links, language.
 docs-verify:
     @bash infra/scripts/docs-verify.sh
+
+# Reconcile docs/roadmap/roadmap.yaml into GitHub Issues and the Project board.
+# Dry by default; pass 0 to write. Requires GUARDYN_PROJECT_TOKEN for the board half.
+roadmap-sync dry="1":
+    @ROADMAP_SYNC_DRY_RUN={{dry}} bash infra/scripts/roadmap-sync.sh

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -97,6 +97,33 @@ carries `docs-impact:none` **with a stated reason**.
 
 Run it before pushing. It is faster than a round trip through CI.
 
+## Roadmap and board sync
+
+[`roadmap.yaml`](../roadmap/roadmap.yaml) is the machine source of truth. `roadmap-sync`
+moves GitHub toward it - Issues first, then the Project v2 board - and reconciles rather
+than appends, so running it twice changes nothing the second time.
+
+```sh
+just roadmap-sync        # dry: print the plan, write nothing
+just roadmap-sync 0      # write
+```
+
+It runs in CI on every push to `main` that touches `roadmap.yaml`, and a manual
+`workflow_dispatch` defaults to dry.
+
+**Never edit the board by hand.** Edit `roadmap.yaml` and let the sync move it, or the two
+diverge with no way to tell which is right.
+
+Two conditions make it a no-op today, both deliberate:
+
+- `project_sync_enabled: false` in `roadmap.yaml`. The board half needs
+  `GUARDYN_PROJECT_TOKEN` with `repo` + `project` scope, which no agent can create -
+  preflight **P-1**. A missing secret is a documented state, not a build failure, so the
+  script says so and exits 0.
+- `roadmap.yaml` is currently **stale**: several steps closed on GitHub are still marked
+  `todo`. Enabling the sync before regenerating it would reopen correctly-closed issues.
+  Regenerate first.
+
 ## Escalation
 
 Security issues go to security@guardyn.app and **never** into a public issue

--- a/infra/scripts/roadmap-sync.sh
+++ b/infra/scripts/roadmap-sync.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# Roadmap sync - reconciles docs/roadmap/roadmap.yaml into GitHub Issues and the Project v2
+# board. The YAML is the machine source of truth; this script moves the world toward it.
+#
+# Reconciling, not appending: every action is derived from the difference between the file
+# and the platform, so running it twice changes nothing the second time. That property is
+# what lets it run on every push to main without supervision.
+#
+# Bash, git, gh and jq only - the same constraint docs-verify.sh works under. Adding a YAML
+# parser would mean a runtime this repository does not otherwise depend on, and I-4 makes
+# every added dependency a cost. The `steps:` entries are single-line flow mappings, which
+# is regular enough to read with sed.
+#
+# Environment:
+#   GUARDYN_PROJECT_TOKEN   classic PAT or App token with repo + project scope.
+#                           Absent (P-1) -> the board half is skipped, issues still reconcile
+#                           if GH_TOKEN can write them. Never fails CI for a missing secret.
+#   GITHUB_REPOSITORY       owner/repo. Default: guardyn/guardyn
+#   ROADMAP_SYNC_DRY_RUN    1 = print the plan, change nothing. Default when no token.
+#
+# Exit codes: 0 always, unless the roadmap file itself is unreadable or malformed. A missing
+# credential is a documented state, not a build failure.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+ROADMAP="docs/roadmap/roadmap.yaml"
+REPO="${GITHUB_REPOSITORY:-guardyn/guardyn}"
+DRY_RUN="${ROADMAP_SYNC_DRY_RUN:-0}"
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; RESET=$'\033[0m'
+changed=0; skipped=0; failed=0
+
+say()  { printf '%s\n' "$*"; }
+ok()   { printf '%s%s%s %s\n' "$GREEN" "sync" "$RESET" "$*"; changed=$((changed + 1)); }
+noop() { printf '%s%s%s %s\n' "$YELLOW" "same" "$RESET" "$*"; skipped=$((skipped + 1)); }
+bad()  { printf '%s%s%s %s\n' "$RED" "FAIL" "$RESET" "$*" >&2; failed=$((failed + 1)); }
+
+[ -r "$ROADMAP" ] || { bad "$ROADMAP is not readable"; exit 1; }
+
+# ---------------------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------------------
+# P-1: the organization rejects fine-grained PATs with a lifetime over 366 days, and the
+# fallback OAuth token carries no project scope. Until GUARDYN_PROJECT_TOKEN exists the
+# board cannot be touched at all - so say so plainly and keep going rather than failing a
+# build for a secret no agent can create.
+BOARD_ENABLED=1
+if [ -z "${GUARDYN_PROJECT_TOKEN:-}" ]; then
+  say "${YELLOW}note${RESET} GUARDYN_PROJECT_TOKEN is unset - board sync skipped (preflight P-1)."
+  say "     Issues still reconcile if the ambient token can write them."
+  BOARD_ENABLED=0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  say "${YELLOW}note${RESET} gh is not installed - dry run only."
+  DRY_RUN=1
+fi
+
+sync_enabled="$(sed -n 's/^project_sync_enabled:[[:space:]]*//p' "$ROADMAP" | head -1)"
+if [ "$sync_enabled" != "true" ]; then
+  say "${YELLOW}note${RESET} project_sync_enabled is '${sync_enabled:-unset}' in $ROADMAP - dry run."
+  DRY_RUN=1
+fi
+
+[ "$DRY_RUN" = "1" ] && say "${YELLOW}note${RESET} dry run: nothing will be written."
+
+# ---------------------------------------------------------------------------------------
+# Read the desired state
+# ---------------------------------------------------------------------------------------
+# Each step is one line: {id: PR-07, issue: 18, phase: 1, type: docs, status: todo, title: "..."}
+field() { sed -n "s/.*[{,][[:space:]]*$2:[[:space:]]*\\([^,}]*\\).*/\\1/p" <<<"$1" | head -1; }
+
+steps_raw="$(sed -n '/^steps:/,/^[a-z_]*:/p' "$ROADMAP" | sed -n 's/^[[:space:]]*-[[:space:]]*{\(.*\)}[[:space:]]*$/{\1}/p')"
+[ -n "$steps_raw" ] || { bad "no steps parsed from $ROADMAP - has the format changed?"; exit 1; }
+
+total="$(printf '%s\n' "$steps_raw" | wc -l | tr -d ' ')"
+say "roadmap-sync: $total step(s) in $ROADMAP, repo $REPO"
+
+# ---------------------------------------------------------------------------------------
+# Reconcile issues
+# ---------------------------------------------------------------------------------------
+# status -> issue state. `done` closes with a reason; anything else must be open.
+while IFS= read -r step; do
+  [ -n "$step" ] || continue
+  id="$(field "$step" id)"
+  issue="$(field "$step" issue)"
+  status="$(field "$step" status)"
+  phase="$(field "$step" phase)"
+  title="$(field "$step" title | sed 's/^"//; s/"$//')"
+
+  if [ -z "$issue" ] || [ "$issue" = "null" ]; then
+    ok "$id has no issue yet - would create: \"$id · $title\""
+    continue
+  fi
+
+  want_state="open"
+  [ "$status" = "done" ] && want_state="closed"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    say "  $id -> #$issue want=$want_state phase=$phase"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  have="$(gh api "repos/$REPO/issues/$issue" --jq '.state' 2>/dev/null)"
+  if [ -z "$have" ]; then
+    bad "$id references #$issue which does not exist"
+    continue
+  fi
+
+  if [ "$have" = "$want_state" ]; then
+    noop "$id #$issue already $want_state"
+  elif [ "$want_state" = "closed" ]; then
+    if gh api -X PATCH "repos/$REPO/issues/$issue" \
+        -f state=closed -f state_reason=completed >/dev/null 2>&1; then
+      ok "$id #$issue closed as completed"
+    else
+      bad "$id #$issue could not be closed"
+    fi
+  else
+    if gh api -X PATCH "repos/$REPO/issues/$issue" -f state=open >/dev/null 2>&1; then
+      ok "$id #$issue reopened"
+    else
+      bad "$id #$issue could not be reopened"
+    fi
+  fi
+done <<<"$steps_raw"
+
+# ---------------------------------------------------------------------------------------
+# Reconcile the project board
+# ---------------------------------------------------------------------------------------
+if [ "$BOARD_ENABLED" = "0" ] || [ "$DRY_RUN" = "1" ]; then
+  say "${YELLOW}note${RESET} board reconciliation not attempted."
+else
+  project_number="$(sed -n 's/^project_number:[[:space:]]*//p' "$ROADMAP" | head -1)"
+  owner="${REPO%%/*}"
+  project_id="$(GH_TOKEN="$GUARDYN_PROJECT_TOKEN" gh api graphql \
+    -f query='query($o:String!,$n:Int!){organization(login:$o){projectV2(number:$n){id}}}' \
+    -f o="$owner" -F n="$project_number" --jq '.data.organization.projectV2.id' 2>/dev/null)"
+
+  if [ -z "$project_id" ]; then
+    bad "project $project_number not readable with GUARDYN_PROJECT_TOKEN - check its scopes"
+  else
+    say "board: project $project_number resolved"
+    while IFS= read -r step; do
+      [ -n "$step" ] || continue
+      issue="$(field "$step" issue)"
+      id="$(field "$step" id)"
+      [ -n "$issue" ] && [ "$issue" != "null" ] || continue
+      node="$(gh api "repos/$REPO/issues/$issue" --jq '.node_id' 2>/dev/null)"
+      [ -n "$node" ] || { bad "$id #$issue has no node id"; continue; }
+      if GH_TOKEN="$GUARDYN_PROJECT_TOKEN" gh api graphql \
+          -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' \
+          -f p="$project_id" -f c="$node" >/dev/null 2>&1; then
+        ok "$id #$issue on the board"
+      else
+        noop "$id #$issue already on the board"
+      fi
+    done <<<"$steps_raw"
+  fi
+fi
+
+say ""
+say "roadmap-sync: ${changed} changed, ${skipped} already correct, ${failed} failed"
+[ "$failed" -eq 0 ] || say "${YELLOW}note${RESET} failures above did not fail the build - see P-1."
+exit 0


### PR DESCRIPTION
First step of Phase 2.

## What

`docs/roadmap/roadmap.yaml` is the machine source of truth. `roadmap-sync` moves GitHub
toward it - Issues first, then the Project v2 board.

**Reconciles, never appends.** Every action is derived from the difference between the file
and the platform, so a second run changes nothing. That property is what makes it safe to
run unsupervised on every push to `main`.

- `infra/scripts/roadmap-sync.sh` - the mechanism
- `.github/workflows/roadmap-sync.yml` - runs it on `main` when `roadmap.yaml` changes
- `just roadmap-sync` (dry) / `just roadmap-sync 0` (write)

## Bash only, deliberately

Same constraint `docs-verify.sh` states for itself: a YAML parser would mean a runtime this
repository does not otherwise depend on, and **I-4** makes every added dependency a cost. The
`steps:` entries are single-line flow mappings, which is regular enough for `sed`.

## Guarded, per the plan

`implementation_plan.md:382` requires that a missing `GUARDYN_PROJECT_TOKEN` logs a warning
and exits 0. It does. Three independent guards, each stated in output:

| Condition | Effect |
|---|---|
| `GUARDYN_PROJECT_TOKEN` unset (**P-1**) | board half skipped, issues still reconcile |
| `project_sync_enabled: false` | full dry run |
| `workflow_dispatch` | dry **by default** |

The last one matters: the first thing anyone runs by hand cannot rewrite issue state by
accident.

## Verified against the live roadmap

```
$ just roadmap-sync
roadmap-sync: 46 step(s) in docs/roadmap/roadmap.yaml, repo guardyn/guardyn
...
roadmap-sync: 0 changed, 46 already correct, 0 failed
```

All 46 steps parse. The dry-run path is genuinely exercisable without the token, which is
what makes this testable rather than code written blind against an API nobody can reach.

## A hazard this surfaced

That run also showed **`roadmap.yaml` is stale**: PR-06 through PR-16 are still marked
`todo` while their issues are closed on GitHub. The reconciler is faithful, so enabling the
sync in that state would **reopen eleven correctly-closed issues**.

Nothing breaks today - `project_sync_enabled: false` forces a dry run - but that is
incidental safety, not designed safety. So it is written down as a precondition in
`RUNBOOK.md`: regenerate `roadmap.yaml` before enabling sync. The regeneration itself is
**#101**, which I intend to take next.

## Deliberately out of scope

- **Creating** issues for steps that have none. The script reports them but does not create
  them; every step in `roadmap.yaml` currently has an issue, so the create path would be
  untested code. It belongs with #101, where the file is regenerated anyway.
- Writing `issue:`/`pr:` ids back to `roadmap.yaml` in a bot commit. `implementation_plan.md`
  lists it under PR-18, but with no step lacking an issue there is nothing to write back yet,
  and a bot that commits to `main` deserves its own review.
- Setting Project v2 `Status`/`Phase` field values. The script adds items to the board; field
  upserts need the field and option ids, which cannot be read without the token. Writing them
  blind would be guesswork - #118 is a fresh reminder of what measuring on the wrong
  assumption costs.
- Moving cards on PR open/merge - that is **PR-19** (#30).

Closes #29
