### PR TITLE
chore(roadmap): mark eight completed steps as done

### DIFF
--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -58,13 +58,13 @@ steps:
   - {id: PR-21, issue: 32, phase: 2, type: chore, status: done, title: "Create label taxonomy"}
   - {id: PR-22, issue: 33, phase: 2, type: docs, status: done, title: "Codify code-style predicates in .claude/rules/20-code-style.md"}
   - {id: PR-23, issue: 34, phase: 2, type: refactor, status: done, gate: G2, title: "Unify protobuf codegen strategy"}
-  - {id: PR-24, issue: 35, phase: 3, type: security, status: review, title: "Add Redacted<T> and the log field denylist"}
-  - {id: PR-24b, issue: 133, phase: 3, type: security, status: review, title: "Redact denied fields in the tracing formatter"}
-  - {id: PR-25, issue: 36, phase: 3, type: security, status: todo, title: "Apply Redacted<T> across crypto, auth and messaging types"}
-  - {id: PR-26, issue: 37, phase: 3, type: security, status: review, title: "Migrate call-service and notification-service to observability::init_tracing"}
+  - {id: PR-24, issue: 35, phase: 3, type: security, status: done, title: "Add Redacted<T> and the log field denylist"}
+  - {id: PR-24b, issue: 133, phase: 3, type: security, status: done, title: "Redact denied fields in the tracing formatter"}
+  - {id: PR-25, issue: 36, phase: 3, type: security, status: done, title: "Apply Redacted<T> across crypto, auth and messaging types"}
+  - {id: PR-26, issue: 37, phase: 3, type: security, status: done, title: "Migrate call-service and notification-service to observability::init_tracing"}
   - {id: PR-27, issue: 38, phase: 3, type: feat, status: todo, title: "Add health checks for all stores and a media-service Health RPC"}
-  - {id: PR-28, issue: 39, phase: 3, type: refactor, status: todo, title: "Wire or delete the unused Redpanda topic constants"}
-  - {id: PR-29, issue: 40, phase: 3, type: fix, status: todo, title: "Replace the presence-service Redis TODO with TTL-correct TiKV storage"}
+  - {id: PR-28, issue: 39, phase: 3, type: refactor, status: done, title: "Wire or delete the unused Redpanda topic constants"}
+  - {id: PR-29, issue: 40, phase: 3, type: fix, status: done, title: "Replace the presence-service Redis TODO with TTL-correct TiKV storage"}
   - {id: PR-30, issue: 41, phase: 3, type: security, status: todo, title: "Implement a persistent KeyStorage backend"}
   - {id: PR-31, issue: 42, phase: 3, type: fix, status: todo, title: "Fix MLS group state round-trip"}
   - {id: PR-32, issue: 43, phase: 3, type: security, status: todo, title: "Enforce Always-On E2EE and remove the non-E2EE handler path"}
@@ -81,5 +81,5 @@ steps:
   - {id: PR-43, issue: 54, phase: 4, type: feat, status: todo, title: "Wire the compose observability stack"}
   - {id: PR-44, issue: 55, phase: 4, type: chore, status: todo, gate: G4, title: "Deployment parity - call-service k8s, digest pins, mobile CI"}
   - {id: PR-45, issue: 60, phase: 1, type: chore, status: done, title: "Untrack the 18.4 MB committed ChromeDriver binary"}
-  - {id: PR-46, issue: 132, phase: 3, type: fix, status: review, title: "Adapt to the rdkafka 0.39 Delivery type and vendor libcurl"}
-  - {id: PR-47, issue: 137, phase: 3, type: chore, status: review, title: "Record the G2 hotfix steps in roadmap.yaml"}
+  - {id: PR-46, issue: 132, phase: 3, type: fix, status: done, title: "Adapt to the rdkafka 0.39 Delivery type and vendor libcurl"}
+  - {id: PR-47, issue: 137, phase: 3, type: chore, status: done, title: "Record the G2 hotfix steps in roadmap.yaml"}


### PR DESCRIPTION
Eight steps recorded `review` or `todo` while their issues were already closed:
PR-24 (#35), PR-24b (#133), PR-25 (#36), PR-26 (#37), PR-28 (#39), PR-29 (#40),
PR-46 (#132), PR-47 (#137).

`roadmap-sync.sh` reconciles issue state **from** this file (`:157-172`), so the next
`just roadmap-sync 0` would have run `PATCH state=open` against all eight and reopened
correctly-closed work. `.claude/skills/issue-sync/SKILL.md` records that this nearly happened
once already, with thirteen issues.

Verified after the change: every step with an issue now agrees with GitHub — 0 mismatches
across all 50 steps.

## Size

1 file, 8 insertions, 8 deletions. Well inside the §2.3 budget.

## Deliberately out of scope

- **The reason this was invisible.** `just roadmap-sync` reports `0 changed, 50 already
  correct` on this exact drift, because its dry run prints the *desired* state and `continue`s
  without ever reading GitHub (`roadmap-sync.sh:142-147`). Filed as #180, not fixed here — it
  is a change to the script, not to the data, and belongs in its own step.
- **No status was advanced forward.** Steps whose PRs are open but unmerged keep their current
  status; this PR only corrects entries that contradict a closed issue.
- No milestone, label or board change.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
