### PR TITLE
security(crypto): redact key and payload material from Debug

### DIFF
--- a/backend/crates/crypto/src/ffi.rs
+++ b/backend/crates/crypto/src/ffi.rs
@@ -14,13 +14,16 @@
 //! guardyn-crypto = { version = "0.1", features = ["ffi"] }
 //! ```
 
+use std::fmt;
+
+use guardyn_common::redact::Redacted;
 use std::sync::RwLock;
 
 // Re-export types that will be available in Dart
 pub use crate::padding::{pad_message, unpad_message};
 
 /// Hybrid key bundle for PQXDH key exchange
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FfiHybridKeyBundle {
     /// X25519 public key (32 bytes)
     pub x25519_public: Vec<u8>,
@@ -32,8 +35,20 @@ pub struct FfiHybridKeyBundle {
     pub ml_kem_private: Vec<u8>,
 }
 
+/// Redacts both private halves. Encapsulation and public keys are published.
+impl fmt::Debug for FfiHybridKeyBundle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FfiHybridKeyBundle")
+            .field("x25519_public", &self.x25519_public)
+            .field("x25519_private", &Redacted::new(&self.x25519_private))
+            .field("ml_kem_public", &self.ml_kem_public)
+            .field("ml_kem_private", &Redacted::new(&self.ml_kem_private))
+            .finish()
+    }
+}
+
 /// Encrypted data with ciphertext, nonce, and tag
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FfiEncryptedData {
     /// Ciphertext
     pub ciphertext: Vec<u8>,
@@ -43,12 +58,34 @@ pub struct FfiEncryptedData {
     pub tag: Vec<u8>,
 }
 
+/// Redacts the ciphertext. The nonce and tag are public AEAD parameters.
+impl fmt::Debug for FfiEncryptedData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FfiEncryptedData")
+            .field("ciphertext", &Redacted::new(&self.ciphertext))
+            .field("nonce", &self.nonce)
+            .field("tag", &self.tag)
+            .finish()
+    }
+}
+
 /// Key pair with public and private components
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FfiKeyPair {
     pub public_key: Vec<u8>,
     pub private_key: Vec<u8>,
     pub key_type: String,
+}
+
+/// Redacts the private half.
+impl fmt::Debug for FfiKeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FfiKeyPair")
+            .field("public_key", &self.public_key)
+            .field("private_key", &Redacted::new(&self.private_key))
+            .field("key_type", &self.key_type)
+            .finish()
+    }
 }
 
 /// Crypto library initialization state

--- a/backend/crates/crypto/src/lib.rs
+++ b/backend/crates/crypto/src/lib.rs
@@ -27,6 +27,9 @@ pub mod ffi;
 mod mls_tests;
 
 #[cfg(test)]
+mod redaction_tests;
+
+#[cfg(test)]
 mod x3dh_conversion_tests;
 
 // Re-exports for convenience

--- a/backend/crates/crypto/src/mls.rs
+++ b/backend/crates/crypto/src/mls.rs
@@ -3,7 +3,10 @@
 /// Implementation using OpenMLS library with RustCrypto backend.
 /// Provides secure group communication with forward secrecy, post-compromise security,
 /// and membership changes (add/remove members).
+use std::fmt;
+
 use crate::{CryptoError, Result};
+use guardyn_common::redact::Redacted;
 use openmls::prelude::*;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::{OpenMlsRustCrypto, RustCrypto};
@@ -28,19 +31,47 @@ const MLS_CIPHERSUITE: Ciphersuite =
     Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519;
 
 /// Key package with metadata
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct MlsKeyPackage {
     pub package_id: Vec<u8>,
     pub key_package_bytes: Vec<u8>,
     pub credential_identity: Vec<u8>,
 }
 
