### PR TITLE
security(auth): wrap credentials and PII in Redacted<T>

### DIFF
--- a/backend/crates/auth-service/src/db.rs
+++ b/backend/crates/auth-service/src/db.rs
@@ -6,6 +6,7 @@
 /// - Session tracking
 /// - Key bundle storage
 use anyhow::{Context, Result};
+use guardyn_common::Redacted;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tikv_client::RawClient;
@@ -15,8 +16,8 @@ use tikv_client::RawClient;
 pub struct UserProfile {
     pub user_id: String,
     pub username: String,
-    pub email: Option<String>,
-    pub password_hash: String,
+    pub email: Option<Redacted<String>>,
+    pub password_hash: Redacted<String>,
     pub created_at: i64,
     pub last_seen: i64,
     pub avatar_media_id: Option<String>, // Reference to media in MediaService
@@ -38,7 +39,7 @@ pub struct Device {
 /// Session information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
-    pub session_token: String,
+    pub session_token: Redacted<String>,
     pub user_id: String,
     pub device_id: String,
     pub created_at: i64,
@@ -270,14 +271,15 @@ impl DatabaseClient {
     /// Create session
     pub async fn create_session(&self, session: &Session) -> Result<()> {
         // Store session by token
-        let token_key = format!("/sessions/{}", session.session_token).into_bytes();
+        let token_key = format!("/sessions/{}", session.session_token.expose()).into_bytes();
         let session_value = serde_json::to_vec(session)?;
         self.client.put(token_key, session_value.clone()).await?;
 
         // Store session in user index
         let user_key = format!(
             "/sessions/user/{}/{}",
-            session.user_id, session.session_token
+            session.user_id,
+            session.session_token.expose()
         )
         .into_bytes();
         self.client.put(user_key, session_value.clone()).await?;
@@ -285,7 +287,9 @@ impl DatabaseClient {
         // Store session in device index (for single-device logout)
         let device_key = format!(
             "/sessions/device/{}/{}/{}",
-            session.user_id, session.device_id, session.session_token
+            session.user_id,
+            session.device_id,
+            session.session_token.expose()
         )
         .into_bytes();
         self.client.put(device_key, session_value).await?;
@@ -590,13 +594,16 @@ impl DatabaseClient {
         for kv in session_keys {
             // Get the session to also delete from main sessions index and device index
             if let Ok(session) = serde_json::from_slice::<Session>(&kv.1) {
-                let token_key = format!("/sessions/{}", session.session_token).into_bytes();
+                let token_key =
+                    format!("/sessions/{}", session.session_token.expose()).into_bytes();
                 let _ = self.client.delete(token_key).await;
 
                 // Delete from device index
                 let device_key = format!(
                     "/sessions/device/{}/{}/{}",
-                    user_id, session.device_id, session.session_token
+                    user_id,
+                    session.device_id,
+                    session.session_token.expose()
                 )
                 .into_bytes();
                 let _ = self.client.delete(device_key).await;
@@ -808,5 +815,81 @@ impl DatabaseClient {
 
         tracing::info!("Deleted all contacts for user: {}", user_id);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A value that must never appear in a `{:?}` rendering.
+    const SECRET: &str = "CANARY-SECRET-VALUE";
+
+    fn sample_profile() -> UserProfile {
+        UserProfile {
+            user_id: "u1".to_string(),
+            username: "alice".to_string(),
+            email: Some(Redacted::new(SECRET.to_string())),
+            password_hash: Redacted::new(SECRET.to_string()),
+            created_at: 0,
+            last_seen: 0,
+            avatar_media_id: None,
+            display_name: None,
+            bio: None,
+        }
+    }
+
+    #[test]
+    fn test_user_profile_debug_hides_password_hash_and_email() {
+        let rendered = format!("{:?}", sample_profile());
+
+        assert!(!rendered.contains(SECRET), "secret leaked: {rendered}");
+        assert!(rendered.contains("[REDACTED]"));
+        // Identifiers are metadata and stay visible for correlation.
+        assert!(rendered.contains("u1") && rendered.contains("alice"));
+    }
+
+    #[test]
+    fn test_session_debug_hides_the_bearer_token() {
+        let session = Session {
+            session_token: Redacted::new(SECRET.to_string()),
+            user_id: "u1".to_string(),
+            device_id: "d1".to_string(),
+            created_at: 0,
+            expires_at: 0,
+        };
+        let rendered = format!("{:?}", session);
+
+        assert!(!rendered.contains(SECRET), "token leaked: {rendered}");
+        assert!(rendered.contains("[REDACTED]"));
+        assert!(
+            rendered.contains("d1"),
+            "device_id stays visible: {rendered}"
+        );
+    }
+
+    /// These types are persisted to TiKV as JSON. If `Redacted<T>` were to
+    /// serialize as `"[REDACTED]"`, every stored profile and session would be
+    /// destroyed on the next write - so the wire format must be byte-identical
+    /// to the unwrapped one.
+    #[test]
+    fn test_serialized_form_is_unchanged_by_wrapping() {
+        let json = serde_json::to_string(&sample_profile()).expect("serialize");
+
+        assert!(
+            json.contains(&format!("\"password_hash\":\"{SECRET}\"")),
+            "password_hash must persist in clear: {json}"
+        );
+        assert!(
+            json.contains(&format!("\"email\":\"{SECRET}\"")),
+            "email must persist in clear, not as Some(..): {json}"
+        );
+
+        let back: UserProfile = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.password_hash.expose(), SECRET);
+        assert_eq!(
+            back.email.map(Redacted::into_inner).as_deref(),
+            Some(SECRET)
+        );
     }
 }

--- a/backend/crates/auth-service/src/handlers/delete_account.rs
+++ b/backend/crates/auth-service/src/handlers/delete_account.rs
@@ -75,7 +75,7 @@ pub async fn handle(
     };
 
     // 3. Verify password for security
-    if !verify_password(&req.password, &user.password_hash) {
+    if !verify_password(&req.password, user.password_hash.expose()) {
         let error = ErrorResponse {
             code: error_response::ErrorCode::Unauthorized as i32,
             message: "Incorrect password".to_string(),

--- a/backend/crates/auth-service/src/handlers/get_user_profile.rs
+++ b/backend/crates/auth-service/src/handlers/get_user_profile.rs
@@ -1,9 +1,10 @@
-/// Get user profile by user ID handler
 use crate::{
     db::DatabaseClient,
     proto::auth::*,
     proto::common::{error_response::ErrorCode, *},
 };
+/// Get user profile by user ID handler
+use guardyn_common::Redacted;
 use tracing::{error, info, warn};
 
 pub async fn handle_get_user_profile(
@@ -46,7 +47,7 @@ pub async fn handle_get_user_profile(
                 result: Some(get_user_profile_response::Result::Success(UserProfile {
                     user_id: user.user_id,
                     username: user.username,
-                    email: user.email.unwrap_or_default(),
+                    email: user.email.map(Redacted::into_inner).unwrap_or_default(),
                     created_at: Some(Timestamp {
                         seconds: user.created_at,
                         nanos: 0,

--- a/backend/crates/auth-service/src/handlers/login.rs
+++ b/backend/crates/auth-service/src/handlers/login.rs
@@ -14,6 +14,7 @@ use argon2::{
     password_hash::{PasswordHash, PasswordVerifier},
     Argon2,
 };
+use guardyn_common::Redacted;
 use tonic::{Request, Response, Status};
 
 pub async fn handle(
@@ -49,7 +50,7 @@ pub async fn handle(
     };
 
     // Verify password
-    if !verify_password(&req.password, &user.password_hash) {
+    if !verify_password(&req.password, user.password_hash.expose()) {
         let error = ErrorResponse {
             code: error_response::ErrorCode::Unauthorized as i32,
             message: "Invalid username or password".to_string(),
@@ -156,7 +157,7 @@ pub async fn handle(
 
     // Create session
     let session = Session {
-        session_token: refresh_token.clone(),
+        session_token: Redacted::new(refresh_token.clone()),
         user_id: user.user_id.clone(),
         device_id: device_id.clone(),
         created_at: now,
@@ -187,7 +188,11 @@ pub async fn handle(
     let profile = Some(UserProfile {
         user_id: user.user_id.clone(),
         username: user.username.clone(),
-        email: user.email.clone().unwrap_or_default(),
+        email: user
+            .email
+            .clone()
+            .map(Redacted::into_inner)
+            .unwrap_or_default(),
         created_at: Some(Timestamp {
             seconds: now,
             nanos: 0,

--- a/backend/crates/auth-service/src/handlers/register.rs
+++ b/backend/crates/auth-service/src/handlers/register.rs
@@ -17,6 +17,7 @@ use argon2::{
     password_hash::{rand_core::OsRng, PasswordHasher, SaltString},
     Argon2,
 };
+use guardyn_common::Redacted;
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
@@ -107,9 +108,9 @@ pub async fn handle(
         email: if req.email.is_empty() {
             None
         } else {
-            Some(req.email.clone())
+            Some(Redacted::new(req.email.clone()))
         },
-        password_hash,
+        password_hash: Redacted::new(password_hash),
         created_at: now,
         last_seen: now,
         avatar_media_id: None,
@@ -206,7 +207,7 @@ pub async fn handle(
 
     // Create session
     let session = Session {
-        session_token: refresh_token.clone(),
+        session_token: Redacted::new(refresh_token.clone()),
         user_id: user_id.clone(),
         device_id: device_id.clone(),
         created_at: now,

--- a/backend/crates/auth-service/src/handlers/update_profile.rs
+++ b/backend/crates/auth-service/src/handlers/update_profile.rs
@@ -5,6 +5,7 @@ use crate::proto::auth::{
     update_profile_response, UpdateProfileRequest, UpdateProfileResponse, UserProfile,
 };
 use crate::proto::common::{error_response::ErrorCode, ErrorResponse, Timestamp};
+use guardyn_common::Redacted;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::Deserialize;
 use std::sync::Arc;
@@ -137,7 +138,7 @@ pub async fn update_profile(
         result: Some(update_profile_response::Result::Profile(UserProfile {
             user_id: user.user_id,
             username: user.username,
-            email: user.email.unwrap_or_default(),
+            email: user.email.map(Redacted::into_inner).unwrap_or_default(),
             created_at: Some(Timestamp {
                 seconds: user.created_at,
                 nanos: 0,

--- a/backend/crates/auth-service/src/main.rs
+++ b/backend/crates/auth-service/src/main.rs
@@ -332,7 +332,7 @@ async fn main() -> Result<()> {
     // Falls back to legacy JWT_SECRET, then to dev default
     let jwt_secret = std::env::var("GUARDYN_AUTH__JWT_SECRET")
         .or_else(|_| std::env::var("JWT_SECRET"))
-        .unwrap_or_else(|_| config.auth.jwt_secret.clone());
+        .unwrap_or_else(|_| config.auth.jwt_secret.expose().clone());
 
     if jwt_secret.len() < 32 {
         tracing::error!("JWT secret is too short (< 32 bytes) - this is insecure!");

--- a/backend/crates/common/src/config.rs
+++ b/backend/crates/common/src/config.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use crate::redact::Redacted;
+
 #[derive(Debug, Deserialize)]
 pub struct ServiceConfig {
     pub service_name: String,
@@ -37,7 +39,7 @@ pub struct AuthConfig {
     /// CRITICAL: Never use default in production!
     /// Set via GUARDYN_AUTH__JWT_SECRET environment variable
     #[serde(default = "default_jwt_secret")]
-    pub jwt_secret: String,
+    pub jwt_secret: Redacted<String>,
 
     /// JWT token expiration in seconds (default: 1 hour)
     #[serde(default = "default_jwt_expiration")]
@@ -48,11 +50,11 @@ pub struct AuthConfig {
     pub refresh_expiration_secs: u64,
 }
 
-fn default_jwt_secret() -> String {
+fn default_jwt_secret() -> Redacted<String> {
     // WARNING: This is only for development!
     // In production, GUARDYN_AUTH__JWT_SECRET must be set
     tracing::warn!("Using default JWT secret - NOT SAFE FOR PRODUCTION!");
-    "UNSAFE_DEV_SECRET_CHANGE_IN_PRODUCTION_32BYTES".to_string()
+    Redacted::new("UNSAFE_DEV_SECRET_CHANGE_IN_PRODUCTION_32BYTES".to_string())
 }
 
 fn default_jwt_expiration() -> u64 {


### PR DESCRIPTION
> **Stacked on #135**, which introduces `Redacted<T>`. `common/src/redact.rs` does not exist on `main` yet, so this cannot target `main` until #135 merges.

## What

`UserProfile`, `Session` and `AuthConfig` each derive `Debug` while holding a bearer credential or PII. `AGENTS.md` §4 names password hashes, session secrets and **email** as things that must never be emitted.

| Type | Wrapped |
|---|---|
| `UserProfile` | `password_hash`, `email` |
| `Session` | `session_token` |
| `AuthConfig` | `jwt_secret` |

## Why wrapping here, when the crypto crate got hand-written `Debug`

This is the opposite choice from #139, and deliberately so.

A hand-written `Debug` protects `{:?}` **on the struct**. It does nothing for `format!("{}", user.password_hash)` — the field is still a bare `String`. Wrapping is *structural*: the field cannot be formatted at all without an explicit `.expose()`, so a new call site has to say out loud that it wants the secret.

That is affordable here because the read sites are few — which is **not** obvious from a grep. `jwt_secret` matches 65 times across the backend, but only **2** of those are `AuthConfig`'s field; the rest are per-service structs with their own `jwt_secret`. Ten call sites needed updating in total, and **the compiler found every one**. A hand-written `Debug` would have found none of them.

The crypto types went the other way because several fields per struct needed covering and the read sites were numerous — the line count there is driven by use sites, not by the type.

## The serde test is the important one

`Serialize`/`Deserialize` stay transparent, and `test_serialized_form_is_unchanged_by_wrapping` now pins that.

These types are persisted to **TiKV as JSON**. If `Redacted<T>` serialized as `"[REDACTED]"`, the next write would destroy every stored profile and session. The test asserts the JSON still carries the raw values under the same keys, and that wrapping `email` as `Option<Redacted<String>>` does not change its encoding.

This is the concrete reason `Redacted<T>`'s serde impls are transparent rather than redacting — a design point that is easy to get backwards.

## One thing worth confirming in review

The `session_token` uses in `db.rs` (`:274`, `:282`, `:292`, `:597`, `:605`) are **TiKV key construction**, not logging — `format!("/sessions/{}", ...)` building a storage key. They take `.expose()` and behave identically. I checked each before converting; none is a log line.

## Verification

- `cargo clippy --workspace --exclude guardyn-e2e-tests --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace --exclude guardyn-e2e-tests` — no failures ✅
- `cargo fmt --all -- --check` ✅
- `just rules-verify` ✅ — `RS-UNWRAP` at 52, unmoved
- `just docs-verify` ✅ (run **after** committing — the impact check reads the committed diff)

## Budget

8 files, 137 lines.

## Deliberately out of scope

- The **per-service `jwt_secret` fields** in `messaging-service`, `call-service`, `media-service`, `notification-service` and `presence-service`. Same treatment warranted, but five more crates would put this well past budget.
- `KeyBundle` in `db.rs` — public E2EE material only.
- Whether `default_jwt_secret` should exist at all. It returns a hardcoded dev secret and warns loudly; that is a separate argument from redaction.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)