### PR TITLE
Execute the code-style predicates (PR-22)

### DIFF
--- a/.claude/rules/20-code-style.md
+++ b/.claude/rules/20-code-style.md
@@ -52,7 +52,8 @@ echo "RS-UNWRAP";  git ls-files 'backend/crates/*/src/*.rs' 'backend/crates/*/sr
                        done
 echo "RS-UNSAFE";  grep -rln 'unsafe ' --include='*.rs' backend/crates/*/src | grep -vE 'crypto-ffi|/ffi'
 echo "RS-FMT";     cargo fmt --all --manifest-path backend/Cargo.toml -- --check
-echo "PROTO-EDIT"; git diff --name-only origin/main...HEAD | grep -E '/(generated|proto)/.*\.rs$'
+echo "PROTO-EDIT"; git diff --name-only --diff-filter=d origin/main...HEAD \
+                     | grep -E '/(generated|proto)/.*\.rs$'
 echo "LANG-MD";    git grep -lIP '[\x{0400}-\x{04FF}]' -- '*.md' | grep -v 'copilot-commit-message'
 echo "NAME-SH";    git ls-files '*.sh' | xargs -n1 basename | grep -vE '^[a-z0-9-]+\.sh$'
 echo "NAME-RS";    git ls-files '*.rs' | grep -vE '/(generated|proto)/' \

--- a/.claude/rules/20-code-style.md
+++ b/.claude/rules/20-code-style.md
@@ -12,20 +12,37 @@ Predicates for [`AGENTS.md`](../../AGENTS.md) §3 (language), §5 (code), §6 (d
 §7 (file organization). AGENTS.md carries the prose and the `ErrorCode` table; this file
 carries only what a machine can check.
 
-**Convention: every check prints its violations. Empty output means PASS.**
+**These predicates are executed, not merely stated.** `just rules-verify` runs them, and
+[`rules.yml`](../../.github/workflows/rules.yml) runs it on every pull request. The script
+[`infra/scripts/rules-verify.sh`](../../infra/scripts/rules-verify.sh) is the authority; the
+greps below are the same checks written out, kept because a predicate you cannot read is a
+predicate you cannot argue with.
 
-| ID | Predicate | Today |
-|---|---|---|
-| `RS-UNWRAP` | No `unwrap()` / `expect()` in non-test Rust | FAIL — 52 in 25 files, PR-22 |
-| `RS-UNSAFE` | No `unsafe` outside an FFI crate | PASS |
-| `RS-FMT` | `cargo fmt` is clean | see `build.yml` |
-| `RS-CLIPPY` | `cargo clippy -- -D warnings` is clean | masked until PR-17 |
-| `PROTO-EDIT` | Generated protobuf is never hand-edited | PASS |
-| `LANG-MD` | No Cyrillic in Markdown outside the one allowlisted file | PASS |
-| `NAME-SH` | Scripts are `kebab-case.sh` | FAIL — 5 files |
-| `NAME-RS` | Rust files are `snake_case.rs` | PASS |
-| `ORG-ROOT` | Only the 8 permitted root Markdown files exist | PASS |
-| `ORG-LOCAL` | No tracked file links into `_local/` | FAIL — `CHANGELOG.md:55` |
+| ID | Predicate | Today | Enforcement |
+|---|---|---|---|
+| `RS-UNWRAP` | No `unwrap()` / `expect()` in non-test Rust | FAIL — 52 in 25 files | ratchet at 52 |
+| `RS-UNSAFE` | No `unsafe` outside an FFI crate | PASS | hard fail |
+| `RS-FMT` | `cargo fmt` is clean | PASS | `build.yml` |
+| `RS-CLIPPY` | `cargo clippy -- -D warnings` is clean | PASS | `build.yml`, real since PR-17 |
+| `PROTO-EDIT` | Generated protobuf is never hand-edited | PASS | hard fail |
+| `LANG-MD` | No Cyrillic in Markdown outside the one allowlisted file | PASS | hard fail |
+| `NAME-SH` | Scripts are `kebab-case.sh` | FAIL — 5 files | ratchet at 5 |
+| `NAME-RS` | Rust files are `snake_case.rs` | PASS | hard fail |
+| `ORG-ROOT` | Only the 8 permitted root Markdown files exist | PASS | hard fail |
+| `ORG-LOCAL` | No tracked file links into `_local/` | PASS | hard fail |
+
+`RS-FMT` and `RS-CLIPPY` stay in `build.yml`: they need a Rust toolchain, and `rules-verify`
+deliberately needs nothing but bash, git and awk.
+
+## Ratchets, not warnings
+
+`RS-UNWRAP` and `NAME-SH` fail today, and fixing them is owned work rather than this file's.
+Each therefore carries a **budget equal to its measured count**: the build fails the moment
+the number *grows*. Existing debt is frozen, new debt is impossible, and every fix lowers the
+ceiling — the budget is edited down in the same PR that removes a site.
+
+A warning nobody has to act on is how `continue-on-error` made CI decorative before PR-17.
+A ratchet cannot be scrolled past.
 
 ```sh
 echo "RS-UNWRAP";  git ls-files 'backend/crates/*/src/*.rs' 'backend/crates/*/src/**/*.rs' \
@@ -42,8 +59,16 @@ echo "NAME-RS";    git ls-files '*.rs' | grep -vE '/(generated|proto)/' \
                      | xargs -n1 basename | grep -vE '^[a-z0-9_]+\.rs$'
 echo "ORG-ROOT";   git ls-files -- '*.md' | grep -v / \
                      | grep -vE '^(README|AGENTS|CLAUDE|CONTRIBUTING|CHANGELOG|SECURITY|CODE_OF_CONDUCT|implementation_plan)\.md$'
