### PR TITLE
security(services): initialise tracing via observability::init_tracing

### DIFF
--- a/.claude/rules/00-invariants.md
+++ b/.claude/rules/00-invariants.md
@@ -18,7 +18,7 @@ If a task appears to require it, stop and ask the user.
 
 | ID | Invariant | Predicate | Today | Owned by |
 |---|---|---|---|---|
-| `ZK-INIT` | I-1 | Tracing is initialised only via `guardyn_common::observability::init_tracing` | FAIL (2) | PR-26 |
+| `ZK-INIT` | I-1 | Tracing is initialised only via `guardyn_common::observability::init_tracing` | PASS | `rules-verify` |
 | `ZK-PII` | I-1 | No log macro is passed a raw IP, email or phone number | FAIL (2) | **none — open an issue** |
 | `E2EE-FLAG` | I-2 | No configuration key can turn encryption off | FAIL (4) | PR-32 |
 | `E2EE-DUP` | I-2 | No handler has a non-E2EE twin | FAIL (2) | PR-32 |
@@ -50,7 +50,7 @@ original still sits beside it. After PR-32 there is one handler, unsuffixed. Not
 `PQ-WIRE` fails while `crypto/src/pqxdh.rs` is a complete hybrid X25519 + ML-KEM-768
 implementation. It is unreached, not absent — no proto field can carry the public key.
 
-**A known failure is not licence to patch it.** Six of these have an owned step; fixing one
+**A known failure is not licence to patch it.** Five of these have an owned step; fixing one
 outside that step breaks the micro-step contract. The two marked *none* were found while
 writing this file and need an issue opened before any fix.
 

--- a/.claude/rules/30-zk-logging.md
+++ b/.claude/rules/30-zk-logging.md
@@ -15,7 +15,7 @@ invariant most easily broken by a one-line "helpful" debug statement, so it gets
 
 | ID | Predicate | Today |
 |---|---|---|
-| `ZK-INIT` | Tracing is initialised only via `guardyn_common::observability::init_tracing` | FAIL — 2 services, PR-26 |
+| `ZK-INIT` | Tracing is initialised only via `guardyn_common::observability::init_tracing` | PASS — enforced by `rules-verify` |
 | `ZK-PII` | No log macro is passed a raw IP, email or phone number | FAIL — 2 sites, no owner |
 | `ZK-PAYLOAD` | No log macro names ciphertext, plaintext, payload or key material | PASS |
 | `ZK-STRUCT` | No whole request or response struct is interpolated | PASS |

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2622,7 +2622,6 @@ dependencies = [
  "tonic 0.12.3",
  "tonic-build",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -2804,7 +2803,6 @@ dependencies = [
  "tonic 0.12.3",
  "tonic-build",
  "tracing",
- "tracing-subscriber",
  "uuid",
  "web-push",
 ]

--- a/backend/crates/call-service/Cargo.toml
+++ b/backend/crates/call-service/Cargo.toml
@@ -26,7 +26,6 @@ chrono = "0.4"
 jsonwebtoken = "9.3"
 dashmap = "6.0"
 parking_lot = "0.12"
-tracing-subscriber.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/backend/crates/call-service/src/main.rs
+++ b/backend/crates/call-service/src/main.rs
@@ -22,9 +22,9 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Result;
+use guardyn_common::observability;
 use tonic::transport::Server;
-use tracing::{info, Level};
-use tracing_subscriber::FmtSubscriber;
+use tracing::info;
 
 use crate::db::CallDb;
 use crate::nats::CallNatsClient;
@@ -33,11 +33,23 @@ use crate::session::CallSessionManager;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize tracing
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::INFO)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+    // Initialize observability (tracing, logging, metrics).
+    //
+    // This must go through `observability::init_tracing`: building a subscriber
+    // here would bypass the redaction layer and forfeit both JSON logs and OTel
+    // traces. See ADR-0007 and the ZK-INIT predicate in rules-verify.
+    //
+    // The guard is bound - dropping it immediately would lose every buffered
+    // span at shutdown.
+    let log_level = std::env::var("LOG_LEVEL")
+        .or_else(|_| std::env::var("GUARDYN_OBSERVABILITY__LOG_LEVEL"))
+        .unwrap_or_else(|_| "info".to_string());
+    let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .or_else(|_| std::env::var("GUARDYN_OBSERVABILITY__OTLP_ENDPOINT"))
+        .ok()
+        .filter(|s| !s.is_empty());
+    let _tracing_guard =
+        observability::init_tracing("call-service", &log_level, otlp_endpoint.as_deref());
 
     info!("Starting Guardyn Call Service");
 

