### PR TITLE
Retire the phase labels in favour of milestones (PR-21)

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -44,6 +44,11 @@ micro-steps across four phases, each ending at an approval gate.
 Phases 1 and 2 touch no source code. Phase 3 carries the security-critical work. Phase 4
 closes invariant I-3.
 
+Each phase is a **GitHub Milestone** titled `Phase N — …`, naming its gate. That is the only
+place phase is recorded: the `phase:1`…`phase:4` labels were retired in PR-21, and the custom
+`Phase` field on the Project v2 board goes with them. One fact, one encoding — and the
+milestone is the encoding that gives a progress bar and a board grouping without maintenance.
+
 ## The two unmet invariants
 
 Stated first, because they are the most important facts about the current state and the
@@ -74,5 +79,12 @@ they can be revised without a documentation change.
 <https://github.com/orgs/guardyn/projects/3> cannot be read or written by any token
 available to CI: the fine-grained PAT is rejected outright by the organization, and the
 fallback OAuth token lacks `read:project`. Until a token with `repo` + `project` scope
-exists as the repository secret `GUARDYN_PROJECT_TOKEN`, roadmap-to-board sync (PR-18)
-ships guarded and inert. This needs a human.
+exists as the repository secret `GUARDYN_PROJECT_TOKEN`, roadmap-to-**board** sync ships
+guarded and inert. This needs a human.
+
+The blast radius is smaller than it was. Issue state and milestones are plain REST and
+reconcile with the ambient token, so `roadmap-sync` and `pr-link` both do real work today;
+only the Project v2 half waits. Two board operations remain manual regardless of the token:
+deleting the `Phase` field, and grouping the board view by Milestone — GitHub's
+`updateProjectV2View` mutation accepts a name, layout, filter and visible fields, but has no
+input for grouping.

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -376,17 +376,26 @@ phases:
 ```
 
 - **PR-18** — `.github/workflows/roadmap-sync.yml`. On push to `main` touching `roadmap.yaml`,
-  reconcile Issues (create / retitle / relabel / close with `state_reason`) and upsert
-  Project v2 `Status` / `Phase` fields via GraphQL. **Idempotent** — reconciles toward desired
-  state, never blindly appends. Writes `issue:` / `pr:` ids back to `roadmap.yaml` in a bot
-  commit. **Guarded:** if `GUARDYN_PROJECT_TOKEN` is unset (P-1), log a warning and `exit 0`.
+  reconcile Issues (close with `state_reason`, reopen) and their **milestones**, then the
+  Project v2 board. **Idempotent** — reconciles toward desired state, never blindly appends.
+  **Guarded:** `project_sync_enabled` gates the board half alone; issue state and milestones
+  are plain REST and reconcile with the ambient token.
 - **PR-19** — `.github/workflows/pr-link.yml`. On PR open, parse the issue id from the branch
-  name, link PR ↔ Issue, move the Project card to `In Review`; on merge → `Done`.
+  name, add `Closes #N` when absent, and set the issue's milestone on the PR. The board move
+  (`In Review` → `Done`) is a guarded stub while P-1 is open.
 - **PR-20** — `.claude/skills/issue-sync/SKILL.md`: the agent's local path. Edit
   `roadmap.yaml`, run `just roadmap-sync`. **Never touch the board by hand.**
-- **PR-21** — Label taxonomy. The repo currently has only the 9 GitHub defaults, 1 open issue,
-  and no milestones. Add: `phase:1`…`phase:4`, `type:{feat,fix,docs,refactor,chore,security}`,
-  `gate:G1`…`gate:G4`, `docs-impact:none`, `blocked`.
+- **PR-21** — Label taxonomy, **then its correction**. The taxonomy shipped early during board
+  bootstrap: `type:{feat,fix,docs,refactor,chore,security}`, `gate:G1`…`gate:G4`,
+  `docs-impact:none`, `blocked`. The `phase:1`…`phase:4` labels it also created are
+  **retired**: phase is now tracked by native GitHub **Milestones**, and a label encoding the
+  same fact is a second source of truth that nothing keeps in sync.
+
+**Phase tracking is a milestone, not a label or a board field.** Four milestones titled
+`Phase N — …`, one per phase, each naming its gate. A step's `phase: N` in `roadmap.yaml`
+selects one. This replaces both the `phase:*` labels and the custom `Phase` field the brief
+put on the Project v2 board — three encodings of one fact, of which only the milestone gives
+a progress bar and a native board grouping for free.
 
 **Result:** the human architect sees exact project state on the board at all times, with zero
 manual maintenance. Every phase maps 1:1 to tracked tickets.


### PR DESCRIPTION
The label taxonomy PR-21 was written to create **already shipped**, early during board
bootstrap — issue #32 says so itself. Its remaining work is therefore the correction.

## What changed on the platform

`phase:1` … `phase:4` are **deleted**. Phase is now tracked by four native GitHub Milestones
(62 issues and 28 PRs assigned), so the labels encoded the same fact a second time with
nothing keeping the two in sync.

Kept, because none of them duplicates a native field: `gate:G1`…`gate:G4`, `type:*`,
`blocked`, `docs-impact:none`.

## Checked before deleting

- Every issue carrying a phase label had the **matching** milestone — the cross-check returned
  empty, so no information was lost.
- Nothing consumed the labels: no workflow, no issue template, no script.

## Three encodings of one fact, now one

| Encoding | Fate |
|---|---|
| `phase:N` label | deleted here |
| custom `Phase` field on Project v2 | to be deleted — **blocked by P-1**, hand-back step |
| **Milestone `Phase N — …`** | the one that stays |

Only the milestone gives a progress bar and a native board grouping without maintenance.

## Docs

`implementation_plan.md` §5.1 described PR-18/19/21 as they were specified, not as they
shipped; it now matches the code. `ROADMAP.md` states where phase lives, and records something
worth knowing for whoever picks up P-1: **grouping the board view by Milestone cannot be
automated at all** — `updateProjectV2View` takes a name, layout, filter and visible fields,
and has no input for grouping. That one is manual whatever the token.

**Budget:** 2 files, +31 −10 = 41 lines.

Closes #32