### PR TITLE
docs(adr): record the pure-relay architecture and correct the two documents that inverted it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,18 @@ ask the user.** Do not proceed under an assumption.
 
 Two invariants are **currently unmet**. Do not "fix" them ad hoc — they have owned steps:
 
-- **I-2 is violated.** `messaging-service/src/handlers/` carries duplicate handler pairs
-  (`send_message.rs` vs `send_message_e2ee.rs`, and three more). **The non-E2EE path is the
-  registered one.** `docker-compose.dev.yml` sets `GUARDYN_E2EE_ENABLED=false`.
-  → Repaired by **PR-32**. Breaking change, already approved.
+- **I-2 is violated.** `messaging-service/src/handlers/` carried duplicate handler pairs and a
+  `GUARDYN_E2EE_ENABLED` flag selecting between them.
+  → Repaired by **PR-32a/b/c** and **PR-30′**. Breaking change, already approved.
+
+  **This entry previously said the opposite of the truth, and the correction is load-bearing.**
+  It claimed four such pairs existed and that the fix was to collapse onto the `_e2ee`
+  variants. There were **two** (`send_message`, `receive_messages`), and the `_e2ee` variants
+  were the violation, not the fix: they encrypted server-side and held the ratchet state
+  (`send_message_e2ee.rs:129`, `receive_messages_e2ee.rs:177`). The unsuffixed handler was
+  already the zero-knowledge relay. Collapsing the way this file used to direct would have
+  traded an I-2 violation for an I-1 one. See
+  [ADR-0010](docs/adr/ADR-0010-pure-relay-server.md).
 - **I-3 is unmet.** `crypto/src/pqxdh.rs` is a real hybrid implementation, but the `pq`
   feature is off by default and no backend service enables it — and decisively,
   `backend/proto/` contains **zero** ML-KEM fields, so the server cannot publish a PQ

