### PR TITLE
refactor(events): delete unused topics and payloads, make Kafka degradation alertable

### DIFF
--- a/backend/crates/auth-service/src/handlers/delete_account.rs
+++ b/backend/crates/auth-service/src/handlers/delete_account.rs
@@ -138,9 +138,14 @@ pub async fn handle(
             }
         }
     } else {
-        tracing::warn!(
+        // Error rather than warn: the account is gone from auth, but the user's messages,
+        // media and presence records are not. That is orphaned personal data and someone
+        // has to reconcile it by hand, which is an incident, not a degradation.
+        tracing::error!(
             user_id = %user_id,
-            "No event producer configured - cross-service cleanup skipped"
+            degraded = "kafka_producer_unavailable",
+            "No event producer configured - user.deleted was not published. Personal data \
+             in messaging, media and presence will NOT be deleted without manual cleanup."
         );
     }
 

--- a/backend/crates/auth-service/src/main.rs
+++ b/backend/crates/auth-service/src/main.rs
@@ -353,9 +353,19 @@ async fn main() -> Result<()> {
             AuthServiceImpl::with_events(db, jwt_secret, producer)
         }
         Err(e) => {
+            // Deliberately non-fatal. Auth is the most critical path in the system: if
+            // the broker is down, auth must keep serving requests rather than take the
+            // whole product offline for a degraded background channel.
+            //
+            // `degraded` is a stable field name so an alert can key on it rather than on
+            // log prose. It is not a metric - the backend has no metrics facade yet, and
+            // adding one is a dependency decision that needs an ADR.
             tracing::warn!(
+                degraded = "kafka_producer_unavailable",
                 error = %e,
-                "Failed to create Kafka producer - cross-service events disabled"
+                "Kafka producer unavailable - starting without cross-service events. \
+                 Account deletions will NOT propagate to messaging, media or presence \
+                 while this persists."
             );
             AuthServiceImpl::new(db, jwt_secret)
         }

--- a/backend/crates/common/src/events.rs
+++ b/backend/crates/common/src/events.rs
@@ -10,18 +10,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub mod topics {
     /// User lifecycle events (account creation, deletion, updates)
     pub const USER_EVENTS: &str = "guardyn.user.events";
-
-    /// Message events (for audit, sync)
-    pub const MESSAGE_EVENTS: &str = "guardyn.message.events";
-
-    /// Group events (creation, member changes)
-    pub const GROUP_EVENTS: &str = "guardyn.group.events";
-
-    /// Presence events (online/offline, typing)
-    pub const PRESENCE_EVENTS: &str = "guardyn.presence.events";
-
-    /// Call events (started, ended, participant changes)
-    pub const CALL_EVENTS: &str = "guardyn.call.events";
 }
 
 /// Base event envelope with common metadata
@@ -75,13 +63,8 @@ impl<T> EventEnvelope<T> {
 pub mod user {
     use super::*;
 
-    /// Event types for user lifecycle
-    pub const TYPE_CREATED: &str = "user.created";
-    pub const TYPE_UPDATED: &str = "user.updated";
+    /// Event type for user lifecycle
     pub const TYPE_DELETED: &str = "user.deleted";
-    pub const TYPE_PASSWORD_CHANGED: &str = "user.password_changed";
-    pub const TYPE_DEACTIVATED: &str = "user.deactivated";
-    pub const TYPE_REACTIVATED: &str = "user.reactivated";
 
     /// Payload for user.deleted event
     ///
@@ -139,70 +122,6 @@ pub mod user {
             }
         }
     }
-
-    /// Payload for user.created event
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct UserCreatedPayload {
-        /// User ID
-        pub user_id: String,
-
-        /// Username
-        pub username: String,
-
-        /// Display name (optional)
-        pub display_name: Option<String>,
-    }
-}
-
-/// Group-related event types
-pub mod group {
-    use super::*;
-
-    pub const TYPE_CREATED: &str = "group.created";
-    pub const TYPE_DELETED: &str = "group.deleted";
-    pub const TYPE_MEMBER_ADDED: &str = "group.member_added";
-    pub const TYPE_MEMBER_REMOVED: &str = "group.member_removed";
-    pub const TYPE_UPDATED: &str = "group.updated";
-
-    /// Payload for member removal (used when user account is deleted)
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct MemberRemovedPayload {
-        /// Group ID
-        pub group_id: String,
-
-        /// User ID being removed
-        pub user_id: String,
-
-        /// Reason for removal
-        pub reason: String,
-
-        /// Was this a cascade from user deletion?
-        pub cascade: bool,
-    }
-}
-
-/// Message-related event types
-pub mod message {
-    use super::*;
-
-    pub const TYPE_SENT: &str = "message.sent";
-    pub const TYPE_DELIVERED: &str = "message.delivered";
-    pub const TYPE_READ: &str = "message.read";
-    pub const TYPE_DELETED: &str = "message.deleted";
-    pub const TYPE_USER_DATA_DELETED: &str = "message.user_data_deleted";
-
-    /// Payload for bulk message deletion (user account deletion)
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct UserDataDeletedPayload {
-        /// User ID whose messages were deleted
-        pub user_id: String,
-
-        /// Number of messages deleted
-        pub messages_deleted: u64,
-
-        /// Number of conversations affected
-        pub conversations_affected: u64,
-    }
 }
 
 #[cfg(test)]
