### PR TITLE
fix(presence): make typing-indicator expiry TTL-correct

### DIFF
--- a/backend/crates/presence-service/src/db.rs
+++ b/backend/crates/presence-service/src/db.rs
@@ -19,6 +19,25 @@ pub struct UserPresence {
     pub updated_at: i64, // Unix timestamp in milliseconds
 }
 
+/// How long a typing indicator stays valid, in milliseconds.
+///
+/// Ten seconds: long enough to survive a slow keystroke cadence, short enough that a
+/// client which disconnects mid-compose stops showing as typing almost immediately.
+pub const TYPING_TTL_MS: i64 = 10_000;
+
+// The value itself is a product decision, but two properties are not: a non-positive TTL
+// expires every indicator instantly, and a long one leaves users shown as typing after
+// they have gone. Asserted at compile time, so a bad edit cannot reach a test run.
+const _: () = assert!(TYPING_TTL_MS > 0 && TYPING_TTL_MS < 60_000);
+
+/// Whether a typing indicator stamped at `started_at` has expired by `now`.
+///
+/// Both arguments are Unix milliseconds. An indicator is still live at exactly
+/// [`TYPING_TTL_MS`] and expires past it.
+pub fn typing_expired(started_at: i64, now: i64) -> bool {
+    now - started_at > TYPING_TTL_MS
+}
+
 /// Typing indicator (ephemeral state)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TypingIndicator {
@@ -102,8 +121,14 @@ impl DatabaseClient {
         Ok(presences)
     }
 
-    /// Set typing indicator (ephemeral - short TTL would be ideal, but TiKV doesn't have TTL)
-    /// In production, this would use Redis or similar with TTL support
+    /// Set a typing indicator.
+    ///
+    /// Expiry is enforced by this module rather than by the store: writers stamp
+    /// `started_at`, and readers treat anything older than [`TYPING_TTL_MS`] as
+    /// absent and delete it. TiKV has no native key TTL, and per
+    /// [ADR-0006](../../../../docs/adr/ADR-0006-no-cache-layer.md) the
+    /// Dragonfly/Redis layer that would provide one is deferred post-launch.
+    /// This is the TTL implementation, not a placeholder for one.
     pub async fn set_typing(
         &self,
         user_id: &str,
@@ -144,10 +169,18 @@ impl DatabaseClient {
 
         let indicator: TypingIndicator = serde_json::from_slice(&indicator_data)?;
 
-        // Check if typing indicator is stale (older than 10 seconds)
+        // Lazy expiry. Reporting the indicator as absent is not enough on its own:
+        // without the delete, every `/typing/` key a client ever wrote would stay in
+        // TiKV forever, because nothing else removes a key whose author disconnected
+        // before sending `is_typing = false`.
         let now = chrono::Utc::now().timestamp_millis();
-        if now - indicator.started_at > 10_000 {
-            // Typing indicator expired
+        if typing_expired(indicator.started_at, now) {
+            let key = format!("/typing/{}/{}", user_id, conversation_user_id).into_bytes();
+            if let Err(e) = self.client.delete(key).await {
+                // Not fatal: the caller asked whether someone is typing, and the answer
+                // is no either way. A failed sweep is retried on the next read.
+                tracing::warn!(error = %e, "Failed to delete expired typing indicator");
+            }
             return Ok(None);
         }
 
@@ -166,6 +199,29 @@ impl DatabaseClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_typing_expired_boundary() {
+        let started = 1_000_000i64;
+
+        assert!(!typing_expired(started, started), "not expired at zero age");
+        assert!(
+            !typing_expired(started, started + TYPING_TTL_MS),
+            "still live at exactly the TTL"
+        );
+        assert!(
+            typing_expired(started, started + TYPING_TTL_MS + 1),
+            "expired one millisecond past the TTL"
+        );
+    }
+
+    #[test]
+    fn test_typing_expired_tolerates_clock_skew_backwards() {
+        // A reader whose clock is behind the writer's must not treat the
+        // indicator as expired - it would flap the typing state.
+        let started = 1_000_000i64;
+        assert!(!typing_expired(started, started - 5_000));
+    }
 
     #[test]
     fn test_user_presence_default() {
@@ -279,7 +335,7 @@ mod tests {
             is_typing: true,
             started_at: now - 1000,
         };
-        assert!(now - fresh.started_at <= 10_000);
+        assert!(now - fresh.started_at <= TYPING_TTL_MS);
 
         // Stale indicator (15 seconds ago)
         let stale = TypingIndicator {
@@ -288,7 +344,7 @@ mod tests {
             is_typing: true,
             started_at: now - 15_000,
         };
-        assert!(now - stale.started_at > 10_000);
+        assert!(now - stale.started_at > TYPING_TTL_MS);
     }
 
     #[test]


### PR DESCRIPTION
## The comment was wrong twice over

`db.rs` carried:

```rust
/// Set typing indicator (ephemeral - short TTL would be ideal, but TiKV doesn't have TTL)
/// In production, this would use Redis or similar with TTL support
```

next to an implementation that **already** expired indicators on read. It described working code as a placeholder, and proposed a datastore that [ADR-0006](docs/adr/ADR-0006-no-cache-layer.md) explicitly defers post-launch. That is the kind of silent gap this phase exists to close.

## There was a real defect underneath it

`get_typing` returned `None` for a stale indicator **but never deleted the key**. Every `/typing/{user}/{peer}` entry whose author disconnected before sending `is_typing = false` stayed in TiKV forever — nothing else removes them, so the keyspace grew without bound.

Reads now delete on expiry (lazy expiry). A failed delete is a `warn`, not an error: the caller asked whether someone is typing, and the answer is *no* either way, so a failed sweep just retries on the next read.

## Tightening

- The 10-second window is now `TYPING_TTL_MS`, not a literal repeated between the reader and its test. The pre-existing `test_typing_indicator_stale_check_logic` referenced a hardcoded `10_000`; it now uses the constant, so the two cannot drift.
- The comparison is extracted into `typing_expired(started_at, now)` so the boundary is testable **without a TiKV client**.
- Bounds on the constant are asserted at **compile time**: `const _: () = assert!(TYPING_TTL_MS > 0 && TYPING_TTL_MS < 60_000);`

That last one is worth explaining. I first wrote it as a test, and clippy rejected it — `assert!` on a `const` folds to a constant value, so the test asserted nothing. `-D warnings` caught it. The compile-time form is the stronger version anyway: a bad edit cannot even reach a test run.

## Two behaviours the tests pin

- An indicator is still live at **exactly** `TYPING_TTL_MS` and expires past it.
- A reader whose clock is **behind** the writer's does not treat the indicator as expired — otherwise the typing state would flap under ordinary clock skew.

## Verification

- `cargo clippy --workspace --exclude guardyn-e2e-tests --all-targets --all-features -- -D warnings` ✅
- `cargo test -p guardyn-presence-service` — 37 passed ✅
- `just rules-verify` ✅ / `just docs-verify` ✅ (`presence-service` maps to nothing in `docs/.manifest.yaml`)

## Budget

1 file, 70 lines.

## Deliberately out of scope

A **background sweep** for keys that are never read again. Lazy expiry bounds growth for anything a client polls — which is every conversation view — so a sweeper is only worth adding if that assumption stops holding.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)