-echo "ORG-LOCAL";  git grep -lI '](.*_local/' -- '*.md'
+echo "ORG-LOCAL";  git grep -lI '](.*_local/' -- '*.md' | grep -v '^\.claude/rules/'
 ```
+
+`ORG-LOCAL` excludes `.claude/rules/` because the line above *contains the pattern it
+searches for* — this file matches itself. Same reason `LANG-MD` allowlists the policy file
+that lists the forbidden alphabets: a rule may state its own violation.
+
+The `CHANGELOG.md:55` instance this predicate was written for is **gone**. The one surviving
+mention of `_local/` in `CHANGELOG.md` is prose in backticks, not a Markdown link, so it never
+matched.
 
 ## Exceptions that are not violations
 

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -1,0 +1,47 @@
+name: rules
+
+# The predicates of .claude/rules/20-code-style.md, executed. They have been stated as
+# testable predicates since PR-05 with nothing behind them; this is the mechanism.
+#
+# Runs on every pull request, not on a path filter. NAME-SH, ORG-ROOT, LANG-MD and ORG-LOCAL
+# are repository-wide properties, so a filter on backend/** - the one build.yml carries -
+# would leave them unenforced for exactly the changes most likely to break them.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - '.claude/rules/**'
+      - 'infra/scripts/rules-verify.sh'
+      - '.github/workflows/rules.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rules-verify:
+    name: rules-verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # PROTO-EDIT diffs the branch against its base, so the history must be present.
+          fetch-depth: 0
+
+      - name: Resolve base ref
+        id: base
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run rules-verify
+        env:
+          RULES_VERIFY_BASE: ${{ steps.base.outputs.ref }}
+        run: bash infra/scripts/rules-verify.sh

--- a/Justfile
+++ b/Justfile
@@ -490,3 +490,7 @@ docs-verify:
 # Dry by default; pass 0 to write. Requires GUARDYN_PROJECT_TOKEN for the board half.
 roadmap-sync dry="1":
     @ROADMAP_SYNC_DRY_RUN={{dry}} bash infra/scripts/roadmap-sync.sh
+
+# Verify the code-style predicates of .claude/rules/20-code-style.md.
+rules-verify:
+    @bash infra/scripts/rules-verify.sh

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -97,6 +97,30 @@ carries `docs-impact:none` **with a stated reason**.
 
 Run it before pushing. It is faster than a round trip through CI.
 
+## Code-style verification
+
+```sh
+just rules-verify
+```
+
+The predicates of [`.claude/rules/20-code-style.md`](../../.claude/rules/20-code-style.md),
+executed. They had been stated as testable predicates since PR-05 with nothing running them.
+[`rules.yml`](../../.github/workflows/rules.yml) runs it on **every** pull request - not on a
+path filter, because `NAME-SH`, `ORG-ROOT`, `LANG-MD` and `ORG-LOCAL` are repository-wide
+properties and a `backend/**` filter would leave them unenforced for exactly the changes most
+likely to break them.
+
+Bash, git and awk only, so the job needs no toolchain and finishes in seconds. `cargo fmt` and
+`cargo clippy` stay in `build.yml`, where a Rust toolchain already exists.
+
+**Two predicates are ratcheted rather than enforced.** `RS-UNWRAP` (52 sites) and `NAME-SH`
+(5 files) fail today and are owned by later work, so each carries a budget equal to its
+measured count: the build fails when the number **grows**, and every fix lowers the ceiling.
+
+If `rules-verify` fails on a ratchet you did not mean to touch, you added a site. If it tells
+you the count is *down*, lower the budget in the same PR - the number is a claim about the
+repository, and a stale one is worse than none.
+
 ## Roadmap and board sync
 
 [`roadmap.yaml`](../roadmap/roadmap.yaml) is the machine source of truth. `roadmap-sync`

--- a/infra/scripts/rules-verify.sh
+++ b/infra/scripts/rules-verify.sh
@@ -106,7 +106,11 @@ check_proto_edit() {
     warn "PROTO-EDIT: $BASE is not available - skipped"
     return
   fi
-  hits="$(git diff --name-only "$BASE"...HEAD | grep -E '/(generated|proto)/.*\.rs$' || true)"
+  # --diff-filter=d excludes deletions. The predicate forbids hand-EDITING generated code;
+  # deleting it is the opposite - PR-23 removes 13 such files, and flagging that as a
+  # violation would have made the predicate fire on the change that satisfies ADR-0008.
+  hits="$(git diff --name-only --diff-filter=d "$BASE"...HEAD \
+    | grep -E '/(generated|proto)/.*\.rs$' || true)"
   if [ -n "$hits" ]; then
     fail "PROTO-EDIT: generated protobuf edited by hand - change the .proto and regenerate"
     show "$hits"

--- a/infra/scripts/rules-verify.sh
+++ b/infra/scripts/rules-verify.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Code-style verification - the predicates of .claude/rules/20-code-style.md, executable.
+# Run via `just rules-verify`.
+#
+# The rules file has stated these as testable predicates since PR-05, but nothing ran them,
+# so they were prose with a table for a hat. This is the mechanism behind them.
+#
+#   RS-UNWRAP    no unwrap()/expect() in non-test Rust          ratcheted
+#   RS-UNSAFE    no `unsafe` outside an FFI crate
+#   PROTO-EDIT   generated protobuf is never hand-edited
+#   LANG-MD      no Cyrillic in Markdown outside the allowlist
+#   NAME-SH      scripts are kebab-case.sh                      ratcheted
+#   NAME-RS      Rust files are snake_case.rs
+#   ORG-ROOT     only the 8 permitted root Markdown files exist
+#   ORG-LOCAL    no tracked file links into _local/
+#
+# RS-FMT and RS-CLIPPY are deliberately absent: build.yml already runs `cargo fmt --check`
+# and `cargo clippy -- -D warnings`, and since PR-17 both actually fail the build. Repeating
+# them here would mean a Rust toolchain in a job that otherwise needs none.
+#
+# Ratchets, not warnings. RS-UNWRAP and NAME-SH fail today - 52 sites and 5 files - and
+# fixing them is owned work, not this step's. A warning everyone learns to scroll past is
+# how `continue-on-error` made CI decorative before PR-17. So each carries a budget equal to
+# its measured count: the build fails the moment the number GROWS. Existing debt is frozen,
+# new debt is impossible, and every fix lowers the ceiling.
+#
+# Bash, git and awk only. I-4 makes every added runtime a cost.
+#
+# Environment:
+#   RULES_VERIFY_BASE   base ref for PROTO-EDIT's changed-file set (default: origin/main)
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+
+# Every predicate below is a git query. Without a working repository they would all return
+# nothing and the script would report "all checks passed" - a verifier that passes vacuously
+# is the same decorative CI that PR-17 removed. Refuse instead.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf "${RED}FAIL${NC} %s\n" "not inside a git work tree - every predicate would pass vacuously"
+  exit 1
+}
+
+BASE="${RULES_VERIFY_BASE:-origin/main}"
+
+# Frozen debt. These may only ever be lowered. Lower them in the same PR that removes a site.
+RS_UNWRAP_BUDGET=52
+NAME_SH_BUDGET=5
+
+failures=0
+
+fail() { printf "${RED}FAIL${NC} %s\n" "$1"; failures=$((failures + 1)); }
+pass() { printf "${GREEN}ok${NC}   %s\n" "$1"; }
+warn() { printf "${YELLOW}warn${NC} %s\n" "$1"; }
+
+# Print the offending lines, indented, so a failure is actionable without a second command.
+show() { printf '%s\n' "$1" | sed 's/^/       /'; }
+
+# A ratcheted predicate: fail when the count exceeds its frozen budget, note when it drops.
+ratchet() {
+  local id="$1" budget="$2" hits="$3" n
+  n="$(printf '%s' "$hits" | grep -c . || true)"
+  if [ "$n" -gt "$budget" ]; then
+    fail "$id: $n site(s), budget $budget - this change adds $((n - budget))"
+    show "$hits"
+  elif [ "$n" -lt "$budget" ]; then
+    pass "$id: $n site(s), down from $budget - lower the budget in this PR"
+  else
+    warn "$id: $n site(s), at the frozen budget - known debt, not a regression"
+  fi
+}
+
+# ---------------------------------------------------------------- RS-UNWRAP
+check_rs_unwrap() {
+  local hits
+  # Everything from the first #[cfg(test)] onward is test code, where unwrap is idiomatic.
+  hits="$(git ls-files 'backend/crates/*/src/*.rs' 'backend/crates/*/src/**/*.rs' \
+    | grep -v '/generated/' \
+    | while IFS= read -r f; do
+        sed '/#\[cfg(test)\]/,$d' "$f" | grep -nE '\.(unwrap|expect)\(' | sed "s|^|$f:|"
+      done)"
+  ratchet RS-UNWRAP "$RS_UNWRAP_BUDGET" "$hits"
+}
+
+# ---------------------------------------------------------------- RS-UNSAFE
+check_rs_unsafe() {
+  local hits
+  hits="$(grep -rln 'unsafe ' --include='*.rs' backend/crates/*/src 2>/dev/null \
+    | grep -vE 'crypto-ffi|/ffi' || true)"
+  if [ -n "$hits" ]; then
+    fail "RS-UNSAFE: unsafe outside an FFI crate"
+    show "$hits"
+  else
+    pass "RS-UNSAFE: no unsafe outside an FFI crate"
+  fi
+}
+
+# ---------------------------------------------------------------- PROTO-EDIT
+check_proto_edit() {
+  local hits
+  if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+    warn "PROTO-EDIT: $BASE is not available - skipped"
+    return
+  fi
+  hits="$(git diff --name-only "$BASE"...HEAD | grep -E '/(generated|proto)/.*\.rs$' || true)"
+  if [ -n "$hits" ]; then
+    fail "PROTO-EDIT: generated protobuf edited by hand - change the .proto and regenerate"
+    show "$hits"
+  else
+    pass "PROTO-EDIT: no generated protobuf hand-edited"
+  fi
+}
+
+# ---------------------------------------------------------------- LANG-MD
+check_lang_md() {
+  local hits
+  hits="$(git grep -lIP '[\x{0400}-\x{04FF}]' -- '*.md' 2>/dev/null \
+    | grep -v 'copilot-commit-message' || true)"
+  if [ -n "$hits" ]; then
+    fail "LANG-MD: Cyrillic in Markdown outside the allowlist"
+    show "$hits"
+  else
+    pass "LANG-MD: no Cyrillic in Markdown outside the allowlist"
+  fi
+}
+
+# ---------------------------------------------------------------- NAME-SH
+check_name_sh() {
+  local hits
+  hits="$(git ls-files '*.sh' | xargs -n1 basename | grep -vE '^[a-z0-9-]+\.sh$' || true)"
+  ratchet NAME-SH "$NAME_SH_BUDGET" "$hits"
+}
+
+# ---------------------------------------------------------------- NAME-RS
+check_name_rs() {
+  local hits
+  hits="$(git ls-files '*.rs' | grep -vE '/(generated|proto)/' \
+    | xargs -n1 basename | grep -vE '^[a-z0-9_]+\.rs$' || true)"
+  if [ -n "$hits" ]; then
+    fail "NAME-RS: Rust files must be snake_case.rs"
+    show "$hits"
+  else
+    pass "NAME-RS: every Rust file is snake_case.rs"
+  fi
+}
+
+# ---------------------------------------------------------------- ORG-ROOT
+check_org_root() {
+  local hits
+  hits="$(git ls-files -- '*.md' | grep -v / \
+    | grep -vE '^(README|AGENTS|CLAUDE|CONTRIBUTING|CHANGELOG|SECURITY|CODE_OF_CONDUCT|implementation_plan)\.md$' || true)"
+  if [ -n "$hits" ]; then
+    fail "ORG-ROOT: only the 8 permitted root Markdown files may exist"
+    show "$hits"
+  else
+    pass "ORG-ROOT: only the 8 permitted root Markdown files exist"
+  fi
+}
+
+# ---------------------------------------------------------------- ORG-LOCAL
+check_org_local() {
+  local hits
+  # .claude/rules/ is excluded because it *documents* this predicate: the grep that defines
+  # the check contains the pattern it searches for, so the rules file matches itself. Same
+  # reason LANG-MD allowlists the policy file that lists the forbidden alphabets.
+  hits="$(git grep -lI '](.*_local/' -- '*.md' 2>/dev/null \
+    | grep -v '^\.claude/rules/' || true)"
+  if [ -n "$hits" ]; then
+    fail "ORG-LOCAL: a tracked document links into _local/, which is gitignored"
+    show "$hits"
+  else
+    pass "ORG-LOCAL: no tracked document links into _local/"
+  fi
+}
+
+echo "rules-verify (base: $BASE)"
+check_rs_unwrap
+check_rs_unsafe
+check_proto_edit
+check_lang_md
+check_name_sh
+check_name_rs
+check_org_root
+check_org_local
+
+if [ "$failures" -gt 0 ]; then
+  printf "\n${RED}%d check(s) failed${NC}\n" "$failures"
+  exit 1
+fi
+printf "\n${GREEN}all checks passed${NC}\n"