@@ -230,13 +149,15 @@ mod tests {
 
     #[test]
     fn test_event_with_correlation_id() {
-        let payload = user::UserCreatedPayload {
+        let payload = user::UserDeletedPayload {
             user_id: "user456".to_string(),
             username: "newuser".to_string(),
-            display_name: Some("New User".to_string()),
+            reason: None,
+            cascade: false,
+            delete_data: user::DeleteDataScope::default(),
         };
 
-        let event = EventEnvelope::new(user::TYPE_CREATED, "auth-service", payload)
+        let event = EventEnvelope::new(user::TYPE_DELETED, "auth-service", payload)
             .with_correlation_id("request-123");
 
         assert_eq!(event.correlation_id, Some("request-123".to_string()));


### PR DESCRIPTION
## Part 1 — delete, per YAGNI

Five Redpanda topic constants were declared; **one** is produced or consumed. Measured across the whole backend:

| Symbol | References outside `events.rs` |
|---|---|
| `topics::USER_EVENTS` | 3 |
| `topics::{MESSAGE,GROUP,PRESENCE,CALL}_EVENTS` | **0** |
| `user::TYPE_DELETED` | 2 |
| the other 11 `TYPE_*` constants | **0** |
| `UserDeletedPayload`, `DeleteDataScope` | 4, 1 |
| `UserCreatedPayload`, `MemberRemovedPayload`, `UserDataDeletedPayload` | **0** |
| the whole `group` and `message` modules | **0** |

Deleted on your call: if the event-sourcing design needs them later, they come back with actual call sites rather than sitting as a contract nobody implements.

What survives is exactly what is wired today — `EventEnvelope`, `topics::USER_EVENTS`, `user::TYPE_DELETED`, `UserDeletedPayload`, `DeleteDataScope` — consumed by `auth-service`'s `delete_account` and `messaging-service`'s `event_consumer`.

**No test coverage is lost.** `test_event_with_correlation_id` used `UserCreatedPayload`, but its subject is `EventEnvelope::with_correlation_id`; the payload type was incidental, so it is retargeted at `UserDeletedPayload` rather than deleted (`AGENTS.md` §8).

## Part 2 — the "silent degradation" was not silent

`implementation_plan.md` §6.2 says the Kafka producer *"degrades **silently** to `None`"*. That is not accurate — I checked both paths and **both already logged**:

- `main.rs` startup: `tracing::warn!` on producer creation failure
- `delete_account.rs`: an `else` branch warning when no producer is configured

The real gap was that neither was keyed for **alerting**, and neither said what the degradation actually costs. Both now carry a stable `degraded = "kafka_producer_unavailable"` field an alert rule can match on, instead of matching log prose, and both name the consequence explicitly: account deletions do not propagate to messaging, media or presence.

**The producer stays non-fatal**, per your decision. Auth is the most critical path in the system; if the broker is down, auth keeps serving rather than taking the product offline for a degraded background channel.

### One deliberate asymmetry

The per-request miss is raised from `warn` to **`error`**; the startup one stays `warn`. They are different events:

- Starting without a broker is a *degradation* — recoverable, and the operator can see it.
- Dropping a `user.deleted` **after the auth row is already gone** leaves orphaned personal data in three services that someone must reconcile by hand. That is an *incident*, and it has data-protection consequences.

## Verification

- `cargo clippy --workspace --exclude guardyn-e2e-tests --all-targets --all-features -- -D warnings` ✅
- `cargo test -p guardyn-common` — 15 passed ✅
- `just rules-verify` ✅ / `just docs-verify` ✅

## Budget

3 files, 112 lines.

## Deliberately out of scope

**An actual counter metric.** The backend has **no metrics facade** — `grep -rn 'metrics\|prometheus'` over `backend/` returns nothing, and `observability.rs` only mentions metrics in a doc comment. Adding one is a major dependency that needs an ADR and your approval per `AGENTS.md` §5.3, so I did not slip it in here. The structured `degraded` field is what this stack can carry today; real metrics belong with PR-43, which wires the observability stack.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)