### PR TITLE
fix(ci): install the cross targets on the pinned toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -10,3 +10,14 @@
 [toolchain]
 channel = "1.98.1"
 components = ["rustfmt", "clippy"]
+# The desktop matrix cross-builds four targets. `dtolnay/rust-toolchain@stable` honours the
+# pin above, so its `targets:` input lands on a toolchain this file then overrides - the
+# pinned toolchain carried only the host target, and the macOS Intel build had never once
+# compiled. Declaring them here is what actually installs them, for CI and for a local
+# cross-build alike.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]


### PR DESCRIPTION
Removing `continue-on-error` from `Build Tauri app` (#182) exposed that **the macOS Intel
desktop build has never compiled**:

```
✓ built in 2.40s
failed to build app: Target x86_64-apple-darwin is not installed
  (installed targets: aarch64-apple-darwin).
```

## Cause

`desktop-build.yml` does ask for the target:

```yaml
uses: dtolnay/rust-toolchain@stable
with:
  targets: ${{ matrix.target }}
```

but that action honours `rust-toolchain.toml` — as that file's own comment states — and the pin
declared `components` with **no `targets`**. So the toolchain actually used is 1.98.1, carrying
only the host target. `macos-latest` is Apple Silicon, so an `x86_64-apple-darwin` build had
nothing to compile against.

Linux and Windows were unaffected only because their single matrix target happens to be the
host.

## Change

Four lines of TOML: declare the four matrix targets on the pinned toolchain.

Declaring them here rather than adding `rustup target add` to the workflow keeps CI and a local
cross-build consistent — which is the stated reason this file exists.

## Size

1 file, 12 insertions (5 of them comment).

## Deliberately out of scope

- The `Node.js 20 is deprecated` warning on `actions/checkout@v4` and `actions/setup-node@v4`.
- Whether an Intel macOS target is still worth building at all. That is a product decision; this
  PR makes the matrix as declared actually work.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)