--- a/backend/crates/notification-service/Cargo.toml
+++ b/backend/crates/notification-service/Cargo.toml
@@ -22,7 +22,6 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 chrono = "0.4"
 jsonwebtoken = "9.3"
 reqwest = { version = "0.12", features = ["json"] }
-tracing-subscriber.workspace = true
 web-push = "0.11"
 base64 = "0.22"
 

--- a/backend/crates/notification-service/src/main.rs
+++ b/backend/crates/notification-service/src/main.rs
@@ -21,20 +21,32 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Result;
+use guardyn_common::observability;
 use tonic::transport::Server;
-use tracing::{info, Level};
-use tracing_subscriber::FmtSubscriber;
+use tracing::info;
 
 use crate::db::NotificationDb;
 use crate::service::NotificationServiceImpl;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize tracing
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::INFO)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+    // Initialize observability (tracing, logging, metrics).
+    //
+    // This must go through `observability::init_tracing`: building a subscriber
+    // here would bypass the redaction layer and forfeit both JSON logs and OTel
+    // traces. See ADR-0007 and the ZK-INIT predicate in rules-verify.
+    //
+    // The guard is bound - dropping it immediately would lose every buffered
+    // span at shutdown.
+    let log_level = std::env::var("LOG_LEVEL")
+        .or_else(|_| std::env::var("GUARDYN_OBSERVABILITY__LOG_LEVEL"))
+        .unwrap_or_else(|_| "info".to_string());
+    let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .or_else(|_| std::env::var("GUARDYN_OBSERVABILITY__OTLP_ENDPOINT"))
+        .ok()
+        .filter(|s| !s.is_empty());
+    let _tracing_guard =
+        observability::init_tracing("notification-service", &log_level, otlp_endpoint.as_deref());
 
     info!("Starting Guardyn Notification Service");
 

--- a/docs/adr/ADR-0007-zero-knowledge-logging.md
+++ b/docs/adr/ADR-0007-zero-knowledge-logging.md
@@ -58,8 +58,7 @@ must route through `common`, and a service that wants a bespoke subscriber canno
 Debugging is harder by design: correlating an incident means using `user_id`/`device_id`
 sparingly rather than dumping a request. That difficulty is the feature.
 
-**Known violations.** `call-service` and `notification-service` build a `FmtSubscriber`
-directly (PR-26). `common/src/rate_limit.rs:241,256` log a raw client IP — PII under this
+**Known violations.** `common/src/rate_limit.rs:241,256` log a raw client IP — PII under this
 ADR — and have **no owned step**; note the denylist cannot reach them, because they
 interpolate the IP positionally into `message` rather than naming a field.
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -41,5 +41,5 @@ is quietly wrong.
 | ADR | Gap | Owned by |
 |---|---|---|
 | 0005 | `pq` feature off by default; **no ML-KEM field in any proto**, so no PQ key can be published | PR-36…PR-40 |
