### PR TITLE
chore(roadmap): record the G2 hotfix steps and the PR-24 split

### DIFF
--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -54,7 +54,8 @@ steps:
   - {id: PR-21, issue: 32, phase: 2, type: chore, status: done, title: "Create label taxonomy"}
   - {id: PR-22, issue: 33, phase: 2, type: docs, status: done, title: "Codify code-style predicates in .claude/rules/20-code-style.md"}
   - {id: PR-23, issue: 34, phase: 2, type: refactor, status: done, gate: G2, title: "Unify protobuf codegen strategy"}
-  - {id: PR-24, issue: 35, phase: 3, type: security, status: todo, title: "Add common/src/redact.rs"}
+  - {id: PR-24, issue: 35, phase: 3, type: security, status: review, title: "Add Redacted<T> and the log field denylist"}
+  - {id: PR-24b, issue: 133, phase: 3, type: security, status: review, title: "Redact denied fields in the tracing formatter"}
   - {id: PR-25, issue: 36, phase: 3, type: security, status: todo, title: "Apply Redacted<T> across crypto, auth and messaging types"}
   - {id: PR-26, issue: 37, phase: 3, type: security, status: todo, title: "Migrate call-service and notification-service to observability::init_tracing"}
   - {id: PR-27, issue: 38, phase: 3, type: feat, status: todo, title: "Add health checks for all stores and a media-service Health RPC"}
@@ -76,3 +77,5 @@ steps:
   - {id: PR-43, issue: 54, phase: 4, type: feat, status: todo, title: "Wire the compose observability stack"}
   - {id: PR-44, issue: 55, phase: 4, type: chore, status: todo, gate: G4, title: "Deployment parity - call-service k8s, digest pins, mobile CI"}
   - {id: PR-45, issue: 60, phase: 1, type: chore, status: done, title: "Untrack the 18.4 MB committed ChromeDriver binary"}
+  - {id: PR-46, issue: 132, phase: 3, type: fix, status: review, title: "Adapt to the rdkafka 0.39 Delivery type and vendor libcurl"}
+  - {id: PR-47, issue: 137, phase: 3, type: chore, status: review, title: "Record the G2 hotfix steps in roadmap.yaml"}


### PR DESCRIPTION
## What

Three issues opened during Phase 3 execution had no step in `roadmap.yaml` and therefore no milestone. `roadmap.yaml` is the machine SSOT and GitHub is a projection of it (`AGENTS.md` §2.6), so the fix is here, not on the platform.

| Step | Issue | Why it exists |
|---|---|---|
| `PR-24b` | #133 | Second half of PR-24. The step came to 540 lines, over the 400-line budget, so it was split at a seam declared before the branch was opened. PR-24's title is also corrected to name what it actually ships. |
| `PR-46` | #132 | The `rdkafka` 0.39 hotfix. Not a planned step — the bump landed on `main` between G2 and the start of Phase 3. |
| `PR-47` | #137 | This step. |

The `b` suffix follows **PR-18b**, the existing precedent for splitting a step after its issue exists. Numbering continues from PR-45, the last non-plan step.

## Status values

All three are `status: review`, not `todo` — their PRs are open but unmerged, and only `status: done` closes an issue.

Per the hazard called out in the `issue-sync` skill (*"a stale `todo` **reopens a correctly-closed issue**"*), I diffed every step's `status` against the live issue list before writing. No mismatches.

## Sync result

```
just roadmap-sync      # dry
just roadmap-sync 0    # 3 changed, 97 already correct, 0 failed
just roadmap-sync 0    # 0 changed, 100 already correct, 0 failed  <- converged
```

The second write reporting `0 changed` is the proof of idempotence the skill asks for. #132, #133 and #137 are now on `Phase 3 — Architectural Scaffolding & ZK Hardening`.

`just docs-verify` and `just rules-verify` both pass.

## Budget

1 file, 5 lines.

## Deliberately out of scope

- **`docs/roadmap/STATE.md`**, which still describes G2 as *"awaiting explicit user approval"*. It is a **generated** file and no generator exists yet — `grep` finds no recipe or script that writes it. Hand-editing it would violate the "regenerated, never hand-edited" rule in `40-doc-sync.md`, so it needs its own step (write the generator, then regenerate).
- **`type:` labels**, which `roadmap-sync` deliberately does not reconcile. Set on the three issues separately, as the skill directs.
- **Board (Projects v2) reconciliation**, still gated by preflight **P-1**. `project_sync_enabled` stays `false`; the flag gates only the board half, and issue state plus milestones reconcile with the ambient token either way.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)