### PR TITLE
feat(media): add the Health RPC and an object-store health check

### DIFF
--- a/backend/crates/media-service/src/handlers/health.rs
+++ b/backend/crates/media-service/src/handlers/health.rs
@@ -1,0 +1,73 @@
+//! Health check handler
+//!
+//! `media-service` was the only backend service without a `Health` RPC, so an
+//! operator had no way to tell a running-but-broken instance from a healthy one
+//! short of uploading a file.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tonic::{Request, Response, Status};
+
+use crate::proto::common::health_status::Status as HealthStatusEnum;
+use crate::proto::common::{HealthStatus, Timestamp};
+use crate::proto::media::HealthRequest;
+use crate::{db, storage};
+
+/// Report the service's own health plus that of each store it depends on.
+///
+/// Always returns `Ok`: a `Health` RPC that fails transport-level tells a probe
+/// nothing it can act on. An unreachable store is reported as `UNHEALTHY` in the
+/// body, with the failing component named in `components`.
+pub async fn handle(
+    _request: Request<HealthRequest>,
+    db: Arc<db::DatabaseClient>,
+    storage: Arc<storage::StorageClient>,
+) -> Result<Response<HealthStatus>, Status> {
+    let mut components = HashMap::new();
+    let mut healthy = true;
+
+    match db.health_check().await {
+        Ok(()) => {
+            components.insert("tikv".to_string(), "healthy".to_string());
+        }
+        Err(e) => {
+            // The error is logged, not returned: it can carry endpoint detail,
+            // and a health probe is an unauthenticated surface.
+            tracing::warn!(error = %e, "TiKV health check failed");
+            components.insert("tikv".to_string(), "unhealthy".to_string());
+            healthy = false;
+        }
+    }
+
+    match storage.health_check().await {
+        Ok(()) => {
+            components.insert("minio".to_string(), "healthy".to_string());
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Object store health check failed");
+            components.insert("minio".to_string(), "unhealthy".to_string());
+            healthy = false;
+        }
+    }
+
+    // SystemTime rather than chrono: media-service does not depend on chrono, and a
+    // timestamp is not worth a new dependency edge.
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    Ok(Response::new(HealthStatus {
+        status: if healthy {
+            HealthStatusEnum::Healthy as i32
+        } else {
+            HealthStatusEnum::Unhealthy as i32
+        },
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        timestamp: Some(Timestamp {
+            seconds: now.as_secs() as i64,
+            nanos: now.subsec_nanos() as i32,
+        }),
+        components,
+    }))
+}

--- a/backend/crates/media-service/src/handlers/mod.rs
+++ b/backend/crates/media-service/src/handlers/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod delete;
 pub mod download;
+pub mod health;
 pub mod list;
 pub mod metadata;
 pub mod presigned;

--- a/backend/crates/media-service/src/main.rs
+++ b/backend/crates/media-service/src/main.rs
@@ -39,12 +39,13 @@ pub mod proto {
     }
 }
 
+use proto::common::HealthStatus;
 use proto::media::{
     media_service_server::{MediaService, MediaServiceServer},
     DeleteMediaRequest, DeleteMediaResponse, DownloadMediaRequest, DownloadMediaResponse,
     GenerateThumbnailRequest, GenerateThumbnailResponse, GetDownloadUrlRequest,
     GetDownloadUrlResponse, GetMediaMetadataRequest, GetMediaMetadataResponse, GetUploadUrlRequest,
-    GetUploadUrlResponse, ListMediaRequest, ListMediaResponse, UploadMediaRequest,
+    GetUploadUrlResponse, HealthRequest, ListMediaRequest, ListMediaResponse, UploadMediaRequest,
     UploadMediaResponse,
 };
 
@@ -170,6 +171,13 @@ impl MediaService for MediaServiceImpl {
         request: Request<ListMediaRequest>,
     ) -> Result<Response<ListMediaResponse>, Status> {
         handlers::list::handle(request, self.db.clone(), &self.jwt_secret).await
+    }
+
+    async fn health(
+        &self,
+        request: Request<HealthRequest>,
+    ) -> Result<Response<HealthStatus>, Status> {
+        handlers::health::handle(request, self.db.clone(), self.storage.clone()).await
     }
 }
 

--- a/backend/crates/media-service/src/storage.rs
+++ b/backend/crates/media-service/src/storage.rs
@@ -3,7 +3,7 @@
 //! Handles file storage operations using AWS SDK for S3-compatible storage
 
 use crate::config::MediaConfig;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use aws_config::Region;
 use aws_credential_types::Credentials;
 use aws_sdk_s3::{
@@ -75,6 +75,21 @@ impl StorageClient {
             bucket: config.bucket_name.clone(),
             presigned_expiry: Duration::from_secs(config.presigned_url_expiry_seconds),
         })
