### PR TITLE
Reconcile milestones in roadmap-sync (PR-18b)

### DIFF
--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -100,8 +100,13 @@ Run it before pushing. It is faster than a round trip through CI.
 ## Roadmap and board sync
 
 [`roadmap.yaml`](../roadmap/roadmap.yaml) is the machine source of truth. `roadmap-sync`
-moves GitHub toward it - Issues first, then the Project v2 board - and reconciles rather
-than appends, so running it twice changes nothing the second time.
+moves GitHub toward it - issue state, then milestones, then the Project v2 board - and
+reconciles rather than appends, so running it twice changes nothing the second time.
+
+Phase is tracked by **native GitHub Milestones**, titled `Phase N - ...`. A step's `phase: N`
+selects the milestone; the script writes it only when it differs from what the issue already
+carries. Milestones are REST and work with the ambient token, so unlike the board half this
+pass is never skipped.
 
 ```sh
 just roadmap-sync        # dry: print the plan, write nothing
@@ -114,15 +119,16 @@ It runs in CI on every push to `main` that touches `roadmap.yaml`, and a manual
 **Never edit the board by hand.** Edit `roadmap.yaml` and let the sync move it, or the two
 diverge with no way to tell which is right.
 
-Two conditions make it a no-op today, both deliberate:
+One condition still makes the **board half** a no-op, deliberately:
+`project_sync_enabled: false` in `roadmap.yaml`. The board needs `GUARDYN_PROJECT_TOKEN`
+with `repo` + `project` scope, which no agent can create - preflight **P-1**. A missing
+secret is a documented state, not a build failure, so the script says so and exits 0. The
+flag gates the board **only** - issue state and milestones reconcile either way.
 
-- `project_sync_enabled: false` in `roadmap.yaml`. The board half needs
-  `GUARDYN_PROJECT_TOKEN` with `repo` + `project` scope, which no agent can create -
-  preflight **P-1**. A missing secret is a documented state, not a build failure, so the
-  script says so and exits 0.
-- `roadmap.yaml` is currently **stale**: several steps closed on GitHub are still marked
-  `todo`. Enabling the sync before regenerating it would reopen correctly-closed issues.
-  Regenerate first.
+> **Before flipping `project_sync_enabled` to `true`, check that every `status:` in
+> `roadmap.yaml` matches its issue's real state.** The script reconciles issue state *from*
+> the file, so a stale `todo` reopens a correctly-closed issue. This bit once: PR-06 through
+> PR-18 stayed `todo` after merging, which would have reopened thirteen issues.
 
 ## Escalation
 

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -35,19 +35,19 @@ steps:
   - {id: PR-03, issue: 14, phase: 1, type: chore, status: done, title: "Remove committed build artifacts and extend .gitignore"}
   - {id: PR-04, issue: 15, phase: 1, type: docs, status: done, title: "Add AGENTS.md and CLAUDE.md agent constitution"}
   - {id: PR-05, issue: 16, phase: 1, type: docs, status: done, title: "Add .claude/rules ruleset"}
-  - {id: PR-06, issue: 17, phase: 1, type: chore, status: todo, title: "Add .claude/settings.json guard hooks and pre-commit hook"}
-  - {id: PR-07, issue: 18, phase: 1, type: docs, status: todo, title: "Add CODEOWNERS and dependabot; rewrite CONTRIBUTING.md and README.md"}
-  - {id: PR-08, issue: 19, phase: 1, type: docs, status: todo, title: "Add docs/INDEX.md and GLOSSARY.md"}
-  - {id: PR-09, issue: 20, phase: 1, type: docs, status: todo, title: "Write docs/spec/SAD.md"}
-  - {id: PR-10, issue: 21, phase: 1, type: docs, status: todo, title: "Write docs/spec/SRS.md"}
-  - {id: PR-11, issue: 22, phase: 1, type: docs, status: todo, title: "Write docs/spec/PRD.md"}
-  - {id: PR-12, issue: 23, phase: 1, type: docs, status: todo, title: "Write ADR-0001 through ADR-0009"}
-  - {id: PR-13, issue: 24, phase: 1, type: docs, status: todo, title: "Write docs/ops DEPLOYMENT, RUNBOOK, OBSERVABILITY"}
-  - {id: PR-14, issue: 25, phase: 1, type: docs, status: todo, title: "Write docs/roadmap ROADMAP.md, roadmap.yaml, STATE.md"}
-  - {id: PR-15, issue: 26, phase: 1, type: feat, status: todo, title: "Add docs/.manifest.yaml and just docs-verify"}
-  - {id: PR-16, issue: 27, phase: 1, type: feat, status: todo, title: "Add .github/workflows/docs.yml"}
-  - {id: PR-17, issue: 28, phase: 1, type: fix, status: todo, gate: G1, title: "Remove continue-on-error from build.yml"}
-  - {id: PR-18, issue: 29, phase: 2, type: feat, status: todo, title: "Add .github/workflows/roadmap-sync.yml"}
+  - {id: PR-06, issue: 17, phase: 1, type: chore, status: done, title: "Add .claude/settings.json guard hooks and pre-commit hook"}
+  - {id: PR-07, issue: 18, phase: 1, type: docs, status: done, title: "Add CODEOWNERS and dependabot; rewrite CONTRIBUTING.md and README.md"}
+  - {id: PR-08, issue: 19, phase: 1, type: docs, status: done, title: "Add docs/INDEX.md and GLOSSARY.md"}
+  - {id: PR-09, issue: 20, phase: 1, type: docs, status: done, title: "Write docs/spec/SAD.md"}
+  - {id: PR-10, issue: 21, phase: 1, type: docs, status: done, title: "Write docs/spec/SRS.md"}
+  - {id: PR-11, issue: 22, phase: 1, type: docs, status: done, title: "Write docs/spec/PRD.md"}
+  - {id: PR-12, issue: 23, phase: 1, type: docs, status: done, title: "Write ADR-0001 through ADR-0009"}
+  - {id: PR-13, issue: 24, phase: 1, type: docs, status: done, title: "Write docs/ops DEPLOYMENT, RUNBOOK, OBSERVABILITY"}
+  - {id: PR-14, issue: 25, phase: 1, type: docs, status: done, title: "Write docs/roadmap ROADMAP.md, roadmap.yaml, STATE.md"}
+  - {id: PR-15, issue: 26, phase: 1, type: feat, status: done, title: "Add docs/.manifest.yaml and just docs-verify"}
+  - {id: PR-16, issue: 27, phase: 1, type: feat, status: done, title: "Add .github/workflows/docs.yml"}
+  - {id: PR-17, issue: 28, phase: 1, type: fix, status: done, gate: G1, title: "Remove continue-on-error from build.yml"}
+  - {id: PR-18, issue: 29, phase: 2, type: feat, status: done, title: "Add .github/workflows/roadmap-sync.yml"}
   - {id: PR-19, issue: 30, phase: 2, type: feat, status: todo, title: "Add .github/workflows/pr-link.yml"}
   - {id: PR-20, issue: 31, phase: 2, type: docs, status: todo, title: "Add .claude/skills/issue-sync skill"}
   - {id: PR-21, issue: 32, phase: 2, type: chore, status: todo, title: "Create label taxonomy"}

--- a/infra/scripts/roadmap-sync.sh
+++ b/infra/scripts/roadmap-sync.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 #
-# Roadmap sync - reconciles docs/roadmap/roadmap.yaml into GitHub Issues and the Project v2
-# board. The YAML is the machine source of truth; this script moves the world toward it.
+# Roadmap sync - reconciles docs/roadmap/roadmap.yaml into GitHub Issues, their Milestones,
+# and the Project v2 board. The YAML is the machine source of truth; this script moves the
+# world toward it.
+#
+# Three passes, in descending order of how reliably they can run:
+#   issue state  - REST, ambient token. Always runs.
+#   milestone    - REST, ambient token. Always runs. `phase: N` maps to milestone "Phase N".
+#   board        - GraphQL, needs a project scope no available token has yet (P-1). Guarded.
 #
 # Reconciling, not appending: every action is derived from the difference between the file
 # and the platform, so running it twice changes nothing the second time. That property is
@@ -60,10 +66,15 @@ if ! command -v gh >/dev/null 2>&1; then
   DRY_RUN=1
 fi
 
+# project_sync_enabled governs the PROJECT BOARD, and nothing else. It used to force a global
+# dry run, which made the issue and milestone passes unreachable while P-1 is open - a
+# decorative automation of exactly the kind `continue-on-error` made of CI before PR-17.
+# Issues and milestones need only the ambient token, so they run regardless.
 sync_enabled="$(sed -n 's/^project_sync_enabled:[[:space:]]*//p' "$ROADMAP" | head -1)"
 if [ "$sync_enabled" != "true" ]; then
-  say "${YELLOW}note${RESET} project_sync_enabled is '${sync_enabled:-unset}' in $ROADMAP - dry run."
-  DRY_RUN=1
+  say "${YELLOW}note${RESET} project_sync_enabled is '${sync_enabled:-unset}' in $ROADMAP - board sync off."
+  say "     Issue state and milestones still reconcile."
+  BOARD_ENABLED=0
 fi
 
 [ "$DRY_RUN" = "1" ] && say "${YELLOW}note${RESET} dry run: nothing will be written."
@@ -79,6 +90,32 @@ steps_raw="$(sed -n '/^steps:/,/^[a-z_]*:/p' "$ROADMAP" | sed -n 's/^[[:space:]]
 
 total="$(printf '%s\n' "$steps_raw" | wc -l | tr -d ' ')"
 say "roadmap-sync: $total step(s) in $ROADMAP, repo $REPO"
+
+# ---------------------------------------------------------------------------------------
+# Resolve the phase -> milestone map
+# ---------------------------------------------------------------------------------------
+# Phase is tracked by native GitHub Milestones titled "Phase N - ...", not by a phase: label
+# and not by a Project v2 field. Milestones are plain REST and writable with the ambient
+# token, so this pass sits OUTSIDE the board guard below: gating it on GUARDYN_PROJECT_TOKEN
+# would make it dead code for a reason (P-1) that only applies to the Project v2 GraphQL API.
+#
+# A repository with no such milestones is a documented state, not an error - say so and let
+# the issue pass run alone.
+MILESTONE_MAP=""
+if command -v gh >/dev/null 2>&1; then
+  MILESTONE_MAP="$(gh api "repos/$REPO/milestones?state=all" --paginate \
+    --jq '.[] | select(.title | test("^Phase [0-9]+ ")) |
+          "\(.title | capture("^Phase (?<p>[0-9]+) ").p)\t\(.number)"' 2>/dev/null)"
+fi
+
+if [ -z "$MILESTONE_MAP" ]; then
+  say "${YELLOW}note${RESET} no \"Phase N\" milestone found in $REPO - milestone pass skipped."
+else
+  say "milestones: $(printf '%s\n' "$MILESTONE_MAP" | wc -l | tr -d ' ') phase milestone(s) resolved"
+fi
+
+# phase number -> milestone number. Empty output means "no milestone for this phase".
+milestone_for() { printf '%s\n' "$MILESTONE_MAP" | awk -F'\t' -v p="$1" '$1 == p { print $2; exit }'; }
 
 # ---------------------------------------------------------------------------------------
 # Reconcile issues
@@ -100,13 +137,18 @@ while IFS= read -r step; do
   want_state="open"
   [ "$status" = "done" ] && want_state="closed"
 
+  want_ms="$(milestone_for "$phase")"
+
   if [ "$DRY_RUN" = "1" ]; then
-    say "  $id -> #$issue want=$want_state phase=$phase"
+    say "  $id -> #$issue want=$want_state phase=$phase milestone=${want_ms:-none}"
     skipped=$((skipped + 1))
     continue
   fi
 
-  have="$(gh api "repos/$REPO/issues/$issue" --jq '.state' 2>/dev/null)"
+  # One read serves both passes. `0` stands for "no milestone", which no real milestone
+  # number can collide with, so it compares safely against an empty want_ms.
+  read -r have have_ms <<<"$(gh api "repos/$REPO/issues/$issue" \
+    --jq '"\(.state) \(.milestone.number // 0)"' 2>/dev/null)"
   if [ -z "$have" ]; then
     bad "$id references #$issue which does not exist"
     continue
@@ -127,6 +169,17 @@ while IFS= read -r step; do
     else
       bad "$id #$issue could not be reopened"
     fi
+  fi
+
+  # Milestone. Written only on mismatch, so the second run of any pair reports `same`.
+  if [ -z "$want_ms" ]; then
+    :
+  elif [ "$have_ms" = "$want_ms" ]; then
+    noop "$id #$issue already on milestone $want_ms"
+  elif gh api -X PATCH "repos/$REPO/issues/$issue" -F milestone="$want_ms" >/dev/null 2>&1; then
+    ok "$id #$issue moved to milestone $want_ms"
+  else
+    bad "$id #$issue could not be moved to milestone $want_ms"
   fi
 done <<<"$steps_raw"
 


### PR DESCRIPTION
Phase tracking moved to native GitHub Milestones: four created, 62 issues and 28 pull
requests assigned. This teaches `roadmap-sync` about them, and corrects the roadmap data it
reads.

## The milestone pass

`phase: N` in a step selects the milestone titled `Phase N - ...`. The map is resolved once
from `GET /repos/:repo/milestones`, then each step's issue is PATCHed **only when its current
milestone differs** - the same reconcile-don't-append property the issue pass already has.
State and milestone come from a single API call per issue, so the pass costs no extra round
trip.

## `project_sync_enabled` now gates the board alone

It previously forced a **global** dry run. That would have left both the issue pass and this
new milestone pass unreachable for as long as **P-1** stays open — decorative automation of
exactly the kind `continue-on-error` made of CI before PR-17. Milestones and issues are plain
REST and need only the ambient token; only the Project v2 half needs a scope no available
token has. So the flag now sets `BOARD_ENABLED=0` and nothing else.

## The data was going to reopen thirteen issues

`roadmap.yaml` still marked PR-06 … PR-18 `status: todo` after those issues had closed and
merged. The script reconciles issue state *from* the file, so the first write-mode run would
have **reopened #17-#29**. Statuses now match the platform, and `RUNBOOK.md` states the
invariant to check before anyone flips the sync flag.

## Verification

Ran against the live repository. The write path was tested by deliberately clearing the
milestone on #30 and watching it repair:

```
sync PR-19 #30 moved to milestone 2
roadmap-sync: 1 changed, 91 already correct, 0 failed     <- repairs
roadmap-sync: 0 changed, 92 already correct, 0 failed     <- idempotent
```

No issue in #12-#29 was reopened (checked, count 0). `just docs-verify` passes all five
checks, including impact — `infra/scripts/` maps to `docs/ops/RUNBOOK.md`, which is updated
here.

## Out of scope

Reconciling `type:` and `gate:` labels — this script reconciles issue **state** and
**milestone**, nothing else. Deleting the redundant `phase:*` labels is PR-21 (#32). The
Project v2 board half remains blocked on P-1 and is untouched.

**Budget:** 3 files, +88 / -29 = 117 lines. Inside the 400-line / 8-file ceiling.

Closes #121