+/// Redacts the key package bytes and the credential identity; `package_id` is an
+/// opaque handle and stays printable so a package can still be correlated.
+impl fmt::Debug for MlsKeyPackage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MlsKeyPackage")
+            .field("package_id", &self.package_id)
+            .field("key_package_bytes", &Redacted::new(&self.key_package_bytes))
+            .field(
+                "credential_identity",
+                &Redacted::new(&self.credential_identity),
+            )
+            .finish()
+    }
+}
+
 /// Group state for serialization/deserialization
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct MlsGroupState {
     pub group_id: Vec<u8>,
     pub epoch: u64,
     pub serialized_state: Vec<u8>,
+}
+
+/// Redacts `serialized_state`, which today holds a 32-byte secret exported from
+/// the epoch secret (see the PR-31 discussion). `group_id` and `epoch` are
+/// metadata and are what an operator actually needs.
+impl fmt::Debug for MlsGroupState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MlsGroupState")
+            .field("group_id", &self.group_id)
+            .field("epoch", &self.epoch)
+            .field("serialized_state", &Redacted::new(&self.serialized_state))
+            .finish()
+    }
 }
 
 /// MLS Group Manager

--- a/backend/crates/crypto/src/redaction_tests.rs
+++ b/backend/crates/crypto/src/redaction_tests.rs
@@ -1,0 +1,156 @@
+//! Proof that no key or payload material can reach a `{:?}` sink (invariant I-1).
+//!
+//! Each test asserts two things: the placeholder is present, and a byte pattern
+//! unique to the secret is absent. Asserting only the former would pass for a
+//! `Debug` impl that printed `[REDACTED]` *next to* the secret.
+
+use crate::mls::{MlsGroupState, MlsKeyPackage};
+use crate::sealed_sender::SealedSenderEnvelope;
+use crate::x3dh::IdentityKeyPair;
+
+/// A byte pattern that will not occur by chance in a struct name or field name.
+const CANARY: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
+
+/// How `{:?}` renders `CANARY` if it is ever printed.
+fn canary_rendered() -> String {
+    format!("{:?}", CANARY)
+}
+
+#[test]
+fn test_identity_key_pair_debug_hides_the_signing_key() -> crate::Result<()> {
+    // Returns Result rather than unwrapping: RS-UNWRAP counts this file, because
+    // it carries no in-file `#[cfg(test)]` for the ratchet's stripper to find.
+    let pair = IdentityKeyPair::generate()?;
+    let rendered = format!("{:?}", pair);
+
+    // The signing key is private and randomly generated, so there is no canary to
+    // look for: assert the exact rendering instead.
+    assert!(
+        rendered.contains("secret: [REDACTED]"),
+        "signing key not redacted: {rendered}"
+    );
+    assert!(
+        rendered.contains("public"),
+        "the public half stays visible: {rendered}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_sealed_sender_envelope_debug_hides_the_payload() {
+    let envelope = SealedSenderEnvelope {
+        version: 1,
+        ephemeral_public_key: [7u8; 32],
+        encrypted_payload: CANARY.to_vec(),
+    };
+    let rendered = format!("{:?}", envelope);
+
+    assert!(rendered.contains("[REDACTED]"), "got: {rendered}");
+    assert!(
+        !rendered.contains(&canary_rendered()),
+        "payload leaked: {rendered}"
+    );
+    assert!(
+        rendered.contains("version: 1"),
+        "version stays visible for correlation: {rendered}"
+    );
+}
+
+#[test]
+fn test_mls_group_state_debug_hides_the_exported_secret() {
+    let state = MlsGroupState {
+        group_id: b"group-1".to_vec(),
+        epoch: 42,
+        serialized_state: CANARY.to_vec(),
+    };
+    let rendered = format!("{:?}", state);
+
+    assert!(rendered.contains("[REDACTED]"), "got: {rendered}");
+    assert!(
+        !rendered.contains(&canary_rendered()),
+        "group secret leaked: {rendered}"
+    );
+    assert!(
+        rendered.contains("epoch: 42"),
+        "epoch stays visible: {rendered}"
+    );
+}
+
+#[test]
+fn test_mls_key_package_debug_hides_bytes_and_identity() {
+    let package = MlsKeyPackage {
+        package_id: b"pkg-1".to_vec(),
+        key_package_bytes: CANARY.to_vec(),
+        credential_identity: CANARY.to_vec(),
+    };
+    let rendered = format!("{:?}", package);
+
+    assert!(rendered.contains("[REDACTED]"), "got: {rendered}");
+    assert!(
+        !rendered.contains(&canary_rendered()),
+        "key package or identity leaked: {rendered}"
+    );
+}
+
+#[cfg(feature = "ffi")]
+mod ffi_types {
+    use super::{canary_rendered, CANARY};
+    use crate::ffi::{FfiEncryptedData, FfiHybridKeyBundle, FfiKeyPair};
+
+    #[test]
+    fn test_hybrid_key_bundle_debug_hides_both_private_halves() {
+        let bundle = FfiHybridKeyBundle {
+            x25519_public: vec![1, 2, 3],
+            x25519_private: CANARY.to_vec(),
+            ml_kem_public: vec![4, 5, 6],
+            ml_kem_private: CANARY.to_vec(),
+        };
+        let rendered = format!("{:?}", bundle);
+
+        assert!(rendered.contains("[REDACTED]"), "got: {rendered}");
+        assert!(
+            !rendered.contains(&canary_rendered()),
+            "private key material leaked: {rendered}"
+        );
+        assert!(
+            rendered.contains("[1, 2, 3]"),
+            "public halves stay visible: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_encrypted_data_debug_hides_only_the_ciphertext() {
+        let data = FfiEncryptedData {
+            ciphertext: CANARY.to_vec(),
+            nonce: vec![9; 12],
+            tag: vec![8; 16],
+        };
+        let rendered = format!("{:?}", data);
+
+        assert!(rendered.contains("[REDACTED]"), "got: {rendered}");
+        assert!(
+            !rendered.contains(&canary_rendered()),
+            "ciphertext leaked: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_key_pair_debug_hides_the_private_key() {
+        let pair = FfiKeyPair {
+            public_key: vec![1, 2, 3],
+            private_key: CANARY.to_vec(),
+            key_type: "x25519".to_owned(),
+        };
+        let rendered = format!("{:?}", pair);
+
+        assert!(rendered.contains("[REDACTED]"), "got: {rendered}");
+        assert!(
+            !rendered.contains(&canary_rendered()),
+            "private key leaked: {rendered}"
+        );
+        assert!(
+            rendered.contains("x25519"),
+            "key_type stays visible: {rendered}"
+        );
+    }
+}

--- a/backend/crates/crypto/src/sealed_sender.rs
+++ b/backend/crates/crypto/src/sealed_sender.rs
@@ -22,12 +22,15 @@
 //! Based on Signal's Sealed Sender:
 //! <https://signal.org/blog/sealed-sender/>
 
+use std::fmt;
+
 use crate::{CryptoError, Result};
 use aes_gcm::{
     aead::{Aead, KeyInit},
     Aes256Gcm, Nonce,
 };
 use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use guardyn_common::redact::Redacted;
 use hkdf::Hkdf;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -253,7 +256,7 @@ impl SenderCertificate {
 }
 
 /// Sealed Sender Envelope - encrypted message with hidden sender identity
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SealedSenderEnvelope {
     /// Protocol version (currently 1)
     pub version: u8,
@@ -263,6 +266,18 @@ pub struct SealedSenderEnvelope {
 
     /// Encrypted payload: certificate + inner message
     pub encrypted_payload: Vec<u8>,
+}
+
+/// Redacts the payload. The version and ephemeral public key travel in clear on
+/// the wire and are needed to correlate a failed decrypt.
+impl fmt::Debug for SealedSenderEnvelope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SealedSenderEnvelope")
+            .field("version", &self.version)
+            .field("ephemeral_public_key", &self.ephemeral_public_key)
+            .field("encrypted_payload", &Redacted::new(&self.encrypted_payload))
+            .finish()
+    }
 }
 
 impl SealedSenderEnvelope {

--- a/backend/crates/crypto/src/x3dh.rs
+++ b/backend/crates/crypto/src/x3dh.rs
@@ -5,9 +5,12 @@
 /// Key conversion: Ed25519 identity keys are converted to X25519 for DH operations
 /// using the birational equivalence between twisted Edwards curve (Ed25519) and
 /// Montgomery curve (Curve25519/X25519). This is the same approach used by Signal Protocol.
+use std::fmt;
+
 use crate::{CryptoError, Result};
 use curve25519_dalek::scalar::clamp_integer;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use guardyn_common::redact::Redacted;
 use hkdf::Hkdf;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
@@ -15,10 +18,20 @@ use sha2::Sha256;
 use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
 
 /// Identity key pair (Ed25519 for signing)
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct IdentityKeyPair {
     pub public: VerifyingKey,
     secret: SigningKey,
+}
+
+/// Redacts the Ed25519 private half. The public half is safe to print.
+impl fmt::Debug for IdentityKeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IdentityKeyPair")
+            .field("public", &self.public)
+            .field("secret", &Redacted::new(&self.secret))
+            .finish()
+    }
 }
 
 impl IdentityKeyPair {

--- a/docs/adr/ADR-0004-openmls-group-e2ee.md
+++ b/docs/adr/ADR-0004-openmls-group-e2ee.md
@@ -33,6 +33,13 @@ Group encryption uses OpenMLS 0.6. One-to-one uses an in-repo X3DH and Double Ra
 One cryptographic implementation serves all platforms, and extending the handshake with
 ML-KEM-768 (ADR-0005) is possible at all — which it would not be with an opaque upstream.
 
+`MlsGroupState` and `MlsKeyPackage` implement `Debug` by hand rather than deriving it.
+`serialized_state` is the highest-value field in the crate - today it holds a secret exported
+from the epoch secret - and `key_package_bytes` and `credential_identity` are likewise not
+things to put in a log line. `group_id`, `epoch` and `package_id` stay visible, because an
+operator debugging a group needs exactly those (see
+[ADR-0007](ADR-0007-zero-knowledge-logging.md)).
+
 The cost is real: hand-rolled protocol code carries the burden of proof. This is why
 property tests and fuzz targets on every attacker-reachable parser are mandatory
 (`AGENTS.md` §8), not optional.

--- a/docs/adr/ADR-0005-hybrid-pqxdh.md
+++ b/docs/adr/ADR-0005-hybrid-pqxdh.md
@@ -37,6 +37,12 @@ ciphertext, 32-byte shared secret.
 A break of either primitive alone leaves the session secure. Key bundles get materially
 larger, and every wire structure carrying key material must have room for an ML-KEM key.
 
+Both private halves are unprintable. `FfiHybridKeyBundle` implements `Debug` by hand,
+wrapping `x25519_private` and `ml_kem_private` in `Redacted<T>` while leaving the
+encapsulation and public keys visible; the decapsulation key is the one value whose
+disclosure retroactively breaks the post-quantum half, so it must not be reachable through
+a `{:?}` (see [ADR-0007](ADR-0007-zero-knowledge-logging.md)).
+
 **Identity keys are Ed25519 and must be converted before any Diffie-Hellman.** The bundle
 stores an Ed25519 identity key because it also signs the pre-keys; the classical half of the
 agreement needs the Curve25519 form. The public side maps through `to_montgomery()`, the


### PR DESCRIPTION
> **Stacked on #135.** Base is `security/35-add-redacted-newtype`, because this consumes `Redacted<T>`. It does **not** need the formatter from #136, so it stacks two deep, not three.

## What

Seven types in the crypto crate derived `Debug` while holding key or payload material. Any `{:?}` on one would have written it straight to a log.

`ZK-DEBUG` in `30-zk-logging.md` flags this class deliberately as a *review trigger* rather than a pass/fail predicate, because a grep cannot tell which derives are dangerous. This is that review, carried out.

| Type | Redacted fields | Still printable |
|---|---|---|
| `IdentityKeyPair` | `secret` (Ed25519 signing key) | `public` |
| `FfiHybridKeyBundle` | `x25519_private`, `ml_kem_private` | both public halves |
| `FfiEncryptedData` | `ciphertext` | `nonce`, `tag` |
| `FfiKeyPair` | `private_key` | `public_key`, `key_type` |
| `SealedSenderEnvelope` | `encrypted_payload` | `version`, `ephemeral_public_key` |
| `MlsKeyPackage` | `key_package_bytes`, `credential_identity` | `package_id` |
| `MlsGroupState` | `serialized_state` | `group_id`, `epoch` |

## Two judgement calls worth reviewing

**Hand-written `Debug`, not wrapped fields.** Wrapping rewrites every read site to `.expose()`, and the line count of that change is driven by use sites, not by the type. `30-zk-logging.md:50` explicitly sanctions either. `Redacted<T>` stays the right tool for a *single* secret field in an otherwise-safe struct — which is what PR-25b's `UserProfile.password_hash`, `Session.session_token` and `AuthConfig.jwt_secret` need.

**Non-sensitive fields stay visible, on purpose.** An operator debugging a failed decrypt needs the envelope version, the MLS epoch and the group id. A blanket `[REDACTED]` over the whole struct would push them toward adding a worse, ad hoc log line — the exact failure mode `ADR-0007` warns about. Everything left visible is either a public wire value or metadata.

`MlsGroupState.serialized_state` is worth singling out: it currently holds a 32-byte secret exported from the epoch secret, so it is the highest-value field here.

## Test design

Each test asserts **two** things: the placeholder is present, *and* a canary byte pattern planted in the secret is absent.

Asserting only the first would pass for a `Debug` impl that printed `[REDACTED]` *next to* the secret — which is precisely the bug my first draft of the `IdentityKeyPair` test had (`!contains("secret: [")` matched `[REDACTED]` itself). The canary makes the test actually load-bearing.

## Verification

- `cargo clippy -p guardyn-crypto --all-targets --all-features -- -D warnings` ✅
- `cargo test -p guardyn-crypto --all-features` — **91 + 22 passed**, 6 ignored (the known MLS self-decryption ones) ✅
- `cargo fmt --all -- --check` ✅
- `just rules-verify` ✅ — `RS-UNWRAP` back at **52**, the frozen budget
- `just docs-verify` ✅

### A note on the ratchet

`RS-UNWRAP` caught a real regression here. `redaction_tests.rs` carries no in-file `#[cfg(test)]`, so the ratchet's `sed` stripper does not skip it, and one `.expect("keygen")` took the count to **53 against a frozen budget of 52**.

Budgets may only ever be lowered, so rather than raise it I made the test return `Result` and use `?`. The count is back to 52, unchanged. (`x3dh_conversion_tests.rs` has the same latent property and contributes 3 today.)

## Budget

6 files, 269 lines.

## Deliberately out of scope

- **`crypto-ffi/src/api.rs`**, which mirrors these FFI types in a separate crate. Same treatment, own step.
- **PR-25b** — `auth-service` `UserProfile.password_hash`, `Session.session_token`, and `common::config` `AuthConfig.jwt_secret` (which derives `Debug` today).
- **`messaging-service/src/models.rs`** (`RatchetSession`, `StoredMessage`, `GroupMessage`). Deferred on purpose: the pure-relay decision may delete those types outright, and redacting code about to be removed spends the budget twice.
- `X3DHKeyBundle`, `OneTimePreKeyPublic`, `X3DHPrekeyMessage` — public halves only.
- `VerifyingKey`'s own `Debug` prints the full `EdwardsPoint`. Public key material, so not a leak, but it makes `IdentityKeyPair` noisy.

## CI note

The backend job will fail until #134 merges — `main` still carries the `rdkafka` 0.39 break, which every branch cut from it inherits. `guardyn-crypto` itself is clean.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)