+    }
+
+    /// Verify object-store connectivity.
+    ///
+    /// `head_bucket` on the configured bucket is the cheapest call that proves
+    /// both that MinIO is reachable and that our credentials still work - a
+    /// plain TCP connect would report healthy against a broken configuration.
+    pub async fn health_check(&self) -> Result<()> {
+        self.client
+            .head_bucket()
+            .bucket(&self.bucket)
+            .send()
+            .await
+            .context("object store health check failed")?;
+        Ok(())
     }
 
     /// Ensure the bucket exists (create if not)

--- a/backend/proto/media.proto
+++ b/backend/proto/media.proto
@@ -32,6 +32,9 @@ service MediaService {
 
   // List media files for a user or conversation
   rpc ListMedia(ListMediaRequest) returns (ListMediaResponse);
+
+  // Health check
+  rpc Health(HealthRequest) returns (guardyn.common.HealthStatus);
 }
 
 // Media type enumeration
@@ -231,3 +234,9 @@ message ListMediaResponse {
   int32 total_count = 3;        // Total items matching filter
   guardyn.common.ErrorResponse error = 4;
 }
+
+// ============================================================================
+// Health Check
+// ============================================================================
+
+message HealthRequest {}

--- a/docs/spec/SAD.md
+++ b/docs/spec/SAD.md
@@ -55,7 +55,7 @@ Ten members in the `backend/` workspace.
 | `auth-service` | binary | common, crypto | Identity, devices, contacts, key bundles. 13 handlers. |
 | `messaging-service` | binary | common, crypto | Messages, conversations, groups, reactions, receipts. 32 handlers. |
 | `presence-service` | binary | common | Reachability and status. 8 handlers. |
-| `media-service` | binary | common | Encrypted blob upload and retrieval. 8 handlers. |
+| `media-service` | binary | common | Encrypted blob upload and retrieval. 9 handlers. |
 | `call-service` | binary | common, crypto | Call signalling and SFrame key exchange. |
 | `notification-service` | binary | common | Push delivery and settings. |
 | `common` | library | — | Config, errors, observability, Kafka, rate limiting, event envelopes. |
@@ -152,6 +152,11 @@ alertmanager configuration.
 ## Known structural gaps
 
 Recorded here because a blueprint that hides its holes is not a blueprint.
+
+All six services expose `Health`, returning `guardyn.common.HealthStatus` with a
+per-component map. `media-service` was the last to gain one (PR-27); it reports `tikv` and
+`minio`. A `Health` call always succeeds at the transport level and reports an unreachable
+store in the body, so a probe can distinguish "service down" from "dependency down".
 
 | Gap | Consequence | Owned by |
 |---|---|---|


### PR DESCRIPTION
## What

`media-service` was **the only backend service without a `Health` RPC**, so an operator had no way to tell a running-but-broken instance from a healthy one short of uploading a file. It now reports both stores it depends on: `tikv` and `minio`.

The proto change is **additive** — a new RPC and an empty `HealthRequest` — so deployed v1.0.1 clients are unaffected. It follows the shape the other five services already use, returning `guardyn.common.HealthStatus` with a per-component map.

## Design points worth reviewing

**`head_bucket`, not a TCP connect.** `StorageClient::health_check()` issues `head_bucket` against the configured bucket. That is the cheapest call that proves both that MinIO is *reachable* **and** that our credentials still work — a plain connect would report healthy against a broken configuration, which is the failure mode a health check exists to catch.

**The handler always returns `Ok`.** A `Health` RPC that fails at the transport level tells a probe nothing it can act on. An unreachable store is reported as `UNHEALTHY` **in the body**, with the failing component named in `components`. That is what lets a probe distinguish *"service down"* from *"dependency down"* — they need different responses.

**Store errors are logged, not returned.** They can carry endpoint detail, and a health endpoint is an unauthenticated surface.

**`SystemTime`, not `chrono`.** `media-service` does not depend on `chrono`, and a timestamp is not worth a new dependency edge.

The handler lives in its own file under `handlers/`, per the one-handler-per-file rule in `AGENTS.md` §5.1 — which is also why `media-service`'s handler count in `SAD.md` goes from 8 to 9.

## Verification

- `cargo clippy --workspace --exclude guardyn-e2e-tests --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `just rules-verify` ✅ — `RS-UNWRAP` at 52, unmoved
- `just docs-verify` ✅ — run **after** committing; `backend/proto/` maps to `SRS.md`, `GLOSSARY.md` and `SAD.md`, and `SAD.md` is updated here

## Budget

6 files, 117 lines.

## Deliberately out of scope

The wider **store and bus health checks across the other five services** — that is PR-27's second half and touches five more crates, which is why the step was split.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)