--- a/docs/adr/ADR-0004-openmls-group-e2ee.md
+++ b/docs/adr/ADR-0004-openmls-group-e2ee.md
@@ -81,6 +81,9 @@ server-side `create_group` path.
 The client-side half of `serialize_state` is [#158](https://github.com/guardyn/guardyn/issues/158):
 `client-desktop` persists the 32-byte export believing a group can be restored from it.
 
+The architecture that replaced the server-side MLS implementation is
+[ADR-0010](ADR-0010-pure-relay-server.md).
+
 ## Alternatives rejected
 
 **libsignal** — proven, but a hard build across five targets and effectively closed to a

--- a/docs/adr/ADR-0010-pure-relay-server.md
+++ b/docs/adr/ADR-0010-pure-relay-server.md
@@ -1,0 +1,124 @@
+---
+id: adr-0010
+type: adr
+status: accepted
+owns: [backend/crates/messaging-service/src/mls_manager.rs, backend/crates/messaging-service/src/handlers/send_message.rs, backend/crates/messaging-service/src/handlers/receive_messages.rs]
+read_when: [touching messaging-service, changing the message path, implementing MLS on a client]
+tokens: 0
+supersedes: []
+---
+
+# ADR-0010 · The server is a pure relay; MLS and the ratchet run on the clients
+
+## Status
+
+`accepted`
+
+## Context
+
+`messaging-service` held the key material for every conversation. Three separate mechanisms,
+all reachable, all removed in Phase 3:
+
+| Mechanism | Where | What the server held |
+|---|---|---|
+| Double Ratchet session store | `models.rs` `RatchetSession.ratchet_state` | "DH keys, root key, chain keys, message counters, skipped keys" — its own words |
+| Server-side E2EE handlers | `send_message_e2ee.rs`, `receive_messages_e2ee.rs` | encrypted on send, decrypted on receive, held the ratchet |
+| MLS group state | `mls_manager.rs`, `crypto/src/mls.rs` `serialize_state` | a 32-byte secret exported from the epoch secret |
+
+Each was presented as progress toward E2EE. Each was the opposite: a design in which the
+server is a party to the encryption rather than blind to it. Invariant I-1 says the server
+must never be able to read plaintext, and a server holding the ratchet state can read all of
+it.
+
+The plan of record made this worse rather than better. `AGENTS.md` §1 and
+`implementation_plan.md` §6.3 both directed PR-32 to collapse the duplicated handler pairs
+**onto the `_e2ee` variants**, on the reasonable-looking assumption that a file named
+`_e2ee` is the encrypted one. It is not. Two comments in that code settle it:
+
+```rust
+// send_message_e2ee.rs:129
+&request.encrypted_content, // Client should send plaintext, we encrypt server-side
+
+// receive_messages_e2ee.rs:177
+encrypted_content: decrypted_content, // Now contains plaintext
+```
+
+The unsuffixed handler passes `request.encrypted_content` through untouched. **It was already
+the zero-knowledge relay.** Following the plan would have deleted it and kept the path where
+the server holds the keys — trading an I-2 violation for an I-1 one.
+
+A second false premise sat under PR-31. In-code comments claimed OpenMLS 0.6 cannot
+deserialize a group, and the "workaround" was to rebuild the group from scratch on every
+membership change. `MlsGroup::load<Storage: StorageProvider>` exists, at
+`openmls-0.6.0/src/group/mls_group/mod.rs:417`. But making the round-trip work would have been
+the breach, not the fix: `load` restores `group_epoch_secrets`, so a server able to reload a
+group is a server able to decrypt it.
+
+## Decision
+
+**The server relays opaque bytes and holds no key material.**
+
+It keeps:
+
+- ciphertext, stored and returned byte-for-byte
+- opaque `KeyPackage`, `Welcome` and `Commit` blobs, routed to their recipients
+- a membership index — who is in which group
+- a monotonic epoch counter the clients advance
+
+It holds **none** of: group state, epoch secrets, MLS credentials, identity keys, ratchet
+state, or any derived secret.
+
+All group operations — create, add, remove, commit, encrypt, decrypt — run on the clients.
+The server cannot perform them, and after Phase 3 it has no code that tries.
+
+## Consequences
+
+**A message is only as encrypted as the client makes it.** With the server out of the
+encryption path there is no longer anything to compensate for a client that does not encrypt.
+`client-desktop` is exactly that case — it puts plaintext in `encrypted_content`
+(`commands/messaging.rs:86`), which the server used to encrypt on its behalf. That must be
+fixed before the flag removal lands; see the sequencing note below.
+
+**Group state persistence becomes a client concern**, and the right mechanism is the OpenMLS
+`StorageProvider` paired with `MlsGroup::load` — not the 32-byte export that
+`serialize_state` returns today.
+
+**The epoch counter is advisory.** The server increments it on relayed commits but cannot
+verify one. A client must treat MLS state as authoritative and the counter as a hint for
+ordering.
+
+**Deployment loses its encryption switches.** `GUARDYN_E2EE_ENABLED` and `GUARDYN_MLS_ENABLED`
+are gone from every surface, and `rules-verify` fails the build if either name returns. This
+is what I-2 means in practice: not a default, an absence.
+
+## Sequencing
+
+Phase 3 implements this across seven steps:
+
+| Step | Issue | What |
+|---|---|---|
+| PR-31a | #42 | delete the dead `*_mls.rs` handlers |
+| PR-31b | #151 | delete server-held MLS secrets and `create_test_credential` |
+| PR-31c | #152 | remove the crate-wide `dead_code` allow that hid it |
+| PR-31d | #153 | this ADR |
+| PR-32a | #43 | delete the server-side E2EE handlers |
+| PR-32b | #154 | delete the E2EE and MLS configuration flags |
+| PR-32c | #155 | delete the deployment variables — **blocked on client-desktop encrypting (#163)** |
+| PR-30′ | #41 | delete the server-side Double Ratchet key storage |
+
+Follow-ups outside Phase 3: #158 (real group-state persistence, both sides), #163
+(`client-desktop` encryption).
+
+## Alternatives rejected
+
+**Collapse onto the `_e2ee` handlers, as originally planned.** Rejected on the evidence above:
+it keeps the server in the encryption path and breaches I-1.
+
+**Keep server-side encryption as "encryption at rest".** It is genuinely better than storing
+plaintext, and it is what production ran. But it is not what this product claims, and a server
+that can decrypt is a server that can be compelled to. The claim is zero-knowledge; the
+architecture has to match it.
+
+**Repair the MLS round-trip with `MlsGroup::load`.** Technically available, and it would have
+made the existing code work. Rejected because working code is the wrong goal here — a server
+that can reload a group can decrypt every message in it.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -28,6 +28,7 @@ accepted ADR **and** explicit user approval (`AGENTS.md` §5.3).
 | [0007](ADR-0007-zero-knowledge-logging.md) | Zero-knowledge logging and mandatory redaction | accepted — **2 known violations** |
 | [0008](ADR-0008-protobuf-codegen.md) | Generated protobuf in `OUT_DIR`, not committed | accepted — **3 strategies coexist** |
 | [0009](ADR-0009-micro-step-budget.md) | Micro-step PR budget and branch isolation | accepted |
+| [0010](ADR-0010-pure-relay-server.md) | The server is a pure relay; MLS and the ratchet run on the clients | accepted |
 
 [`ADR-0000-template.md`](ADR-0000-template.md) is the shape. Copy it and take the next free
 number.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -56,11 +56,22 @@ reason phases 3 and 4 exist.
 
 | Invariant | State | Closed by |
 |---|---|---|
-| **I-2** Always-On E2EE | `GUARDYN_E2EE_ENABLED` still exists and the non-E2EE handler is the registered one | PR-32 (Phase 3) |
+| **I-2** Always-On E2EE | server-side encryption removed and no flag remains; `client-desktop` still sends plaintext | PR-30′, PR-31a–d, PR-32a–c (Phase 3) + #163 |
 | **I-3** Post-Quantum | `pq` is off by default and no proto field carries an ML-KEM key, so no server can publish one | PR-36…PR-40 (Phase 4) |
 
 Until those land, **the product must not be described as always-encrypted or
 post-quantum protected.**
+
+**I-2's scope changed during Phase 3.** The row above used to read "`GUARDYN_E2EE_ENABLED` still
+exists and the non-E2EE handler is the registered one", which had the fix backwards: the `_e2ee`
+handlers encrypted *server-side*, so the registered unsuffixed handler was already the relay.
+PR-32 is therefore three deletion steps rather than a collapse, and PR-30 and PR-31 are
+re-scoped with it. [ADR-0010](../adr/ADR-0010-pure-relay-server.md) records the architecture;
+`implementation_plan.md` §6.3 records the two false premises the original scoping rested on.
+
+The remaining gap is on the client, not the server: `client-desktop` puts plaintext in
+`encrypted_content` (#163), which the server used to encrypt on its behalf. PR-32c is blocked on
+that.
 
 ## After the revision
 

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -22,7 +22,7 @@ project_sync_enabled: true
 
 invariants:
   - {id: I-1, name: Zero-Knowledge,   met: partial, note: "rate_limit.rs logs a raw IP; span fields are not redacted"}
-  - {id: I-2, name: Always-On E2EE,   met: false,   closed_by: PR-32}
+  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c], note: "E2EE-DUP and E2EE-FLAG pass; PR-32c blocked on #163 - client-desktop sends plaintext"}
   - {id: I-3, name: Post-Quantum,     met: false,   closed_by: [PR-36, PR-37, PR-38, PR-39, PR-40]}
   - {id: I-4, name: Data Sovereignty, met: partial, note: "envoy/ingress.yaml hardcodes a domain"}
 
