### PR TITLE
security(common): stop logging raw client IP addresses

### DIFF
--- a/.claude/rules/00-invariants.md
+++ b/.claude/rules/00-invariants.md
@@ -19,12 +19,12 @@ If a task appears to require it, stop and ask the user.
 | ID | Invariant | Predicate | Today | Owned by |
 |---|---|---|---|---|
 | `ZK-INIT` | I-1 | Tracing is initialised only via `guardyn_common::observability::init_tracing` | PASS | `rules-verify` |
-| `ZK-PII` | I-1 | No log macro is passed a raw IP, email or phone number | FAIL (2) | **none — open an issue** |
+| `ZK-PII` | I-1 | No log macro is passed a raw IP, email or phone number | PASS | `rules-verify` |
 | `E2EE-FLAG` | I-2 | No configuration key can turn encryption off | FAIL (4) | PR-32b, PR-32c |
 | `E2EE-DUP` | I-2 | No handler has a non-E2EE twin | PASS | `rules-verify` |
 | `PQ-DEFAULT` | I-3 | The `pq` feature is on by default in the crypto crate | FAIL | PR-38 |
 | `PQ-WIRE` | I-3 | The wire contract carries ML-KEM key material | FAIL | PR-36 |
-| `SOV-DOMAIN` | I-4 | Every hostname derives from `${DOMAIN}` | FAIL (1) | **none — open an issue** |
+| `SOV-DOMAIN` | I-4 | Every hostname derives from `${DOMAIN}` | FAIL (1) | **none — tracked by #82** |
 | `SOV-STORE` | I-4 | No datastore added, replaced or removed without an accepted ADR | PASS | reviewer |
 
 Run from the repository root:
@@ -56,9 +56,13 @@ an I-1 one. §1 also says four such pairs existed; the measured count was **two*
 `PQ-WIRE` fails while `crypto/src/pqxdh.rs` is a complete hybrid X25519 + ML-KEM-768
 implementation. It is unreached, not absent — no proto field can carry the public key.
 
-**A known failure is not licence to patch it.** Four of these have an owned step; fixing one
-outside that step breaks the micro-step contract. The two marked *none* were found while
-writing this file and need an issue opened before any fix.
+**A known failure is not licence to patch it.** Three of the remaining failures have an owned
+step - `E2EE-FLAG` (PR-32b, PR-32c), `PQ-DEFAULT` (PR-38) and `PQ-WIRE` (PR-36) - and fixing one
+outside that step breaks the micro-step contract.
+
+`ZK-PII` and `SOV-DOMAIN` were both found while writing this file, with no owning step. Each had
+an issue opened before any fix. `ZK-PII` is now closed by #81 and enforced by `rules-verify`;
+`SOV-DOMAIN` is tracked by #82 and still has **no roadmap step**.
 
 ## Detail
 

--- a/.claude/rules/30-zk-logging.md
+++ b/.claude/rules/30-zk-logging.md
@@ -16,7 +16,7 @@ invariant most easily broken by a one-line "helpful" debug statement, so it gets
 | ID | Predicate | Today |
 |---|---|---|
 | `ZK-INIT` | Tracing is initialised only via `guardyn_common::observability::init_tracing` | PASS — enforced by `rules-verify` |
-| `ZK-PII` | No log macro is passed a raw IP, email or phone number | FAIL — 2 sites, no owner |
+| `ZK-PII` | No log macro is passed a raw IP, email or phone number | PASS |
 | `ZK-PAYLOAD` | No log macro names ciphertext, plaintext, payload or key material | PASS |
 | `ZK-STRUCT` | No whole request or response struct is interpolated | PASS |
 | `ZK-DEBUG` | No `#[derive(Debug)]` on a crypto type that holds key material | review trigger |
