### PR TITLE
chore(messaging): narrow the crate-wide allow, and record what it was hiding

### DIFF
--- a/backend/crates/messaging-service/src/db.rs
+++ b/backend/crates/messaging-service/src/db.rs
@@ -1070,14 +1070,14 @@ impl DatabaseClient {
         // Truncate preview to 100 chars
         let preview: String = last_message_preview.chars().take(100).collect();
 
-        // First, try to delete old entry for this conversation (if exists)
-        // We need to do this because last_message_time is part of clustering key
-        let delete_query = "DELETE FROM guardyn.conversations 
+        // Never executed. `last_message_time` is part of the clustering key, so
+        // every update inserts a new row rather than replacing one, and this
+        // delete cannot address the old one because `conversation_id` is not the
+        // partition key. `get_conversations` filters the duplicates on read, so
+        // the output stays correct while the partition grows without bound.
+        // Tracked as #173, which needs a schema change and an ADR.
+        let _delete_query = "DELETE FROM guardyn.conversations 
                            WHERE user_id = ? AND conversation_id = ?";
-
-        // Note: This won't work as-is because conversation_id is not the partition key
-        // We need a different approach - using a separate lookup or accepting duplicates
-        // For MVP, we'll just insert and accept that old entries remain (they'll be filtered)
 
         // Insert new conversation entry
         let insert_query = if increment_unread {
@@ -1732,7 +1732,11 @@ impl DatabaseClient {
         recipient_username: &str,
         content: &str,
         content_type: &str,
-        encrypted: bool,
+        // Ignored: the column stores whatever the client sent, and under
+        // ADR-0010 the server cannot tell ciphertext from plaintext anyway.
+        // The parameter stays for now because removing it changes the
+        // WebSocket handler's call site.
+        _encrypted: bool,
         timestamp: chrono::DateTime<chrono::Utc>,
     ) -> Result<()> {
         // Generate conversation ID (deterministic for 1-on-1)
@@ -1894,7 +1898,7 @@ impl DatabaseClient {
     pub async fn remove_reaction(
         &self,
         message_id: &str,
-        conversation_id: &str,
+        _conversation_id: &str,
         user_id: &str,
         emoji: &str,
         _is_group: bool,
@@ -2319,7 +2323,7 @@ impl DatabaseClient {
         recipient_user_id: &str,
         encrypted_content: &[u8],
         message_type: i32,
-        client_message_id: &str,
+        _client_message_id: &str,
         forward_info: &crate::proto::messaging::ForwardInfo,
     ) -> Result<()> {
         let message_uuid = uuid::Uuid::parse_str(message_id)?;
@@ -2364,7 +2368,7 @@ impl DatabaseClient {
     #[allow(clippy::too_many_arguments)]
     pub async fn store_forwarded_group_message(
         &self,
-        message_id: &str,
+        _message_id: &str,
         group_id: &str,
         sender_user_id: &str,
         sender_device_id: &str,

--- a/backend/crates/messaging-service/src/handlers/disappearing_messages.rs
+++ b/backend/crates/messaging-service/src/handlers/disappearing_messages.rs
@@ -238,8 +238,11 @@ pub async fn get_disappearing_config(
 ) -> Result<Response<GetDisappearingConfigResponse>, Status> {
     let req = request.into_inner();
 
-    // Validate token
-    let claims = match validate_access_token(&req.access_token) {
+    // Authenticated but NOT authorized: `_claims` is never read, so nothing
+    // checks that the caller belongs to the conversation this returns data for.
+    // Tracked as #172 - renamed rather than fixed here, because the fix is a
+    // behaviour change needing its own tests.
+    let _claims = match validate_access_token(&req.access_token) {
         Ok(c) => c,
         Err(e) => {
             warn!("Invalid access token: {}", e);

--- a/backend/crates/messaging-service/src/handlers/get_conversations.rs
+++ b/backend/crates/messaging-service/src/handlers/get_conversations.rs
@@ -53,7 +53,7 @@ pub async fn get_conversations(
             // No conversations in new table, fall back to old method for backward compatibility
             info!("No conversations in optimized table, falling back to messages scan");
             match db.get_recent_conversations(&user_id, limit as i32).await {
-                Ok(mut conversations) => {
+                Ok(conversations) => {
                     info!(
                         "Successfully fetched {} conversations via fallback",
                         conversations.len()

--- a/backend/crates/messaging-service/src/handlers/reactions.rs
+++ b/backend/crates/messaging-service/src/handlers/reactions.rs
@@ -189,8 +189,11 @@ pub async fn get_reactions(
 ) -> Result<Response<GetReactionsResponse>, Status> {
     let req = request.into_inner();
 
-    // Validate token
-    let claims = match validate_access_token(&req.access_token) {
+    // Authenticated but NOT authorized: `_claims` is never read, so nothing
+    // checks that the caller belongs to the conversation this returns data for.
+    // Tracked as #172 - renamed rather than fixed here, because the fix is a
+    // behaviour change needing its own tests.
+    let _claims = match validate_access_token(&req.access_token) {
         Ok(c) => c,
         Err(e) => {
             warn!("Invalid access token: {}", e);

--- a/backend/crates/messaging-service/src/handlers/read_receipts.rs
+++ b/backend/crates/messaging-service/src/handlers/read_receipts.rs
@@ -140,8 +140,11 @@ pub async fn get_read_receipts(
 ) -> Result<Response<GetReadReceiptsResponse>, Status> {
     let req = request.into_inner();
 
-    // Validate token
-    let claims = match validate_access_token(&req.access_token) {
+    // Authenticated but NOT authorized: `_claims` is never read, so nothing
+    // checks that the caller belongs to the conversation this returns data for.
+    // Tracked as #172 - renamed rather than fixed here, because the fix is a
+    // behaviour change needing its own tests.
+    let _claims = match validate_access_token(&req.access_token) {
         Ok(c) => c,
         Err(e) => {
             warn!("Invalid access token: {}", e);

--- a/backend/crates/messaging-service/src/main.rs
+++ b/backend/crates/messaging-service/src/main.rs
@@ -5,8 +5,11 @@
 // the trait, so it is not available. Scoped to crates that speak gRPC: `crypto` and
 // `common` still get the lint.
 #![allow(clippy::result_large_err)]
-// Allow common development-time warnings for code under active development
-#![allow(unused_variables, unused_mut, dead_code, unused_imports)]
+// `dead_code` only, and on its way out in #174. The crate-wide allow this
+// replaces also covered `unused_variables`, `unused_mut` and `unused_imports`,
+// which is how three authenticated-but-unauthorized handlers (#172) and a
+// delete that never ran (#173) sat here without a single warning.
+#![allow(dead_code)]
 
 mod auth_client;
 mod config;

--- a/backend/crates/messaging-service/src/nats.rs
+++ b/backend/crates/messaging-service/src/nats.rs
@@ -3,7 +3,6 @@ use anyhow::{Context, Result};
 use async_nats::jetstream::{self, consumer::PullConsumer, stream::Stream};
 use futures::StreamExt; // For .next() on async streams
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 /// NATS message envelope
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/crates/messaging-service/src/websocket/server.rs
+++ b/backend/crates/messaging-service/src/websocket/server.rs
@@ -235,9 +235,9 @@ async fn handle_socket(socket: WebSocket, state: WsState) {
                 Ok(Message::Binary(_)) => {
                     debug!("Received binary message (not supported)");
                 }
-                Ok(Message::Ping(data)) => {
-                    debug!("Received ping, sending pong");
-                    // Axum handles pong automatically
+                Ok(Message::Ping(_)) => {
+                    // Axum answers the pong itself; the payload is its business.
+                    debug!("Received ping");
                 }
                 Ok(Message::Pong(_)) => {
                     debug!("Received pong");


### PR DESCRIPTION
Closes #152

**Depends on both pure-relay stacks.** Its base is #162 (which carries #160 → #161 → #162), and
it also merges #159 (which carries #157). Review those first; this PR only owns the last commit.

That ordering is deliberate: removing the allow on the pre-deletion tree surfaces nine warnings
in files those PRs delete outright, so the count would measure pending deletions rather than
genuine dead code.

## What the allow was hiding

This is the part that matters. Three defects had never produced a warning:

### 1. Three handlers authenticate but never authorize — #172

`get_disappearing_config`, `get_reactions` and `get_read_receipts` each validate the access token,
bind `claims`, and **never read it**. Nothing checks that the caller belongs to the conversation
whose data is returned.

Any authenticated user can read any conversation's disappearing-message config, any message's
reactions (including who reacted), and any conversation's read receipts (including who read what,
when). A straightforward IDOR.

The only signal this ever produced was `unused variable: claims` — suppressed crate-wide.

Renamed to `_claims` with a comment naming the gap. **Not fixed here**: the fix is a behaviour
change needing its own tests, plus an audit of handlers that never bind claims at all.

### 2. A delete that never runs — #173

`update_conversation` builds a `delete_query` and drops it. `last_message_time` is part of the
clustering key, so every update **inserts** rather than replaces, and the partition grows without
bound. `get_conversations` filters duplicates on read, so output stays correct while storage does
not — which is exactly why nobody noticed. Needs a schema change and an ADR.

### 3. A flag that does nothing

`execute_message_insert` takes `encrypted: bool` and ignores it. Under ADR-0010 that is now
*correct* — the server cannot tell ciphertext from plaintext — but the parameter reads as though
it decides something. Commented rather than removed, since dropping it changes the WebSocket call
site.

## The mechanical rest

Four unused parameters, one unused import, one unnecessary `mut`, one ping payload axum handles
itself.

## Negative test

With the allow narrowed, planting `let planted = 42;` produces a warning, which `-D warnings`
turns into a build failure. The remaining `dead_code` family is #174.

`#![allow(clippy::result_large_err)]` stays — it has a written rationale and tonic fixes the
handler signature that trips it.

## Budget

8 files, 39 insertions, 24 deletions in the commit this PR owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)