@@ -63,11 +63,19 @@ steps:
   - {id: PR-25, issue: 36, phase: 3, type: security, status: done, title: "Apply Redacted<T> across crypto, auth and messaging types"}
   - {id: PR-26, issue: 37, phase: 3, type: security, status: done, title: "Migrate call-service and notification-service to observability::init_tracing"}
   - {id: PR-27, issue: 38, phase: 3, type: feat, status: todo, title: "Add health checks for all stores and a media-service Health RPC"}
+  - {id: PR-27b, issue: 150, phase: 3, type: feat, status: todo, title: "Add store health checks to notification-service and call-service"}
   - {id: PR-28, issue: 39, phase: 3, type: refactor, status: done, title: "Wire or delete the unused Redpanda topic constants"}
   - {id: PR-29, issue: 40, phase: 3, type: fix, status: done, title: "Replace the presence-service Redis TODO with TTL-correct TiKV storage"}
-  - {id: PR-30, issue: 41, phase: 3, type: security, status: todo, title: "Implement a persistent KeyStorage backend"}
-  - {id: PR-31, issue: 42, phase: 3, type: fix, status: todo, title: "Fix MLS group state round-trip"}
-  - {id: PR-32, issue: 43, phase: 3, type: security, status: todo, title: "Enforce Always-On E2EE and remove the non-E2EE handler path"}
+  # PR-30/31/32 re-scoped under ADR-0010: the server becomes a pure relay. See
+  # implementation_plan.md 6.3 for the two false premises the original scoping rested on.
+  - {id: PR-30, issue: 41, phase: 3, type: security, status: todo, title: "Delete the server-side Double Ratchet key storage"}
+  - {id: PR-31a, issue: 42, phase: 3, type: fix, status: done, title: "Delete the dead server-side MLS handlers"}
+  - {id: PR-31b, issue: 151, phase: 3, type: security, status: todo, title: "Stop the server holding MLS group secrets"}
+  - {id: PR-31c, issue: 152, phase: 3, type: chore, status: todo, title: "Remove the blanket dead_code allow in messaging-service"}
+  - {id: PR-31d, issue: 153, phase: 3, type: docs, status: todo, title: "ADR-0010 - the server is a pure relay"}
+  - {id: PR-32a, issue: 43, phase: 3, type: security, status: done, title: "Delete the server-side E2EE handlers"}
+  - {id: PR-32b, issue: 154, phase: 3, type: security, status: todo, title: "Delete the E2EE and MLS configuration flags"}
+  - {id: PR-32c, issue: 155, phase: 3, type: security, status: todo, blocked_by: 163, title: "Remove the E2EE kill-switch environment variables"}
   - {id: PR-33, issue: 44, phase: 3, type: security, status: todo, title: "Add cargo-fuzz targets for attacker-controlled parsers"}
   - {id: PR-34, issue: 45, phase: 3, type: security, status: todo, title: "Add proptest suites for crypto invariants"}
   - {id: PR-35, issue: 46, phase: 3, type: chore, status: todo, gate: G3, title: "Add baseline test coverage for notification-service and call-service"}

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -455,24 +455,33 @@ Per the approved ADRs — **no store is added or removed in this phase**.
 
 ### 6.3 E2EE correctness — PR-30 … PR-32
 