--- a/infra/scripts/rules-verify.sh
+++ b/infra/scripts/rules-verify.sh
@@ -135,7 +135,7 @@ check_lang_md() {
 # ---------------------------------------------------------------- NAME-SH
 check_name_sh() {
   local hits
-  hits="$(git ls-files '*.sh' | xargs -n1 basename | grep -vE '^[a-z0-9-]+\.sh$' || true)"
+  hits="$(git ls-files '*.sh' | xargs -r -n1 basename | grep -vE '^[a-z0-9-]+\.sh$' || true)"
   ratchet NAME-SH "$NAME_SH_BUDGET" "$hits"
 }
 
@@ -143,7 +143,7 @@ check_name_sh() {
 check_name_rs() {
   local hits
   hits="$(git ls-files '*.rs' | grep -vE '/(generated|proto)/' \
-    | xargs -n1 basename | grep -vE '^[a-z0-9_]+\.rs$' || true)"
+    | xargs -r -n1 basename | grep -vE '^[a-z0-9_]+\.rs$' || true)"
   if [ -n "$hits" ]; then
     fail "NAME-RS: Rust files must be snake_case.rs"
     show "$hits"


### PR DESCRIPTION
`.claude/rules/20-code-style.md` has stated ten testable predicates since PR-05. Nothing ran
them — `grep -rn 'RS-UNWRAP' .github/ Justfile` was empty. The gap was enforcement, not
authorship, so this ships the mechanism rather than more prose.

`just rules-verify`, wired by [`rules.yml`](.github/workflows/rules.yml) to **every** pull
request.

## Ratchets, not warnings

`RS-UNWRAP` (52 sites in 25 files) and `NAME-SH` (5 files) fail today, and fixing them is
owned work rather than this step's. A `continue-on-error`-style warning is what made CI
decorative before PR-17, so instead each carries a **budget equal to its measured count**:

```
budget 51, actual 52  ->  FAIL  RS-UNWRAP: 52 site(s), budget 51 - this change adds 1   (exit 1)
budget 52, actual 52  ->  warn  at the frozen budget - known debt, not a regression     (exit 0)
budget 53, actual 52  ->  ok    down from 53 - lower the budget in this PR              (exit 0)
```

Existing debt is frozen, new debt is impossible, every fix lowers the ceiling. All three
directions were tested.

## Not on a path filter

`NAME-SH`, `ORG-ROOT`, `LANG-MD` and `ORG-LOCAL` are repository-wide properties. The
`backend/**` filter `build.yml` carries would leave them unenforced for precisely the changes
most likely to break them. `RS-FMT` and `RS-CLIPPY` stay in `build.yml` where a Rust toolchain
already exists; this job needs only bash, git and awk, and finishes in seconds.

## It refuses to pass vacuously

Every predicate is a git query. Run outside a work tree they all return nothing and the script
reports **"all checks passed"** — the exact defect it exists to prevent. Found by running it
from the wrong directory during development; it now fails fast instead.

## Two stale entries in the rules table, corrected

- **`ORG-LOCAL`** was recorded as `FAIL — CHANGELOG.md:55`. That defect is **gone**: the one
  surviving `_local/` mention in `CHANGELOG.md` is prose in backticks, never a Markdown link,
  so it never matched. The predicate's only remaining hit was the rules file quoting the grep
  that *defines* it — the file matches itself. `.claude/rules/` is now excluded, the same way
  `LANG-MD` allowlists the policy file that lists the forbidden alphabets.
- **`RS-CLIPPY`** was `masked until PR-17`. PR-17 landed.

## Verified

```
warn RS-UNWRAP: 52 site(s), at the frozen budget - known debt, not a regression
ok   RS-UNSAFE / PROTO-EDIT / LANG-MD / NAME-RS / ORG-ROOT / ORG-LOCAL
warn NAME-SH:   5 site(s), at the frozen budget - known debt, not a regression
```

A deliberately introduced `BadName.rs` was caught by `NAME-RS`, with the offending path
printed. `just docs-verify` passes all five checks — `infra/scripts/` maps to `RUNBOOK.md`,
updated here.

## Out of scope

The predicates in `00-invariants.md` and `30-zk-logging.md` — the `ZK-*`, `E2EE-*`, `PQ-*` and
`SOV-*` families. They are the higher-value checks and deserve the same treatment, but they
belong to owned steps (PR-26, PR-32, PR-36…PR-40) and folding them in here would break the
micro-step contract. Worth its own issue after G2.

**Budget:** 5 files, +308 −14 = 322 lines.

Closes #33