-| 0007 | `call-service` and `notification-service` build a `FmtSubscriber` directly; `rate_limit.rs:241,256` log a raw IP | PR-26; the IP leak is **unowned** |
+| 0007 | `rate_limit.rs:241,256` log a raw IP; span fields bypass the redacting formatter | both **unowned** |
 | 0008 | Committed generated protobuf in `backend/crates/*/src/generated/` **and** `client-desktop/src-tauri/src/proto/`, while `messaging-service` uses `include_proto!` | PR-23 |

--- a/docs/ops/OBSERVABILITY.md
+++ b/docs/ops/OBSERVABILITY.md
@@ -102,7 +102,6 @@ alertmanager configuration.
 
 | Gap | Consequence | Owned by |
 |---|---|---|
-| `call-service` and `notification-service` build a `FmtSubscriber` directly | two services log outside the redaction layer | PR-26 |
 | `common/src/rate_limit.rs:241,256` log a raw client IP | PII in logs — a direct I-1 breach; positional, so the denylist cannot see it | **unowned** |
 | Span fields bypass `RedactingFormat` | secrets recorded via `Span::current().record` are not redacted | **unowned** |
 | The Compose observability stack is commented out, and references `./infra/observability/prometheus.yml` which does not exist | no local metrics; uncommenting it fails | PR-43 |

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -103,8 +103,8 @@ Run it before pushing. It is faster than a round trip through CI.
 just rules-verify
 ```
 
-The predicates of [`.claude/rules/20-code-style.md`](../../.claude/rules/20-code-style.md),
-executed. They had been stated as testable predicates since PR-05 with nothing running them.
+The predicates of [`.claude/rules/20-code-style.md`](../../.claude/rules/20-code-style.md)
+plus `ZK-INIT` from [`30-zk-logging.md`](../../.claude/rules/30-zk-logging.md), executed. They had been stated as testable predicates since PR-05 with nothing running them.
 [`rules.yml`](../../.github/workflows/rules.yml) runs it on **every** pull request - not on a
 path filter, because `NAME-SH`, `ORG-ROOT`, `LANG-MD` and `ORG-LOCAL` are repository-wide
 properties and a `backend/**` filter would leave them unenforced for exactly the changes most
@@ -120,6 +120,14 @@ measured count: the build fails when the number **grows**, and every fix lowers 
 If `rules-verify` fails on a ratchet you did not mean to touch, you added a site. If it tells
 you the count is *down*, lower the budget in the same PR - the number is a claim about the
 repository, and a stale one is worse than none.
+
+**If `ZK-INIT` fails**, a service is building its own `tracing` subscriber. That service gets
+no JSON logs, no OTel traces, and - the reason this is a hard fail rather than a style nit -
+**no redaction layer**, so any payload or key field it logs reaches the writer in clear. The
+fix is never to relax the check: route the service through
+`guardyn_common::observability::init_tracing`, binding the returned guard to a named variable
+so it is not dropped immediately. `presence-service/src/main.rs` is the reference for a
+service with no `ServiceConfig`; `auth-service/src/main.rs` for one with.
 
 ## Roadmap and board sync
 

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -17,7 +17,7 @@ charter: implementation_plan.md
 project_sync_enabled: false
 
 invariants:
-  - {id: I-1, name: Zero-Knowledge,   met: partial, note: "2 services log outside init_tracing; rate_limit.rs logs a raw IP"}
+  - {id: I-1, name: Zero-Knowledge,   met: partial, note: "rate_limit.rs logs a raw IP; span fields are not redacted"}
   - {id: I-2, name: Always-On E2EE,   met: false,   closed_by: PR-32}
   - {id: I-3, name: Post-Quantum,     met: false,   closed_by: [PR-36, PR-37, PR-38, PR-39, PR-40]}
   - {id: I-4, name: Data Sovereignty, met: partial, note: "envoy/ingress.yaml hardcodes a domain"}
@@ -56,7 +56,7 @@ steps:
   - {id: PR-23, issue: 34, phase: 2, type: refactor, status: done, gate: G2, title: "Unify protobuf codegen strategy"}
   - {id: PR-24, issue: 35, phase: 3, type: security, status: todo, title: "Add common/src/redact.rs"}
   - {id: PR-25, issue: 36, phase: 3, type: security, status: todo, title: "Apply Redacted<T> across crypto, auth and messaging types"}
-  - {id: PR-26, issue: 37, phase: 3, type: security, status: todo, title: "Migrate call-service and notification-service to observability::init_tracing"}
+  - {id: PR-26, issue: 37, phase: 3, type: security, status: review, title: "Migrate call-service and notification-service to observability::init_tracing"}
   - {id: PR-27, issue: 38, phase: 3, type: feat, status: todo, title: "Add health checks for all stores and a media-service Health RPC"}
   - {id: PR-28, issue: 39, phase: 3, type: refactor, status: todo, title: "Wire or delete the unused Redpanda topic constants"}
   - {id: PR-29, issue: 40, phase: 3, type: fix, status: todo, title: "Replace the presence-service Redis TODO with TTL-correct TiKV storage"}

--- a/docs/spec/SAD.md
+++ b/docs/spec/SAD.md
@@ -157,7 +157,7 @@ Recorded here because a blueprint that hides its holes is not a blueprint.
 |---|---|---|
 | No `call-service` Deployment in `infra/k8s/base/apps/` | call-service runs under Compose but is not deployable to Kubernetes | PR-44 |
 | Envoy routes only 3 of 6 services | media, calls and notifications are unreachable from a browser client | PR-44 |
-| `notification-service` and `call-service` have no `handlers/` directory | they break the one-handler-per-file rule and are the two services bypassing `observability::init_tracing` | PR-26, PR-35 |
+| `notification-service` and `call-service` have no `handlers/` directory | they break the one-handler-per-file rule | PR-35 |
 | Generated protobuf is committed in two places — `backend/crates/*/src/generated/` (13 files) and `client-desktop/src-tauri/src/proto/` (8 files) — while `messaging-service` uses `include_proto!` | three codegen strategies coexist | PR-23 |
 | `RateLimiter` is process-local | rate limits multiply by replica count | PR-41 |
 | `infra/k8s/base/envoy/ingress.yaml` hardcodes `envoy.guardyn.local` | violates the `${DOMAIN}` rule | unowned |

--- a/infra/scripts/rules-verify.sh
+++ b/infra/scripts/rules-verify.sh
@@ -8,6 +8,7 @@
 #
 #   RS-UNWRAP    no unwrap()/expect() in non-test Rust          ratcheted
 #   RS-UNSAFE    no `unsafe` outside an FFI crate
+#   ZK-INIT      tracing is initialised only via observability::init_tracing
 #   PROTO-EDIT   generated protobuf is never hand-edited
 #   LANG-MD      no Cyrillic in Markdown outside the allowlist
 #   NAME-SH      scripts are kebab-case.sh                      ratcheted
@@ -99,6 +100,24 @@ check_rs_unsafe() {
   fi
 }
 
+# ---------------------------------------------------------------- ZK-INIT
+#
+# Enforces I-1. A service that builds its own subscriber gets neither JSON logs
+# nor OTel traces nor the redaction layer, so a payload or key field reaches the
+# writer unfiltered. A plain fail, not a ratchet: PR-26 left zero sites, and a
+# ratchet's warn branch is for frozen debt rather than a predicate that holds.
+check_zk_init() {
+  local hits
+  hits="$(grep -rln --include='*.rs' -e FmtSubscriber -e 'tracing_subscriber::fmt()' \
+    backend/crates/*/src 2>/dev/null || true)"
+  if [ -n "$hits" ]; then
+    fail "ZK-INIT: tracing initialised outside observability::init_tracing"
+    show "$hits"
+  else
+    pass "ZK-INIT: every service initialises tracing via init_tracing"
+  fi
+}
+
 # ---------------------------------------------------------------- PROTO-EDIT
 check_proto_edit() {
   local hits
@@ -184,6 +203,7 @@ check_org_local() {
 echo "rules-verify (base: $BASE)"
 check_rs_unwrap
 check_rs_unsafe
+check_zk_init
 check_proto_edit
 check_lang_md
 check_name_sh


### PR DESCRIPTION
## What

`call-service` and `notification-service` each built a raw `FmtSubscriber`, so they got neither JSON logs nor OTel traces nor — decisively, now that #135 has landed `Redacted<T>` and #136 the redacting formatter — **the redaction layer**. A payload or key field logged by either would have reached the writer unfiltered.

That is the `ZK-INIT` predicate in `30-zk-logging.md`, and it has failed since those services were written.

Both now use the env-var pattern from `presence-service/src/main.rs` verbatim. Neither crate has a `ServiceConfig`, so none was invented for this.

## `ZK-INIT` is now enforced, not just documented

`check_zk_init` lands in `infra/scripts/rules-verify.sh` on the `check_rs_unsafe` template — bash/git/awk only, per that script's stated constraint.

It is a **plain fail, not a ratchet with budget 0**. This PR leaves zero sites, and a ratchet's `warn` branch exists for frozen debt, not for a predicate that actually holds.

**Verified in both directions.** A check that cannot fail is worthless, so I planted a `FmtSubscriber` in a service `src/` tree and confirmed:

```
FAIL ZK-INIT: tracing initialised outside observability::init_tracing
1 check(s) failed
```

then removed it and confirmed it passes. `rules.yml` already triggers on this script, so no workflow change is needed.

## Two details that would otherwise break the build

- `use tracing::{info, Level}` narrows to `use tracing::info` — `Level` goes unused and `-D warnings` turns that into a failure.
- `tracing-subscriber` is dropped from both manifests; with `FmtSubscriber` gone, neither crate references it anywhere in `src/`.

And one that would break silently: the guard is bound to `_tracing_guard`, **not** `_`. Binding to `_` drops it immediately and loses every buffered span at shutdown.

## Documentation

`40-doc-sync.md` step 3 requires the mapped docs in the same PR. The predicate flips to PASS in `00-invariants.md` and `30-zk-logging.md`, and the stale claims elsewhere go with it:

- the `ADR-0007` known-violations paragraph
- the `OBSERVABILITY.md` gap table row
- the ADR index row for 0007
- a `SAD.md` row that cited these two services as `init_tracing` offenders while making a separate, still-valid point about handler layout
- `roadmap.yaml`'s I-1 note, which now names what is actually left

## I-1 is still `partial`, not met

Two gaps remain, **both unowned**:

1. `rate_limit.rs:241,256` log a raw client IP — positional interpolation into `message`, so a field-name denylist is structurally blind to it.
2. Span fields bypass the redacting formatter (see #136).

`30-zk-logging.md:60-64` requires an issue before either is touched, so neither is fixed here.

## Verification

- `cargo clippy --workspace --exclude guardyn-e2e-tests --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace --exclude guardyn-e2e-tests` — all 14 test binaries green ✅
- `cargo fmt --all -- --check` ✅
- `just rules-verify` ✅ — including the new `ZK-INIT`, with `RS-UNWRAP` at 52 and `NAME-SH` at 5, both unmoved
- `just docs-verify` ✅

## Budget

12 files, **92 lines**. Inside budget on the "≤400 lines **or** ≤8 files" contract — `10-git-workflow.md` uses almost this exact case as its worked example ("A 12-file, 90-line documentation PR is inside budget"). Nine of the twelve files are one- or two-line documentation corrections.

## Deliberately out of scope

- **`docs/roadmap/STATE.md`**, which still carries the old I-1 note. It is generated and no generator exists yet, so hand-editing it would violate the "regenerated, never hand-edited" rule in `40-doc-sync.md`.
- The two unowned I-1 gaps above.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)