### PR TITLE
chore(roadmap): enable board sync and make it idempotent

### DIFF
--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -11,10 +11,14 @@ project_number: 3
 project_url: https://github.com/orgs/guardyn/projects/3
 charter: implementation_plan.md
 
-# P-1: no token available to CI can read or write the project board. The fine-grained
-# PAT is rejected by the organization; the fallback OAuth token lacks read:project.
-# Board sync stays inert until GUARDYN_PROJECT_TOKEN exists with repo + project scope.
-project_sync_enabled: false
+# P-1 is resolved: the ambient gh credential now carries the project scope, obtained with
+# `gh auth refresh -h github.com -s project`. The fine-grained PAT the organization rejects
+# is out of the picture, and the OAuth token that replaced it reads and writes the board.
+#
+# Still outstanding: GUARDYN_PROJECT_TOKEN as a repository *secret*, which is what
+# roadmap-sync.yml needs to reconcile the board from CI rather than from a developer's
+# machine. Without it the workflow skips the board half and exits 0.
+project_sync_enabled: true
 
 invariants:
   - {id: I-1, name: Zero-Knowledge,   met: partial, note: "2 services log outside init_tracing; rate_limit.rs logs a raw IP"}

--- a/infra/scripts/roadmap-sync.sh
+++ b/infra/scripts/roadmap-sync.sh
@@ -199,19 +199,35 @@ else
     bad "project $project_number not readable with GUARDYN_PROJECT_TOKEN - check its scopes"
   else
     say "board: project $project_number resolved"
+
+    # addProjectV2ItemById is idempotent on GitHub's side: adding content that is already
+    # on the board returns the existing item rather than an error. The mutation therefore
+    # cannot tell us whether it changed anything, and reporting every successful call as a
+    # change made the second write report the same count as the first - which is exactly
+    # the convergence check the issue-sync skill asks for. So read the board once and diff
+    # against it.
+    on_board="$(GH_TOKEN="$GUARDYN_PROJECT_TOKEN" gh api graphql --paginate \
+      -f query='query($o:String!,$n:Int!,$endCursor:String){organization(login:$o){projectV2(number:$n){items(first:100,after:$endCursor){pageInfo{hasNextPage,endCursor},nodes{content{... on Issue{number}}}}}}}' \
+      -f o="$owner" -F n="$project_number" \
+      --jq '.data.organization.projectV2.items.nodes[].content.number' 2>/dev/null)"
+
     while IFS= read -r step; do
       [ -n "$step" ] || continue
       issue="$(field "$step" issue)"
       id="$(field "$step" id)"
       [ -n "$issue" ] && [ "$issue" != "null" ] || continue
+      if printf '%s\n' "$on_board" | grep -qx "$issue"; then
+        noop "$id #$issue already on the board"
+        continue
+      fi
       node="$(gh api "repos/$REPO/issues/$issue" --jq '.node_id' 2>/dev/null)"
       [ -n "$node" ] || { bad "$id #$issue has no node id"; continue; }
       if GH_TOKEN="$GUARDYN_PROJECT_TOKEN" gh api graphql \
           -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' \
           -f p="$project_id" -f c="$node" >/dev/null 2>&1; then
-        ok "$id #$issue on the board"
+        ok "$id #$issue added to the board"
       else
-        noop "$id #$issue already on the board"
+        bad "$id #$issue could not be added to the board"
       fi
     done <<<"$steps_raw"
   fi


### PR DESCRIPTION
## P-1 is resolved

The ambient `gh` credential now carries the `project` scope (`gh auth refresh -h github.com -s project`), so `organization(login:"guardyn"){projectV2(number:3)}` resolves. `project_sync_enabled` was still `false`, with a comment stating that no usable token existed — no longer true.

## Flipping the flag exposed a bug that made the documented loop impossible

`addProjectV2ItemById` is **idempotent on GitHub's side**: adding content already on the board returns the existing item rather than an error. So the mutation always succeeded, the `noop` branch was unreachable, and every run reported every step as changed.

That meant the second write could never report `0 changed` — which is exactly the convergence check the `issue-sync` skill asks for as step 4 of its loop:

> *Step 4 is the real test. `roadmap-sync` reconciles rather than appends, so a correct run is idempotent. If the second write still reports changes, something outside the YAML is moving and you need to find out what before running again.*

The board contents are now read **once**, with paging, and only missing issues are added. A failed mutation is now a genuine failure rather than a silent "already there".

## Verification

```
just roadmap-sync 0    # 47 changed, 94 already correct, 0 failed
just roadmap-sync 0    # 0 changed, 141 already correct, 0 failed   <- converged
```

The board now holds **47 items**, one per step that has an issue. Confirmed via GraphQL:

```
Guardyn Refactoring: 47 items
```

`just rules-verify` passes.

## Budget

2 files, 32 lines.

## Deliberately out of scope

**`GUARDYN_PROJECT_TOKEN` as a repository secret.** That is what `roadmap-sync.yml` needs in order to reconcile the board *from CI* rather than from a developer's machine. Without it the workflow still skips the board half and exits 0, exactly as before — this PR does not pretend otherwise. It remains a human action, and it is the last piece of P-1.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)