### PR TITLE
security(common): redact denied fields in the tracing formatter

### DIFF
--- a/backend/crates/common/src/observability.rs
+++ b/backend/crates/common/src/observability.rs
@@ -66,13 +66,24 @@ pub fn init_tracing(
     let env_filter =
         tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| log_level.into());
 
-    // JSON formatting layer for structured logs
+    // JSON formatting layer for structured logs.
+    //
+    // The event formatter is wrapped in `RedactingFormat` so that no field named
+    // on the `redact::DENIED_FIELDS` denylist can reach the writer (invariant
+    // I-1). `.fmt_fields(JsonFields)` is required because `.event_format()` sets
+    // only the event formatter, whereas the `.json()` shorthand it replaces set
+    // the field formatter too; without it, span fields regress to the `Full`
+    // formatter and emit non-JSON inside a JSON document.
     let fmt_layer = tracing_subscriber::fmt::layer()
-        .json()
-        .with_file(true)
-        .with_line_number(true)
-        .with_thread_ids(true)
-        .with_target(true);
+        .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
+        .event_format(crate::redact::RedactingFormat::new(
+            tracing_subscriber::fmt::format()
+                .json()
+                .with_file(true)
+                .with_line_number(true)
+                .with_thread_ids(true)
+                .with_target(true),
+        ));
 
     // Try to initialize OpenTelemetry if endpoint is provided
     let provider = if let Some(endpoint) = otlp_endpoint {

--- a/backend/crates/common/src/redact.rs
+++ b/backend/crates/common/src/redact.rs
@@ -1,24 +1,33 @@
 //! Redaction primitives for zero-knowledge logging (invariant I-1).
 //!
+//! Two independent mechanisms live here.
+//!
 //! [`Redacted<T>`] is a newtype whose `Debug` and `Display` impls emit
 //! [`REDACTED`] whatever `T` is. Wrap a field in it and the containing struct
 //! may keep `#[derive(Debug)]` without leaking that field.
 //!
-//! [`DENIED_FIELDS`] is the companion denylist of log field names whose values
-//! must never be emitted. The `tracing` formatter that enforces it consumes this
-//! list; this module supplies the vocabulary.
+//! [`RedactingFormat`] is a `tracing` event formatter that replaces the value of
+//! any field whose *name* appears in [`DENIED_FIELDS`], and records which names
+//! were hit so the incident is alertable rather than merely suppressed.
 //!
 //! `Redacted<T>`'s `Serialize` and `Deserialize` impls are deliberately
 //! **transparent**. Several crypto and messaging types derive `Serialize` for
 //! *persistence*; a redacting serializer would write `[REDACTED]` into TiKV and
 //! destroy the stored key material. This is safe because `tracing`'s JSON output
 //! never routes through `serde::Serialize` on our types — `tracing_serde`
-//! serializes whatever a `tracing::field::Visit` recorded, which is `Debug` or
+//! serializes whatever a [`tracing::field::Visit`] recorded, which is `Debug` or
 //! `Display`. Redacting those two is exactly sufficient for I-1.
 
 use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
 
 /// The placeholder substituted for every redacted value.
 pub const REDACTED: &str = "[REDACTED]";
@@ -176,9 +185,187 @@ pub fn is_denied(field_name: &str) -> bool {
         .any(|denied| denied.eq_ignore_ascii_case(field_name))
 }
 
+// =============================================================================
+// RedactingFormat
+// =============================================================================
+
+/// A `tracing` event formatter that redacts denied fields before they are written.
+///
+/// Wraps an inner [`FormatEvent`] (in this crate, the JSON formatter). Events
+/// carrying no denied field are delegated to the inner formatter untouched, so
+/// the common path is byte-for-byte identical to formatting without this wrapper.
+///
+/// This is a `FormatEvent` rather than a `Layer` because a `Layer` receives
+/// `&Event` and cannot remove or rewrite a field — the `fmt` layer downstream
+/// would re-read the original event regardless.
+pub struct RedactingFormat<F> {
+    inner: F,
+}
+
+impl<F> RedactingFormat<F> {
+    /// Wrap `inner` so that denied fields are redacted before it sees them.
+    pub const fn new(inner: F) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, N, F> FormatEvent<S, N> for RedactingFormat<F>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+    F: FormatEvent<S, N>,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let metadata = event.metadata();
+
+        // Fast path: the field set is `&'static` metadata, so this inspects names
+        // only and never touches a value.
+        if !metadata.fields().iter().any(|f| is_denied(f.name())) {
+            return self.inner.format_event(ctx, writer, event);
+        }
+
+        let mut visitor = RedactingVisitor::default();
+        event.record(&mut visitor);
+
+        let mut out = serde_json::Map::new();
+        out.insert("timestamp_ms".to_owned(), Value::from(unix_millis()));
+        out.insert(
+            "level".to_owned(),
+            Value::String(metadata.level().to_string()),
+        );
+        out.insert(
+            "target".to_owned(),
+            Value::String(metadata.target().to_owned()),
+        );
+        if let Some(file) = metadata.file() {
+            out.insert("filename".to_owned(), Value::String(file.to_owned()));
+        }
+        if let Some(line) = metadata.line() {
+            out.insert("line_number".to_owned(), Value::from(line));
+        }
+        out.insert("fields".to_owned(), Value::Object(visitor.fields));
+        out.insert(
+            "redacted".to_owned(),
+            Value::Array(visitor.redacted.into_iter().map(Value::String).collect()),
+        );
+
+        let rendered = serde_json::to_string(&out).map_err(|_| fmt::Error)?;
+        writeln!(writer, "{}", rendered)
+    }
+}
+
+/// Records event fields into a JSON map, substituting [`REDACTED`] for denied names.
+#[derive(Default)]
+struct RedactingVisitor {
+    fields: serde_json::Map<String, Value>,
+    redacted: Vec<String>,
+}
+
+impl RedactingVisitor {
+    /// Insert `field`, calling `value` only when the field is permitted.
+    fn record<V: FnOnce() -> Value>(&mut self, field: &Field, value: V) {
+        let name = field.name();
+        if is_denied(name) {
+            self.redacted.push(name.to_owned());
+            self.fields
+                .insert(name.to_owned(), Value::String(REDACTED.to_owned()));
+        } else {
+            self.fields.insert(name.to_owned(), value());
+        }
+    }
+}
+
+impl Visit for RedactingVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record(field, || Value::String(value.to_owned()));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record(field, || Value::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record(field, || Value::from(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record(field, || Value::Bool(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record(field, || Value::from(value));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.record(field, || Value::String(format!("{:?}", value)));
+    }
+}
+
+/// Milliseconds since the Unix epoch, or 0 if the clock is before it.
+///
+/// `common` has no `chrono` dependency and the redacting path is a bug detector
+/// rather than the steady state, so it carries its own timestamp key.
+fn unix_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[derive(Clone, Default)]
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for BufWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let mut guard = self
+                .0
+                .lock()
+                .map_err(|_| io::Error::other("buffer poisoned"))?;
+            guard.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for BufWriter {
+        type Writer = BufWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Run `f` under a subscriber wired exactly as `init_tracing` wires it.
+    fn capture(f: impl FnOnce()) -> String {
+        let buf = BufWriter::default();
+        let layer = tracing_subscriber::fmt::layer()
+            .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
+            .event_format(RedactingFormat::new(
+                tracing_subscriber::fmt::format()
+                    .json()
+                    .with_file(true)
+                    .with_line_number(true)
+                    .with_target(true),
+            ))
+            .with_writer(buf.clone());
+        tracing::subscriber::with_default(tracing_subscriber::registry().with(layer), f);
+        let bytes = buf.0.lock().expect("buffer poisoned").clone();
+        String::from_utf8(bytes).expect("formatter emitted invalid UTF-8")
+    }
 
     #[test]
     fn test_redacted_debug_and_display_hide_the_value() {
@@ -243,5 +430,37 @@ mod tests {
                 "{allowed} is metadata, not key material"
             );
         }
+    }
+
+    #[test]
+    fn test_denied_field_value_never_reaches_the_writer() {
+        let output = capture(|| {
+            tracing::info!(user_id = "u1", ciphertext = "TOPSECRET", "message stored");
+        });
+
+        assert!(!output.contains("TOPSECRET"), "secret leaked: {output}");
+        assert!(output.contains(REDACTED));
+        assert!(output.contains("\"ciphertext\""), "the field name is kept");
+        assert!(output.contains("u1"), "identifiers survive redaction");
+        assert!(
+            output.contains("\"redacted\":[\"ciphertext\"]"),
+            "the hit must be alertable: {output}"
+        );
+        serde_json::from_str::<Value>(output.trim()).expect("redacting path must emit valid JSON");
+    }
+
+    #[test]
+    fn test_clean_event_takes_the_fast_path_unchanged() {
+        let output = capture(|| {
+            tracing::info!(user_id = "u1", "message stored");
+        });
+
+        let parsed: Value = serde_json::from_str(output.trim()).expect("valid JSON");
+        assert_eq!(parsed["fields"]["message"], "message stored");
+        assert_eq!(parsed["fields"]["user_id"], "u1");
+        assert!(
+            parsed.get("redacted").is_none(),
+            "clean events must not gain a redacted key: {output}"
+        );
     }
 }

--- a/docs/adr/ADR-0007-zero-knowledge-logging.md
+++ b/docs/adr/ADR-0007-zero-knowledge-logging.md
@@ -41,8 +41,14 @@ Two mechanisms, shipped in `common/src/redact.rs` (PR-24):
   `tracing_serde` serializes what a `Visit` recorded, which is `Debug` or `Display`.
 - **`DENIED_FIELDS`** — the companion denylist of log field names whose values must never be
   emitted. Matching is exact and case-insensitive, never substring: a substring rule on `key`
-  would fire on `key_id`, and identifiers are metadata, not key material. The `tracing`
-  formatter that enforces this list consumes it; this module supplies the vocabulary.
+  would fire on `key_id`, and identifiers are metadata, not key material.
+- **`RedactingFormat`** — a `FormatEvent` that replaces the value of any event field named on
+  that denylist, and emits a `redacted: [names]` array so a hit is alertable rather than
+  silently swallowed. Events carrying no denied field are delegated untouched, so the common
+  path is byte-identical.
+
+It is a `FormatEvent` rather than a `Layer` because a `Layer` receives `&Event` and cannot
+remove or rewrite a field — the `fmt` layer downstream re-reads the original event regardless.
 
 ## Consequences
 
@@ -56,6 +62,10 @@ sparingly rather than dumping a request. That difficulty is the feature.
 directly (PR-26). `common/src/rate_limit.rs:241,256` log a raw client IP — PII under this
 ADR — and have **no owned step**; note the denylist cannot reach them, because they
 interpolate the IP positionally into `message` rather than naming a field.
+
+**Span fields are not yet redacted.** `RedactingFormat` covers event fields only. `JsonFields`
+overrides `add_fields` to re-parse and re-serialize, so a naive `FormatFields` emits malformed
+JSON on the six live `Span::current().record` handlers in `messaging-service`. Unowned.
 
 ## Alternatives rejected
 

--- a/docs/ops/OBSERVABILITY.md
+++ b/docs/ops/OBSERVABILITY.md
@@ -42,6 +42,27 @@ genuinely needs them, and never at `info` on a hot path.
 
 When unsure whether a field is sensitive: **do not log it.**
 
+## The redaction mechanism
+
+Two things in `guardyn_common::redact` enforce the list above rather than merely stating it.
+
+`Redacted<T>` wraps a secret field. Its `Debug`/`Display` emit `[REDACTED]` with no bound on
+`T`, so the containing struct can keep `#[derive(Debug)]` safely. `expose()` is the only way
+back out, and is named to be conspicuous in review and greppable in CI. `Serialize` is
+**transparent** — it must be, or persisted key material would be overwritten with `[REDACTED]`.
+
+`RedactingFormat` is the event formatter `init_tracing` installs. Any event field whose *name*
+is in `DENIED_FIELDS` has its value replaced, and the event gains a `redacted: [names]` array
+so the hit is alertable. Events with no denied field are delegated untouched, so the common
+path is byte-identical.
+
+Matching is **exact**, never substring — `key` is denied, `key_id` is not. Identifiers are
+metadata and remain loggable, sparingly.
+
+**Limits worth knowing.** Only *event* fields are covered; span fields are not yet redacted.
+And a positional interpolation (`warn!("Blocked IP {}", ip)`) collapses into `message` and is
+invisible to a field-name denylist — name your fields.
+
 ## Checking yourself
 
 ```sh
@@ -82,7 +103,8 @@ alertmanager configuration.
 | Gap | Consequence | Owned by |
 |---|---|---|
 | `call-service` and `notification-service` build a `FmtSubscriber` directly | two services log outside the redaction layer | PR-26 |
-| `common/src/rate_limit.rs:241,256` log a raw client IP | PII in logs — a direct I-1 breach | **unowned** |
+| `common/src/rate_limit.rs:241,256` log a raw client IP | PII in logs — a direct I-1 breach; positional, so the denylist cannot see it | **unowned** |
+| Span fields bypass `RedactingFormat` | secrets recorded via `Span::current().record` are not redacted | **unowned** |
 | The Compose observability stack is commented out, and references `./infra/observability/prometheus.yml` which does not exist | no local metrics; uncommenting it fails | PR-43 |
 | `GUARDYN_OBSERVABILITY__OTLP_ENDPOINT` is `""` for every Compose service | no traces are exported locally | PR-43 |
 | `Sampler::AlwaysOn` (`observability.rs:132`) | 100% trace sampling — fine in development, a cost and volume decision in production | PR-43 |


### PR DESCRIPTION
> **Stacked on #135.** Base is `security/35-add-redacted-newtype`, not `main`. Merge #135 first; GitHub will retarget this to `main` automatically. Reviewing against `main` will show #135's diff as well — review against the base branch.

## What

The enforcement half of PR-24. #135 landed `Redacted<T>` and `DENIED_FIELDS`; this installs the formatter that actually enforces the list, so a denied field name can no longer carry its value into a log line, and wires it into `init_tracing`.

## Design notes worth reviewing

**This is a `FormatEvent`, not a `Layer`** — a correction to the wording in `implementation_plan.md` §6.1, which describes "a `tracing` layer dropping a denylist of field names". That is not implementable: `Layer::on_event` receives `&Event<'_>` by shared reference and has no way to remove, rewrite or hide a field, and the `fmt` layer downstream re-reads the original `Event` regardless.

In tracing-subscriber 0.3, `Format<Json, T>` visits event fields itself (`fmt/format/json.rs:215,267`) and uses `N: FormatFields` only for *span* fields — so event-field redaction has to happen in the event formatter.

**The fast path is the important one.** `event.metadata().fields().iter().any(|f| is_denied(f.name()))` reads the `&'static` `FieldSet` from metadata: it inspects names only, never touches a value, and costs a few pointer comparisons. Clean events delegate straight to the inner formatter and are **byte-identical** to formatting without this wrapper. `test_clean_event_takes_the_fast_path_unchanged` is the regression guard for exactly that.

**A redacted event gains `redacted: [names]`** so the hit is alertable rather than silently swallowed. Suppressing a leak without recording that you suppressed it just moves the problem.

**The `observability.rs` hook needs `.fmt_fields(JsonFields::new())` explicitly.** `.json()` on the *layer* sets the event format **and** the field format together; `.event_format()` sets only the former. Without the explicit `.fmt_fields(...)`, span fields regress to the `Full` formatter and emit non-JSON inside a JSON document.

`fmt_layer` is built once at `observability.rs:70-75` and moved into three exclusive `.init()` branches, so this is a **single** edit site — the three `.init()` calls are untouched.

## Verification

- `cargo clippy -p guardyn-common --all-targets -- -D warnings` ✅
- `cargo test -p guardyn-common` — 21 passed, plus the doctest ✅
- `cargo fmt --all -- --check` ✅
- `just rules-verify` ✅ (`RS-UNWRAP` 52, `NAME-SH` 5 — unmoved)
- `just docs-verify` ✅

The two tests that carry the security claim: a denied value emits no substring of itself and the event is still valid JSON; a clean event gains no `redacted` key and keeps its normal shape.

`docs/ops/OBSERVABILITY.md` and `ADR-0007` are updated here, as `docs/.manifest.yaml` maps both to `common/src/observability.rs`.

## Budget

4 files, 288 changed lines against its base.

## Deliberately out of scope

- **Span-field redaction.** Implementable, but `JsonFields` overrides `add_fields` (`json.rs:377-415`) to re-parse and re-serialize, because the default appends and produces malformed JSON. Six live handlers call `Span::current().record(...)` — in `search_messages.rs`, `forward_message.rs`, `edit_message.rs`, `read_receipts.rs` and `reactions.rs` — so a naive `FormatFields` would emit broken JSON in production on the most-instrumented paths. Recorded as an unowned gap in `ADR-0007` and `OBSERVABILITY.md`; **needs its own issue.**
- **`ZK-PII`** (`rate_limit.rs:241,256`) — positional interpolation into `message`, invisible to a field-name denylist. Also recorded as unowned.
- One thing a reviewer should weigh: `search_messages.rs:41` records a `query` field — a user's plaintext search string — into a span. It is not on the denylist. Whether that is PII under `AGENTS.md` §4 is a judgement call I did not want to make silently.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)