### PR TITLE
fix(ci): run the desktop workflows on ubuntu-latest

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-22.04
+          - platform: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             name: Linux
           - platform: windows-latest
@@ -58,7 +58,7 @@ jobs:
           cache-dependency-path: client-desktop/package-lock.json
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: ubuntu-22.04
+          - platform: ubuntu-latest
             name: Linux
           - platform: windows-latest
             name: Windows
@@ -136,7 +136,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -26,7 +26,7 @@ jobs:
   # Task 17: Test Job
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout repository
@@ -58,7 +58,7 @@ jobs:
   # Task 19: Linting CI Check  
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout repository
@@ -86,7 +86,7 @@ jobs:
   # Task 16: Vitest Coverage >80%
   coverage-check:
     name: Coverage Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: test
     
     steps:
@@ -112,7 +112,7 @@ jobs:
   # Rust tests
   rust-test:
     name: Rust Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout repository
@@ -163,7 +163,7 @@ jobs:
   # Task 18: Linux Build
   build-linux:
     name: Build Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [test, lint, rust-test]
     
     steps:


### PR DESCRIPTION
`Build Linux` (desktop-ci.yml) and `Test (Linux)` (desktop-build.yml) were failing on **every**
open PR — sampled on #178, #170, #167 and #96, including dependabot branches that predate the
current work.

```
error: failed to run custom build command for `guardyn-desktop`
  Error: "protoc failed: calls.proto: This file contains proto3 optional fields,
          but --experimental_allow_proto3_optional was not set."
```

`ubuntu-22.04` resolves `protobuf-compiler` to `3.12.4-1ubuntu7.22.04.6`, which predates
proto3-optional stabilisation (protobuf 3.15.0). `backend/proto/calls.proto:476` and `:481`
declare `optional` fields, and `client-desktop/src-tauri/build.rs` sets no `protoc_arg`.

`.github/workflows/build.yml` compiles the same protos and is green **because it already runs
`ubuntu-latest`**. That single line is the entire delta.

## Change

- `ubuntu-22.04` → `ubuntu-latest`: 5 `runs-on:` in `desktop-ci.yml`, both matrices in
  `desktop-build.yml`.
- The two `if: matrix.platform == 'ubuntu-22.04'` guards become `if: runner.os == 'Linux'`,
  matching the `macOS`/`Windows` guards directly beside them. Otherwise the platform string
  would have to stay correct in two places at once.

Both files re-parsed as YAML after the change; job sets unchanged.

## Size

2 files, 9 insertions, 9 deletions.

## Deliberately out of scope

- **`continue-on-error` on these same jobs** (#182). Until it is removed, `Build (Linux)` will
  keep reporting green whether or not it builds — this PR makes the build genuinely succeed,
  but does not yet make the check honest.
- **The missing frontend build** (#116): `cargo test` still runs without `dist/`, so
  `tauri::generate_context!()` panics. `Test (Linux)` will not go green from this PR alone.
- Pinning protoc to an explicit version, or `arduino/setup-protoc`. `ubuntu-latest` matches
  what `build.yml` already proves works; a pin is a separate decision.
- `actions/setup-node@v4` and `actions/checkout@v4` still warn about Node 20 deprecation.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