@@ -57,8 +57,20 @@ them, and never at `info` on a hot path. `ZK-PAYLOAD` deliberately excludes `*_i
 the four `ratchet session: {session_id}` lines in `messaging-service` are identifiers, not
 key material, and are allowed under that rule.
 
-## The two failures with no owned step
+## How ZK-PII was closed
 
-`ZK-PII` fires on `common/src/rate_limit.rs:241` and `:256`, which log a raw client IP.
-`AGENTS.md` §4 lists IP address as PII. This was found while writing these predicates and
-has no step in `implementation_plan.md` — open an issue before fixing it.
+It fired on `common/src/rate_limit.rs:241` and `:256`, which logged a raw client IP, and on the
+`Display` of `RateLimitError::IpBlocked`, which a grep over log macros could not see.
+
+The fix is `ip_fingerprint` — a per-process-salted 64-bit hash. An operator can still tell that
+the *same* address was blocked repeatedly, which is the operational need, while the log carries
+no address. The salt lives only in process memory, so fingerprints do not correlate across
+restarts or between replicas and cannot be matched against a precomputed table.
+
+It is not a cryptographic commitment, and the doc comment says so: anyone who can read process
+memory recovers the salt. That is the right bar for log hygiene, not for defence against an
+attacker already inside the process.
+
+**The predicate is a field-name grep and cannot see everything.** A raw IP under a neutral name,
+or one reaching a log through a `Display` impl, passes it. `IpBlocked` was exactly that case and
+was found by reading, not by the check.

--- a/backend/crates/common/src/rate_limit.rs
+++ b/backend/crates/common/src/rate_limit.rs
@@ -3,13 +3,39 @@
 //! Provides rate limiting functionality for protecting Guardyn services from abuse.
 //! Uses a sliding window algorithm with configurable limits per endpoint.
 
+use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
+use std::hash::BuildHasher;
 use std::net::IpAddr;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use parking_lot::RwLock;
 use thiserror::Error;
+
+/// Per-process salt for [`ip_fingerprint`].
+static IP_SALT: OnceLock<RandomState> = OnceLock::new();
+
+/// A stable, per-process fingerprint for an IP address.
+///
+/// Invariant I-1 forbids a raw IP in any log, span or metric (`AGENTS.md` §4
+/// lists IP address as PII), but an operator still needs to see that the *same*
+/// address was blocked repeatedly rather than five different ones. This gives
+/// them that and nothing else.
+///
+/// The salt is generated once per process, so fingerprints correlate within one
+/// service's lifetime and nowhere else — not across restarts, not between
+/// replicas, and not against a precomputed table.
+///
+/// **Not a cryptographic commitment.** Anyone who can read the process's memory
+/// recovers the salt and can then confirm a guessed address. This is log
+/// hygiene, not a defence against an attacker already inside the process.
+pub fn ip_fingerprint(ip: &IpAddr) -> String {
+    format!(
+        "{:016x}",
+        IP_SALT.get_or_init(RandomState::new).hash_one(ip)
+    )
+}
 
 /// Rate limiting errors
 #[derive(Debug, Clone, Error)]
@@ -21,7 +47,10 @@ pub enum RateLimitError {
         retry_after: Duration,
     },
 
-    #[error("Blocked IP address: {ip}")]
+    // The address is carried for the caller to act on, but deliberately kept out
+    // of the message: `Display` is what reaches a log, and I-1 forbids a raw IP
+    // there.
+    #[error("Blocked IP address")]
     IpBlocked { ip: IpAddr },
 
     #[error("Blocked user: {user_id}")]
@@ -238,7 +267,7 @@ impl RateLimiter {
     pub fn block_ip(&self, ip: IpAddr, duration: Duration) {
         let until = Instant::now() + duration;
         self.blocked_ips.write().insert(ip, until);
-        tracing::warn!("Blocked IP {} for {:?}", ip, duration);
+        tracing::warn!(ip = %ip_fingerprint(&ip), ?duration, "Blocked IP");
     }
 
     /// Block a user for a duration
@@ -253,7 +282,7 @@ impl RateLimiter {
     /// Unblock an IP address
     pub fn unblock_ip(&self, ip: IpAddr) {
         self.blocked_ips.write().remove(&ip);
-        tracing::info!("Unblocked IP {}", ip);
+        tracing::info!(ip = %ip_fingerprint(&ip), "Unblocked IP");
     }
 
     /// Unblock a user
@@ -485,6 +514,39 @@ impl Default for RateLimiters {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ip_fingerprint_is_stable_within_a_process() {
+        let ip: IpAddr = "203.0.113.7".parse().expect("parse");
+        assert_eq!(ip_fingerprint(&ip), ip_fingerprint(&ip));
+    }
+
+    #[test]
+    fn ip_fingerprint_separates_distinct_addresses() {
+        let a: IpAddr = "203.0.113.7".parse().expect("parse");
+        let b: IpAddr = "203.0.113.8".parse().expect("parse");
+        assert_ne!(ip_fingerprint(&a), ip_fingerprint(&b));
+    }
+
+    #[test]
+    fn ip_fingerprint_contains_no_part_of_the_address() {
+        // The point of the fingerprint: what reaches the log must not let a
+        // reader reconstruct the address, including by octet.
+        let ip: IpAddr = "203.0.113.7".parse().expect("parse");
+        let printed = ip_fingerprint(&ip);
+        assert!(!printed.contains("203"), "octet leaked: {printed}");
+        assert!(!printed.contains("113"), "octet leaked: {printed}");
+        assert_eq!(printed.len(), 16, "fixed width, so length leaks nothing");
+        assert!(printed.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn blocked_ip_error_does_not_render_the_address() {
+        // `Display` is what reaches a log. AGENTS.md §4 lists IP address as PII.
+        let ip: IpAddr = "203.0.113.7".parse().expect("parse");
+        let rendered = RateLimitError::IpBlocked { ip }.to_string();
+        assert!(!rendered.contains("203.0.113.7"), "leaked: {rendered}");
+    }
 
     #[test]
     fn test_rate_limiter_allows_requests_under_limit() {

--- a/backend/crates/common/src/rate_limit_middleware.rs
+++ b/backend/crates/common/src/rate_limit_middleware.rs
@@ -271,8 +271,11 @@ pub fn rate_limit_interceptor(
                     retry_after.as_secs()
                 )))
             }
-            Err(RateLimitError::IpBlocked { ip }) => Err(tonic::Status::permission_denied(
-                format!("IP address {} is blocked", ip),
+            // The address is not echoed back: the caller already knows its own,
+            // and a gRPC status message travels through logging middleware where
+            // I-1 applies.
+            Err(RateLimitError::IpBlocked { .. }) => Err(tonic::Status::permission_denied(
+                "Your IP address is blocked",
             )),
             Err(RateLimitError::UserBlocked { user_id }) => Err(tonic::Status::permission_denied(
                 format!("User {} is blocked", user_id),

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -136,6 +136,17 @@ encrypted the client's plaintext server-side and decrypted on the way back out, 
 unsuffixed handler relayed ciphertext untouched. The fix is to delete the twin, never to rename
 it or to exempt the path.
 
+**If `ZK-PII` fails**, a log macro is being handed a raw IP address, email or phone number.
+All three are PII under `AGENTS.md` §4, and **I-1** forbids PII in any log, span or metric.
+Do not silence it by renaming the field — the address is the problem, not the label. For a
+client IP, log `guardyn_common::rate_limit::ip_fingerprint(&ip)` instead: an operator still
+sees that the same address recurred, without the address reaching the log.
+
+The predicate greps for the field *name*, so it is a floor, not a ceiling. **It cannot see a
+raw IP under a neutral name, or one that reaches a log through a `Display` impl.**
+`RateLimitError::IpBlocked` was exactly that second case and was found by reading the code,
+not by the check. Treat a `ZK-PII` pass as "no obvious breach", never as proof.
+
 ## Roadmap and board sync
 
 [`roadmap.yaml`](../roadmap/roadmap.yaml) is the machine source of truth. `roadmap-sync`

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -132,7 +132,19 @@ effective limit is the preset multiplied by the replica count. Until PR-41 resol
 either the state is shared or the single-replica constraint is documented and enforced — a
 limit that silently scales with replicas is not a limit.
 
-Blocking an address must not log the address (**I-1**).
+Blocking an address must not log the address (**I-1**). The block and unblock paths
+therefore log `ip_fingerprint(&ip)` — a 16-hex-digit hash under a salt generated once per
+process — instead of the address itself. An operator can still tell that the *same* address
+was blocked repeatedly, which is the operational need; the log carries no address.
+
+Because the salt lives only in process memory, fingerprints do not correlate across restarts
+or between replicas, and cannot be matched against a precomputed table. They are **not** a
+cryptographic commitment: anyone able to read process memory recovers the salt and can confirm
+a guessed address. That is the right bar for log hygiene, not for defence against an attacker
+already inside the process.
+
+`RateLimitError::IpBlocked` still carries the address as a field for the caller to act on, but
+its `Display` must not render it — `Display` is what reaches a log.
 
 ## Logging
 

--- a/infra/scripts/rules-verify.sh
+++ b/infra/scripts/rules-verify.sh
@@ -133,6 +133,25 @@ check_e2ee_dup() {
   fi
 }
 
+# -------------------------------------------------------------------- ZK-PII
+# A log macro handed a raw IP, email or phone number. AGENTS.md §4 lists all
+# three as PII, and I-1 forbids PII in any log, span or metric.
+#
+# Matches the field NAME, positionally interpolated or structured. It cannot see
+# a value that is PII under a neutral name - that is what review is for.
+check_zk_pii() {
+  local hits
+  hits="$(git ls-files -z -- 'backend/crates/*/src/*.rs' 'backend/crates/*/src/**/*.rs' \
+    | xargs -0 grep -nE '(trace|debug|info|warn|error)!\(' 2>/dev/null \
+    | grep -iE '"[^"]*\b(ip|email|phone)\b[^"]*"[^)]*,' || true)"
+  if [ -n "$hits" ]; then
+    fail "ZK-PII: a log macro is passed a raw IP, email or phone number"
+    show "$hits"
+  else
+    pass "ZK-PII: no raw IP, email or phone number in a log macro"
+  fi
+}
+
 # ---------------------------------------------------------------- PROTO-EDIT
 check_proto_edit() {
   local hits
@@ -220,6 +239,7 @@ check_rs_unwrap
 check_rs_unsafe
 check_zk_init
 check_e2ee_dup
+check_zk_pii
 check_proto_edit
 check_lang_md
 check_name_sh


### PR DESCRIPTION
Closes #81

Independent of every other Phase 3 stack — `common/src/rate_limit.rs` only.

## A live I-1 breach in the phase whose point is I-1

`rate_limit.rs:241` and `:256` logged a client IP in clear. `AGENTS.md` §4 lists IP address as
PII and I-1 forbids PII in any log, span or metric. `.claude/rules/00-invariants.md` has carried
this as `ZK-PII · FAIL (2) · none — open an issue` since the rules were written; #81 is that
issue.

## The fix

`ip_fingerprint` replaces the address with a **per-process-salted 64-bit hash**. An operator can
still see that the *same* address was blocked repeatedly rather than five different ones — the
actual operational need — while the log carries no address.

The salt is generated once per process, so fingerprints correlate within one service's lifetime
and nowhere else: not across restarts, not between replicas, not against a precomputed table.

**It is not a cryptographic commitment**, and the doc comment says so plainly — anyone who can
read process memory recovers the salt and can confirm a guessed address. That is the right bar
for log hygiene, not for defence against an attacker already inside the process. Flagging it
explicitly so nobody later mistakes it for one.

**No new dependency.** `RandomState` and `BuildHasher::hash_one` are both in std, so this does
not touch AGENTS.md §5.3.

## Two sites the grep could not have found

| Site | Why the predicate missed it |
|---|---|
| `RateLimitError::IpBlocked` | its `#[error(...)]` embedded the address, and **`Display` is what reaches a log** |
| `rate_limit_middleware.rs:274` | echoed the address back to the client in a gRPC status, which travels through logging middleware |

The caller already knows its own address, so naming it in the error bought nothing.

## ZK-PII is now enforced

`rules-verify.sh` gains `check_zk_pii` as a hard fail; the row flips to PASS in both
`00-invariants.md` and `30-zk-logging.md`.

**Negative-tested**: restoring `tracing::info!("Unblocked IP {}", ip)` makes it FAIL and name the
line; removing it makes it pass.

`30-zk-logging.md` now states the predicate's limit rather than implying it is complete — a field-
name grep cannot see a raw IP under a neutral name, or one reaching a log through a `Display`
impl. `IpBlocked` was exactly that case and was found by reading, not by the check.

## Tests

Four, including one asserting the fingerprint contains no octet of the address (not merely that
it differs from it) and one asserting the error's `Display` does not render it.

## Budget

5 files, 27 tests pass in `guardyn-common`, `rules-verify` and `docs-verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)