### PR TITLE
security(mls): stop the server holding MLS group secrets

### DIFF
--- a/backend/crates/crypto/src/lib.rs
+++ b/backend/crates/crypto/src/lib.rs
@@ -35,7 +35,7 @@ mod x3dh_conversion_tests;
 // Re-exports for convenience
 pub use double_ratchet::DoubleRatchet;
 pub use key_storage::{create_test_storage, KeyMetadata, KeyStorage, KeyType};
-pub use mls::{create_test_credential, MlsGroupManager};
+pub use mls::MlsGroupManager;
 pub use padding::{next_padme_length, pad_message, unpad_message};
 pub use pqxdh::{generate_hybrid_key_bundle, HybridKeyBundle, HybridSharedSecret};
 pub use sealed_sender::{SealedSender, SealedSenderEnvelope, SenderCertificate};

--- a/backend/crates/crypto/src/mls.rs
+++ b/backend/crates/crypto/src/mls.rs
@@ -448,10 +448,16 @@ impl MlsGroupManager {
         }
     }
 
-    /// Serialize group state for storage
+    /// Export a 32-byte secret derived from the current epoch secret.
     ///
-    /// # Returns
-    /// MlsGroupState with serialized group data
+    /// # This does not serialize the group
+    ///
+    /// The name is wrong and there is no deserializer: a group cannot be
+    /// restored from what this returns. Real persistence is the OpenMLS
+    /// `StorageProvider`'s job, paired with `MlsGroup::load`. Tracked in #158,
+    /// which replaces this and migrates `client-desktop` off it.
+    ///
+    /// The server no longer calls this at all — it holds no group state.
     pub fn serialize_state(&self) -> Result<MlsGroupState> {
         let serialized_state = self
             .mls_group
@@ -496,24 +502,6 @@ impl MlsGroupManager {
 /// ⚠️ WARNING: This is for testing only! In production, signature keypairs
 /// should be generated securely and stored with proper key management.
 pub fn create_test_keypair() -> Result<SignatureKeyPair> {
-    let signature_keypair = SignatureKeyPair::new(MLS_CIPHERSUITE.signature_algorithm())
-        .map_err(|e| CryptoError::Protocol(format!("Failed to generate signature key: {:?}", e)))?;
-    Ok(signature_keypair)
-}
-
-/// Helper function to create test credential for MLS operations
-///
-/// This is a convenience function for testing and development.
-/// In production, use proper credential management with secure storage.
-///
-/// # Arguments
-/// * `identity` - User identity bytes (typically "user_id:device_id")
-///
-/// # Returns
-/// SignatureKeyPair for MLS operations
-pub fn create_test_credential(_identity: &[u8]) -> Result<SignatureKeyPair> {
-    // Note: identity parameter is kept for API compatibility but not used
-    // OpenMLS 0.6 SignatureKeyPair::new() only takes signature scheme
     let signature_keypair = SignatureKeyPair::new(MLS_CIPHERSUITE.signature_algorithm())
         .map_err(|e| CryptoError::Protocol(format!("Failed to generate signature key: {:?}", e)))?;
     Ok(signature_keypair)

--- a/backend/crates/messaging-service/src/mls_manager.rs
+++ b/backend/crates/messaging-service/src/mls_manager.rs
@@ -1,23 +1,24 @@
-/// MLS Group Manager Integration for Messaging Service
-///
-/// Provides a high-level interface to manage MLS group state,
-/// including serialization, TiKV storage, and integration with
-/// the crypto crate's MlsGroupManager.
+//! MLS membership index for the messaging service.
+//!
+//! The server keeps a membership list and a monotonic epoch counter, and
+//! nothing else. Group state, epoch secrets and credentials live on the
+//! clients; the server routes opaque `Welcome`, `Commit` and ciphertext blobs
+//! and cannot read any of them.
+
 use crate::db::DatabaseClient;
 use anyhow::{Context, Result};
-use guardyn_crypto::mls::{MlsGroupManager, MlsGroupState};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{error, info};
 
-/// Group state storage paths in TiKV
-const MLS_GROUP_STATE_PREFIX: &str = "/mls/groups";
+/// Group metadata storage paths in TiKV
+const MLS_GROUP_METADATA_PREFIX: &str = "/mls/groups";
 const MLS_GROUP_MEMBERS_PREFIX: &str = "/mls/group_members";
 
-/// MLS Manager for Messaging Service
+/// MLS membership index.
 ///
-/// Manages MLS group state persistence and provides helper methods
-/// for group operations (create, add/remove members, encrypt/decrypt).
+/// Tracks who is in a group and which epoch the group is on. Deliberately has
+/// no group-state, encrypt or decrypt operations: holding those server-side is
+/// what invariant I-1 forbids.
 #[allow(dead_code)]
 pub struct MlsManager {
     db: Arc<DatabaseClient>,
@@ -38,126 +39,6 @@ impl MlsManager {
     /// Create a new MLS manager instance
     pub fn new(db: Arc<DatabaseClient>) -> Self {
         Self { db }
-    }
-
-    /// Create a new MLS group
-    ///
-    /// # Arguments
-    /// * `group_id` - Unique group identifier
-    /// * `creator_identity` - Creator's identity (user_id:device_id)
-    /// * `credential_bundle_bytes` - Serialized credential bundle
-    ///
-    /// # Returns
-    /// Serialized group state for initial storage
-    pub async fn create_group(
-        &self,
-        group_id: &str,
-        creator_user_id: &str,
-        creator_device_id: &str,
-        creator_identity: &[u8],
-    ) -> Result<MlsGroupState> {
-        info!("Creating MLS group: {}", group_id);
-
-        // Create MLS group using crypto crate
-        // Note: In a real implementation, we need to pass the actual credential bundle
-        // For now, we'll generate it on the fly (should be fetched from user's stored credentials)
-        let credential_bundle = guardyn_crypto::mls::create_test_credential(creator_identity)?;
-
-        let group_manager =
-            MlsGroupManager::create_group(group_id, creator_identity, credential_bundle)?;
-
-        // Serialize group state
-        let group_state = group_manager.serialize_state()?;
-
-        // Store group state in TiKV
-        let state_key = format!("{}/{}/state", MLS_GROUP_STATE_PREFIX, group_id);
-        let state_json =
-            serde_json::to_vec(&group_state).context("Failed to serialize group state")?;
-        self.db.put(state_key.as_bytes(), state_json).await?;
-
-        // Store group metadata
-        let metadata = GroupMetadata {
-            group_id: group_id.to_string(),
-            creator_user_id: creator_user_id.to_string(),
-            creator_device_id: creator_device_id.to_string(),
-            created_at: chrono::Utc::now().timestamp(),
-            current_epoch: 0,
-            member_count: 1,
-        };
-
-        let metadata_key = format!("{}/{}/metadata", MLS_GROUP_STATE_PREFIX, group_id);
-        let metadata_json =
-            serde_json::to_vec(&metadata).context("Failed to serialize metadata")?;
-        self.db.put(metadata_key.as_bytes(), metadata_json).await?;
-
-        // Add creator to members list
-        self.add_member_to_list(group_id, creator_user_id, creator_device_id)
-            .await?;
-
-        info!("MLS group created: {}", group_id);
-        Ok(group_state)
-    }
-
-    /// Load MLS group state from TiKV
-    ///
-    /// # Arguments
-    /// * `group_id` - Unique group identifier
-    ///
-    /// # Returns
-    /// Deserialized MLS group state
-    pub async fn load_group_state(&self, group_id: &str) -> Result<MlsGroupState> {
-        let state_key = format!("{}/{}/state", MLS_GROUP_STATE_PREFIX, group_id);
-
-        let state_bytes = self
-            .db
-            .get(state_key.as_bytes())
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Group state not found: {}", group_id))?;
-
-        let group_state: MlsGroupState =
-            serde_json::from_slice(&state_bytes).context("Failed to deserialize group state")?;
-
-        Ok(group_state)
-    }
-
-    /// Save MLS group state to TiKV
-    ///
-    /// # Arguments
-    /// * `group_id` - Unique group identifier
-    /// * `group_state` - Serialized group state to save
-    pub async fn save_group_state(
-        &self,
-        group_id: &str,
-        group_state: &MlsGroupState,
-    ) -> Result<()> {
-        let state_key = format!("{}/{}/state", MLS_GROUP_STATE_PREFIX, group_id);
-        let state_json =
-            serde_json::to_vec(group_state).context("Failed to serialize group state")?;
-
-        self.db.put(state_key.as_bytes(), state_json).await?;
-
-        // Update epoch in metadata
-        self.update_epoch(group_id, group_state.epoch).await?;
-
-        Ok(())
-    }
-
-    /// Update group epoch in metadata
-    async fn update_epoch(&self, group_id: &str, epoch: u64) -> Result<()> {
-        let metadata_key = format!("{}/{}/metadata", MLS_GROUP_STATE_PREFIX, group_id);
-
-        if let Some(metadata_bytes) = self.db.get(metadata_key.as_bytes()).await? {
-            let mut metadata: GroupMetadata = serde_json::from_slice(&metadata_bytes)
-                .context("Failed to deserialize metadata")?;
-
-            metadata.current_epoch = epoch;
-
-            let updated_json =
-                serde_json::to_vec(&metadata).context("Failed to serialize metadata")?;
-            self.db.put(metadata_key.as_bytes(), updated_json).await?;
-        }
-
-        Ok(())
     }
 
     /// Add member to group members list
@@ -218,7 +99,7 @@ impl MlsManager {
 
     /// Increment member count in metadata
     async fn increment_member_count(&self, group_id: &str) -> Result<()> {
-        let metadata_key = format!("{}/{}/metadata", MLS_GROUP_STATE_PREFIX, group_id);
+        let metadata_key = format!("{}/{}/metadata", MLS_GROUP_METADATA_PREFIX, group_id);
 
         if let Some(metadata_bytes) = self.db.get(metadata_key.as_bytes()).await? {
             let mut metadata: GroupMetadata = serde_json::from_slice(&metadata_bytes)
@@ -236,7 +117,7 @@ impl MlsManager {
 
     /// Decrement member count in metadata
     async fn decrement_member_count(&self, group_id: &str) -> Result<()> {
-        let metadata_key = format!("{}/{}/metadata", MLS_GROUP_STATE_PREFIX, group_id);
+        let metadata_key = format!("{}/{}/metadata", MLS_GROUP_METADATA_PREFIX, group_id);
 
         if let Some(metadata_bytes) = self.db.get(metadata_key.as_bytes()).await? {
             let mut metadata: GroupMetadata = serde_json::from_slice(&metadata_bytes)
@@ -262,7 +143,7 @@ impl MlsManager {
     /// # Returns
     /// Group metadata if exists
     pub async fn get_metadata(&self, group_id: &str) -> Result<Option<GroupMetadata>> {
-        let metadata_key = format!("{}/{}/metadata", MLS_GROUP_STATE_PREFIX, group_id);
+        let metadata_key = format!("{}/{}/metadata", MLS_GROUP_METADATA_PREFIX, group_id);
 
         match self.db.get(metadata_key.as_bytes()).await? {
             Some(metadata_bytes) => {
@@ -274,26 +155,16 @@ impl MlsManager {
         }
     }
 
-    /// Get current MLS epoch for a group
+    /// Get the current MLS epoch for a group.
     ///
-    /// Returns the current epoch number, or 0 if the group doesn't have MLS state
-    ///
-    /// # Arguments
-    /// * `group_id` - Group identifier
-    ///
-    /// # Returns
-    /// Current epoch number
+    /// Returns 0 for a group with no metadata: the epoch is a counter the
+    /// clients advance, and a group the server has not seen a commit for is at
+    /// its initial epoch.
     pub async fn get_current_epoch(&self, group_id: &str) -> Result<u64> {
-        match self.get_metadata(group_id).await? {
-            Some(metadata) => Ok(metadata.current_epoch),
-            None => {
-                // Try to load from group state if metadata doesn't exist
-                match self.load_group_state(group_id).await {
-                    Ok(state) => Ok(state.epoch),
-                    Err(_) => Ok(0), // Default to epoch 0
-                }
-            }
-        }
+        Ok(self
+            .get_metadata(group_id)
+            .await?
+            .map_or(0, |metadata| metadata.current_epoch))
     }
 
     /// Check if user is a member of the group

--- a/docs/adr/ADR-0004-openmls-group-e2ee.md
+++ b/docs/adr/ADR-0004-openmls-group-e2ee.md
@@ -59,11 +59,27 @@ correctly; any test or handler that expects a self round-trip is wrong.
 secret rather than the group, and there is no deserialization counterpart. A two-party
 exchange is also not yet possible: `generate_key_package` drops the provider and signature
 keypair it creates, and `join_group` builds a fresh empty provider with no init keys, so no
-Welcome can be processed. PR-31 (#42) owns all of it.
+Welcome can be processed.
 
 This ADR previously recorded the defect as "group state serialization fails to round-trip
 (`SecretTreeError(RatchetTypeError)`)". That conflated two unrelated things: the error comes
 from self-decryption, and the round-trip does not fail so much as never happen.
+
+**The server does not participate in MLS.** PR-31 (#42, #151, #152, #153) removes the
+server-side group operations entirely rather than repairing them. The server keeps a membership
+index and a monotonic epoch counter over opaque blobs; group state, epoch secrets and
+credentials exist only on the clients. `MlsGroup::load<Storage: StorageProvider>` does exist
+(`openmls-0.6.0/src/group/mls_group/mod.rs:417`) — the in-code comments claiming otherwise were
+wrong — and that is precisely why the server must not hold group state: `load` restores
+`group_epoch_secrets`, so a server able to reload a group is a server able to decrypt it.
+
+`create_test_credential` is gone. It ignored its `identity` argument and was a byte-for-byte
+duplicate of `create_test_keypair`, so the server calling it with a user's identity minted a
+credential unrelated to that user — while appearing to act as them. Its only caller was the
+server-side `create_group` path.
+
+The client-side half of `serialize_state` is [#158](https://github.com/guardyn/guardyn/issues/158):
+`client-desktop` persists the 32-byte export believing a group can be restored from it.
 
 ## Alternatives rejected
 


### PR DESCRIPTION
Closes #151

Second of four steps implementing the pure-relay decision. **Stacked on #157** — review that first;
this PR targets its branch, and GitHub will retarget to `main` when #157 merges.

## Two I-1 breaches, both deleted

**The server created groups as the user.** `MlsManager::create_group` called
`create_test_credential(creator_identity)` and built the MLS group with the result. That function
ignores its `identity` argument — it is a byte-for-byte duplicate of `create_test_keypair`:

```rust
pub fn create_test_credential(_identity: &[u8]) -> Result<SignatureKeyPair> {
    // Note: identity parameter is kept for API compatibility but not used
    let signature_keypair = SignatureKeyPair::new(MLS_CIPHERSUITE.signature_algorithm())?;
```

So the server minted a credential unrelated to the user, while appearing to act as them. Its only
caller was this path; it comes out of `crypto/src/mls.rs` and the `lib.rs` re-export too.

**The server persisted a group secret.** `save_group_state` wrote what `serialize_state` returns —
32 bytes exported from the current epoch secret — into TiKV under `/mls/groups/<id>/state`, and
`load_group_state` read it back.

The fix is deletion rather than a working round-trip, and the reason is worth stating plainly:
`MlsGroup::load` **does** exist (`openmls-0.6.0/src/group/mls_group/mod.rs:417`, contrary to the
in-code comments #157 deletes) and it restores `group_epoch_secrets`. A server that can reload a
group is a server that can decrypt it. Making the round-trip work would have been the breach.

## What the server keeps

A membership index and a monotonic epoch counter, both over data it cannot read:
`add_member_to_list`, `remove_member_from_list`, `get_current_epoch`, `get_metadata`, `is_member`.
These are the only three `MlsManager` methods any registered handler reaches
(`add_group_member.rs:178`, `remove_group_member.rs:198`, `send_group_message.rs:138`).

`get_current_epoch` no longer falls back to loading group state. A group with no metadata is at
epoch 0 — which is what "the clients have not committed yet" means.

## Why `serialize_state` survives this PR

`client-desktop/src-tauri/src/commands/mls.rs:329` calls it and persists the 32-byte export to
secure storage, believing a group can be restored from it. It cannot. That is a real client-side
defect, but crypto and `client-desktop` have to move together and this step is scoped to the
server — so it is **#158**, and `serialize_state`s doc comment now describes what it does rather
than what its name claims.

## Verification

- `cargo clippy -p guardyn-crypto -p guardyn-messaging-service --all-targets --all-features -- -D warnings` clean
- 132 tests pass (91 crypto + 22 + 19); no test deleted or weakened
- `rules-verify`, `docs-verify` green

## Budget

4 files, 34 insertions, 175 deletions. ADR-0004 records the architecture and the
`create_test_credential` removal, per the `backend/crates/crypto/` manifest mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)