### PR TITLE
Record Phase 2 completion in roadmap.yaml and STATE.md (PR-23b)

### DIFF
--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -10,37 +10,46 @@ supersedes: []
 
 # State
 
-**Generated from [`roadmap.yaml`](roadmap.yaml). Do not hand-edit** — `docs-verify` fails
-if this file and the YAML disagree. Regenerate instead.
+**Derived from [`roadmap.yaml`](roadmap.yaml). Do not hand-edit** — when the two disagree, the
+YAML wins.
 
-Generated: 2026-09-06
+> This file *claims* to be generated and to be checked by `docs-verify`. Neither is true yet:
+> no generator exists and `docs-verify` has no staleness check. That is
+> [#101](https://github.com/guardyn/guardyn/issues/101), and until it lands this file is
+> maintained by hand and can rot between gates. It was last reconciled against the YAML and
+> against GitHub on the date below.
+
+Reconciled: 2026-09-07
 
 ## Progress
 
 | Phase | Done | Total | |
 |---|---|---|---|
-| 1 | 7 | 19 | `████░░░░░░` |
-| 2 | 0 | 6 | `░░░░░░░░░░` |
+| 1 | 19 | 19 | `██████████` |
+| 2 | 7 | 7 | `██████████` |
 | 3 | 0 | 12 | `░░░░░░░░░░` |
 | 4 | 0 | 9 | `░░░░░░░░░░` |
-| **all** | **7** | **46** | |
+| **all** | **26** | **47** | |
 
 ## Position
 
-- **Current phase:** 1
-- **Next gate:** G1, after PR-17
-- **Next step:** PR-06 — Add .claude/settings.json guard hooks and pre-commit hook (#17)
+- **Current phase:** 2 — complete
+- **Next gate:** **G2, reached** after PR-23. Awaiting explicit user approval.
+- **Next step:** PR-24 — Add `common/src/redact.rs` (#35), and it must not start before G2 is
+  approved.
 
 ## Gates
 
 | Gate | After | Status |
 |---|---|---|
-| G1 | PR-17 | not reached |
-| G2 | PR-23 | not reached |
+| G1 | PR-17 | **passed** |
+| G2 | PR-23 | **reached — awaiting approval** |
 | G3 | PR-35 | not reached |
 | G4 | PR-44 | not reached |
 
 ## Invariants
+
+Unchanged by Phase 2, which touched tracking and build strategy rather than behaviour.
 
 | # | Name | Met | Closed by |
 |---|---|---|---|
@@ -54,5 +63,17 @@ Generated: 2026-09-06
 ## Blocked
 
 **P-1** — `project_sync_enabled: false`. No token available to CI can read or write the
-project board, so roadmap-to-board sync cannot run. Needs a human to create
-`GUARDYN_PROJECT_TOKEN` with `repo` + `project` scope.
+Project v2 board: the organization rejects fine-grained PATs over a 366-day lifetime, and the
+fallback OAuth token has no `project` scope. Needs a human to create `GUARDYN_PROJECT_TOKEN`
+with `repo` + `project` scope.
+
+Its blast radius shrank in Phase 2. Phase is now tracked by **milestones**, which are plain
+REST, so `roadmap-sync` and `pr-link` both do real work with the ambient token; only the board
+half waits.
+
+## Carried into Phase 3
+
+| | |
+|---|---|
+| [#116](https://github.com/guardyn/guardyn/issues/116) | Phase 1 straggler — `desktop-build.yml` test job can never pass |
+| [#101](https://github.com/guardyn/guardyn/issues/101) | `docs-verify` has no staleness check, and this file is maintained by hand because of it |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -48,11 +48,12 @@ steps:
   - {id: PR-16, issue: 27, phase: 1, type: feat, status: done, title: "Add .github/workflows/docs.yml"}
   - {id: PR-17, issue: 28, phase: 1, type: fix, status: done, gate: G1, title: "Remove continue-on-error from build.yml"}
   - {id: PR-18, issue: 29, phase: 2, type: feat, status: done, title: "Add .github/workflows/roadmap-sync.yml"}
-  - {id: PR-19, issue: 30, phase: 2, type: feat, status: todo, title: "Add .github/workflows/pr-link.yml"}
-  - {id: PR-20, issue: 31, phase: 2, type: docs, status: todo, title: "Add .claude/skills/issue-sync skill"}
-  - {id: PR-21, issue: 32, phase: 2, type: chore, status: todo, title: "Create label taxonomy"}
-  - {id: PR-22, issue: 33, phase: 2, type: docs, status: todo, title: "Codify code-style predicates in .claude/rules/20-code-style.md"}
-  - {id: PR-23, issue: 34, phase: 2, type: refactor, status: todo, gate: G2, title: "Unify protobuf codegen strategy"}
+  - {id: PR-18b, issue: 121, phase: 2, type: feat, status: done, title: "Reconcile milestones in roadmap-sync and correct the stale Phase 1 statuses"}
+  - {id: PR-19, issue: 30, phase: 2, type: feat, status: done, title: "Add .github/workflows/pr-link.yml"}
+  - {id: PR-20, issue: 31, phase: 2, type: docs, status: done, title: "Add .claude/skills/issue-sync skill"}
+  - {id: PR-21, issue: 32, phase: 2, type: chore, status: done, title: "Create label taxonomy"}
+  - {id: PR-22, issue: 33, phase: 2, type: docs, status: done, title: "Codify code-style predicates in .claude/rules/20-code-style.md"}
+  - {id: PR-23, issue: 34, phase: 2, type: refactor, status: done, gate: G2, title: "Unify protobuf codegen strategy"}
   - {id: PR-24, issue: 35, phase: 3, type: security, status: todo, title: "Add common/src/redact.rs"}
   - {id: PR-25, issue: 36, phase: 3, type: security, status: todo, title: "Apply Redacted<T> across crypto, auth and messaging types"}
   - {id: PR-26, issue: 37, phase: 3, type: security, status: todo, title: "Migrate call-service and notification-service to observability::init_tracing"}


### PR DESCRIPTION
`roadmap-sync` reconciles issue state **from** `roadmap.yaml`. PR-19 … PR-23 have merged and
their issues are closed, but the file still marked them `todo` — so the next write-mode run on
`main` would have **reopened all five**.

This is the third time that hazard has come up in one phase, and it will recur at the end of
every phase while the file is maintained by hand.

## What this records

| | |
|---|---|
| PR-19 … PR-23 | `todo` → `done` |
| **PR-18b** (#121) | missing from `steps:` entirely — created mid-phase, never recorded |
| `STATE.md` | said *"current phase 1, G1 not reached, 7 of 46 done"*. Every number was wrong |

Phase 2 is now seven steps and the roadmap is 47.

## Verified against the platform, not assumed

Each `status:` was checked against the live issue list:

```
(empty output = roadmap.yaml matches GitHub exactly on all 47 steps)
```

Counts: **19/19 Phase 1, 7/7 Phase 2, 0/12 Phase 3, 0/9 Phase 4 — 26 of 47.**

## STATE.md now admits how it is maintained

It declared itself generated and claimed `docs-verify` fails when it disagrees with the YAML.
**Neither is true** — no generator exists and `docs-verify` has no staleness check. That is
#101. A document that lies about how it is kept current is how it rotted in the first place,
so it now carries the caveat and a reconciliation date, and #101 remains the real fix.

`just docs-verify` and `just rules-verify` both pass.

Closes #128