-- **PR-30** — `crypto/src/key_storage.rs` ships **only** `MemoryKeyStorage`, self-documented
-  `WARNING: This backend does NOT persist keys across restarts`, while its own doc comment
-  advertises Keychain / KeyStore / TPM backends that do not exist. `messaging-service/src/crypto.rs`
-  constructs `CryptoManager` with `key_storage: None` ("development mode"). Implement a
-  persistent backend; remove the dev-mode path.
-- **PR-31** — MLS group state cannot round-trip:
-  `handlers/send_group_message_mls.rs:179` cannot deserialize OpenMLS 0.6 group state;
-  `:213` passes client ciphertext through unchanged;
-  `handlers/add_group_member_mls.rs:258,285` **rebuilds the group from scratch** on membership
-  change. Fix, or explicitly gate the MLS path off behind a flag with a tracked upstream issue.
-- **PR-32** — **Invariant I-2 repair.** Collapse the duplicated handler pairs in
-  `messaging-service/src/handlers/`: `send_message.rs` vs `send_message_e2ee.rs`,
-  `receive_messages.rs` vs `receive_messages_e2ee.rs`, `add_group_member.rs` vs `_mls`,
-  `send_group_message.rs` vs `_mls`. The `_e2ee` variants carry
-  `TODO: Replace existing ... after testing`, and **the non-E2EE path is the one registered**.
-  Additionally, `docker-compose.dev.yml` sets `GUARDYN_E2EE_ENABLED=false` and
-  `GUARDYN_MLS_ENABLED=false` for dev; per I-2 these flags should not exist.
-  **Removing them is a behaviour change → requires explicit user sign-off at G3.**
+**Re-scoped.** All three steps below were written on two premises that turned out to be false,
+and the corrected architecture is recorded in
+[ADR-0010](docs/adr/ADR-0010-pure-relay-server.md). The server becomes a **pure relay**: it
+routes opaque bytes and holds no key material. MLS and the Double Ratchet run on the clients.
+
+The false premises, both verified against the code before re-scoping:
+
+1. The `_e2ee` handlers were assumed to be the encrypted path. They encrypted **server-side**
+   and held the ratchet state; the unsuffixed handler was already the zero-knowledge relay.
+2. OpenMLS 0.6 was assumed unable to deserialize a group. `MlsGroup::load` exists
+   (`openmls-0.6.0/src/group/mls_group/mod.rs:417`) — and using it would have been the breach,
+   since it restores `group_epoch_secrets`.
+
+- **PR-30′** (#41) — **deletion, not implementation.** The dependency edge inverts: once PR-32a
+  removes the `_e2ee` handlers, `messaging-service/src/crypto.rs` has no caller.
+  `CryptoManager::with_storage` had zero call sites, `SessionManager::new` hard-coded
+  `key_storage: None`, and `get_or_create_session` errored on every new peer pair — there was no
+  working path to preserve. Persistent key storage belongs to the clients via `crypto/src/ffi.rs`
+  (Phase 4).
+- **PR-31a…d** (#42, #151, #152, #153) — remove server-side MLS: the dead `*_mls.rs` handlers,
+  the server-held group secrets and `create_test_credential`, the crate-wide `dead_code` allow
+  that hid them, and the ADR.
+- **PR-32a…c** (#43, #154, #155) — **invariant I-2 repair.** Delete the server-side E2EE
+  handlers, then the `E2eeConfig`/`MlsConfig` flags, then the deployment variables.
+  **PR-32c is a behaviour change → requires explicit user sign-off at G3**, and is additionally
+  blocked on #163: `client-desktop` sends plaintext in `encrypted_content`, which the server
+  currently encrypts on its behalf.
 
 ### 6.4 Security testing — PR-33 … PR-35
 


### PR DESCRIPTION
Closes #153

Fourth of four PR-31 steps. **Independent of the code stacks** — this is documentation only and
can merge in any order relative to #157/#159/#160/#161/#162.

## ADR-0010

The server relays opaque bytes and holds no key material. MLS and the Double Ratchet run on the
clients.

Phase 3 deletes three separate mechanisms by which the server held conversation keys:

| Mechanism | What the server held |
|---|---|
| `RatchetSession.ratchet_state` | "DH keys, root key, chain keys, message counters, skipped keys" — its own field comment |
| `send_message_e2ee.rs` / `receive_messages_e2ee.rs` | encrypted on send, decrypted on receive, held the ratchet |
| `mls_manager.rs` + `serialize_state` | a 32-byte secret exported from the epoch secret |

Deleting all that without recording *why* guarantees it comes back. The next contributor reads
`mls_manager.rs`, finds a membership index with no group operations, and reasonably concludes the
group logic is missing rather than deliberately absent.

## Two documents said the opposite of the truth

Both corrections are load-bearing, not editorial.

**`AGENTS.md` §1** directed PR-32 to collapse the handler pairs **onto the `_e2ee` variants**. Those
variants encrypted server-side (`send_message_e2ee.rs:129`) and returned plaintext
(`receive_messages_e2ee.rs:177`). The unsuffixed handler was already the zero-knowledge relay.

Following the instruction as written would have deleted the relay and kept the path where the
server can read every message — trading an I-2 violation for an I-1 one. §1 also claimed four such
pairs existed; there were two.

Since AGENTS.md wins over `.claude/rules/` by its own rule, AGENTS.md is the file that had to
change — `00-invariants.md` already had the correct count.

**`implementation_plan.md` §6.3** rested on that premise plus a second: that OpenMLS 0.6 cannot
deserialize a group. It can (`MlsGroup::load`, `openmls-0.6.0/src/group/mls_group/mod.rs:417`),
and using it would have been the breach rather than the fix — `load` restores
`group_epoch_secrets`. All three steps re-scoped, including PR-30′s inverted dependency edge.

## Also

- `docs/adr/index.md` — ADR-0010 row
- `docs/adr/ADR-0004` — cross-reference
- `docs/roadmap/ROADMAP.md` — the I-2 row said the fix was backwards; now records the real
  remaining gap, which is on the client (#163), not the server
- `docs/roadmap/roadmap.yaml` — the eight split steps, PR-27b, and I-2 → `partial`
  (`E2EE-DUP` and `E2EE-FLAG` both pass; PR-32c blocked)

## Budget

7 files, 191 insertions, 27 deletions. `docs-verify` green — 141 links resolve, 22 documents
pass frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)