### PR TITLE
chore(ci): let the desktop workflows fail where they can pass

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -98,7 +98,6 @@ jobs:
           projectPath: client-desktop
           tauriScript: npm run tauri
           args: --target ${{ matrix.target }}
-        continue-on-error: true
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Run tests with coverage
         working-directory: client-desktop
         run: npx vitest run --coverage --reporter=verbose
-        continue-on-error: true
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
@@ -107,6 +106,10 @@ jobs:
       - name: Run tests with coverage threshold
         working-directory: client-desktop
         run: npx vitest run --coverage --coverage.thresholds.lines=70 --coverage.thresholds.functions=70 --coverage.thresholds.branches=60
+        # Measured 43.33% lines / 52.51% functions against a declared 70% bar. The
+        # thresholds are aspirational, not met - #192 either lowers them to the real
+        # figure and ratchets up, or adds the missing tests. Until then this step
+        # cannot be allowed to fail the build.
         continue-on-error: true
 
   # Rust tests
@@ -168,11 +171,12 @@ jobs:
       - name: Run Rust tests
         working-directory: client-desktop/src-tauri
         run: cargo test --all-features
-        continue-on-error: true
 
       - name: Run Clippy
         working-directory: client-desktop/src-tauri
         run: cargo clippy -- -D warnings
+        # 132 errors today, 95 of them result_large_err. Tracked as #191; the step
+        # stays non-blocking until that lands, and must become blocking when it does.
         continue-on-error: true
 
   # Task 18: Linux Build


### PR DESCRIPTION
`build.yml` was de-decorated by PR-17 — `.claude/rules/20-code-style.md` records that as the
moment CI stopped being decorative. The desktop workflows kept five `continue-on-error` steps,
and the consequence was not theoretical: `Build (Linux)` reported a **green check without
building anything**, swallowing the protoc failure and emitting only
`! No files were found with the provided path: ...`.

## Three removed, each measured rather than assumed

| Step | Evidence |
|---|---|
| `vitest run --coverage` | 28 files, **410 passed**, 17 skipped, **0 failed** |
| `cargo test --all-features` | passes — proven by the now-green `Test (Linux)`, `Test (macOS)`, `Test (Windows)`, which carry no flag |
| `Build Tauri app` (desktop-build.yml) | passes on all four targets since #181, #116 and #186 |

## Two kept, with the reason in the file

| Step | Measured | Tracked |
|---|---|---|
| `coverage-check` | declares 70% lines / 70% functions; measures **43.33 / 52.51** | #192 |
| `cargo clippy -- -D warnings` | **132 errors**, 95 of them `result_large_err` | #191 |

Both are genuine debt, each far larger than one micro-step. Removing their flags would turn CI
red rather than meaningful; silently keeping them is exactly what let the debt accumulate. So
each now carries an inline comment naming its blocking issue, and both issues say the flag must
come off when they land.

Two of the clippy findings are correctness-adjacent rather than style: `MutexGuard` held across
an await point (2 sites), and `result_large_err` at 95 sites in a client doing per-message
crypto.

## Size

2 files, 6 insertions, 3 deletions.

## Deliberately out of scope

- Fixing the clippy (#191) or coverage (#192) debt.
- `continue-on-error` elsewhere: 8x in `security.yml`, 3x in `test.yml`, 2x in `release.yml`,
  1x in `build.yml:85`. Same class of problem, different step.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
