### PR TITLE
security(crypto): bind the ratchet header into the AEAD and version the wire

### DIFF
--- a/backend/crates/crypto/src/double_ratchet.rs
+++ b/backend/crates/crypto/src/double_ratchet.rs
@@ -19,6 +19,15 @@ const MESSAGE_KEY_INFO: &[u8] = b"guardyn-message-key";
 const ROOT_KEY_INFO: &[u8] = b"guardyn-root-key";
 const MAX_SKIP: usize = 1000; // Maximum number of skipped messages to store
 
+/// Wire format version for [`EncryptedMessage`].
+///
+/// Version 1 binds the header into the AEAD associated data. The previous, unversioned
+/// format did not, and began with the high byte of a big-endian `u32` header length -
+/// always `0x00` for the 40-byte header. A leading `0x01` is therefore unambiguous
+/// against every message the old format could produce, so a peer that has not upgraded
+/// fails with a clear version error instead of an opaque authentication failure.
+const WIRE_VERSION: u8 = 1;
+
 /// Chain key for symmetric ratchet
 #[derive(Clone)]
 struct ChainKey {
@@ -187,6 +196,21 @@ impl MessageHeader {
     }
 }
 
+/// Associated data for the AEAD: the caller's context, then the wire header.
+///
+/// The Signal Double Ratchet binds the header into the associated data
+/// (`AD = AD_initial || header`) precisely so that an attacker who can modify a message in
+/// flight cannot rewrite `dh_public_key`, `previous_chain_length` or `message_number`
+/// without invalidating the tag. Those 40 bytes were previously unauthenticated, and
+/// `message_number` in particular drives `skip_message_keys`.
+fn aad_with_header(associated_data: &[u8], header: &MessageHeader) -> Vec<u8> {
+    let header_bytes = header.to_bytes();
+    let mut aad = Vec::with_capacity(associated_data.len() + header_bytes.len());
+    aad.extend_from_slice(associated_data);
+    aad.extend_from_slice(&header_bytes);
+    aad
+}
+
 /// Encrypted message with header
 pub struct EncryptedMessage {
     pub header: MessageHeader,
@@ -196,7 +220,8 @@ pub struct EncryptedMessage {
 impl EncryptedMessage {
     pub fn to_bytes(&self) -> Vec<u8> {
         let header_bytes = self.header.to_bytes();
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(5 + header_bytes.len() + self.ciphertext.len());
+        result.push(WIRE_VERSION);
         // Use Big-Endian (Network Byte Order) per RFC 1700
         result.extend_from_slice(&(header_bytes.len() as u32).to_be_bytes());
         result.extend_from_slice(&header_bytes);
@@ -205,21 +230,31 @@ impl EncryptedMessage {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() < 4 {
+        if bytes.len() < 5 {
             return Err(CryptoError::Protocol("Message too short".to_string()));
         }
 
+        if bytes[0] != WIRE_VERSION {
+            return Err(CryptoError::Protocol(format!(
+                "Unsupported ratchet message version {} (expected {})",
+                bytes[0], WIRE_VERSION
+            )));
+        }
+
         let mut header_len_bytes = [0u8; 4];
-        header_len_bytes.copy_from_slice(&bytes[..4]);
+        header_len_bytes.copy_from_slice(&bytes[1..5]);
         // Use Big-Endian (Network Byte Order) per RFC 1700
         let header_len = u32::from_be_bytes(header_len_bytes) as usize;
 
-        if bytes.len() < 4 + header_len {
+        let body_start = 5usize
+            .checked_add(header_len)
+            .ok_or_else(|| CryptoError::Protocol("Invalid message format".to_string()))?;
+        if bytes.len() < body_start {
             return Err(CryptoError::Protocol("Invalid message format".to_string()));
         }
 
-        let header = MessageHeader::from_bytes(&bytes[4..4 + header_len])?;
-        let ciphertext = bytes[4 + header_len..].to_vec();
+        let header = MessageHeader::from_bytes(&bytes[5..body_start])?;
+        let ciphertext = bytes[body_start..].to_vec();
 
         Ok(Self { header, ciphertext })
     }
@@ -326,16 +361,20 @@ impl DoubleRatchet {
         let chain_key = self
             .sending_chain_key
             .as_ref()
-            .ok_or_else(|| CryptoError::Protocol("No sending chain key".to_string()))?;
+            .ok_or_else(|| CryptoError::Protocol("No sending chain key".to_string()))?
+            .clone();
 
-        let message_key = chain_key.message_key()?;
-        let ciphertext = message_key.encrypt(plaintext, associated_data)?;
-
+        // The header is built before encryption now, because it is part of the associated
+        // data the tag covers.
         let header = MessageHeader {
             dh_public_key: self.public_key(),
             previous_chain_length: self.previous_chain_length,
             message_number: self.sending_message_number,
         };
+
+        let message_key = chain_key.message_key()?;
+        let ciphertext =
+            message_key.encrypt(plaintext, &aad_with_header(associated_data, &header))?;
 
         // Advance sending chain
         self.sending_chain_key = Some(chain_key.next()?);
@@ -350,10 +389,12 @@ impl DoubleRatchet {
         message: &EncryptedMessage,
         associated_data: &[u8],
     ) -> Result<Vec<u8>> {
+        let aad = aad_with_header(associated_data, &message.header);
+
         // Check if we have a skipped message key
         let key = (message.header.dh_public_key, message.header.message_number);
         if let Some(message_key) = self.skipped_message_keys.remove(&key) {
-            return message_key.decrypt(&message.ciphertext, associated_data);
+            return message_key.decrypt(&message.ciphertext, &aad);
         }
 
         // Check if we need to perform DH ratchet
@@ -376,7 +417,7 @@ impl DoubleRatchet {
             .ok_or_else(|| CryptoError::Protocol("No receiving chain key".to_string()))?;
 
         let message_key = chain_key.message_key()?;
-        let plaintext = message_key.decrypt(&message.ciphertext, associated_data)?;
+        let plaintext = message_key.decrypt(&message.ciphertext, &aad)?;
 
         // Advance receiving chain
         self.receiving_chain_key = Some(chain_key.next()?);
@@ -742,6 +783,88 @@ mod tests {
 
         assert_eq!(message.header.message_number, decoded.header.message_number);
         assert_eq!(message.ciphertext, decoded.ciphertext);
+    }
+
+    /// A message carrying the old, unversioned framing must be rejected by version, not by
+    /// a tag failure. The point of the version byte is that an un-upgraded peer gets a
+    /// diagnosable error instead of "decryption failed".
+    #[test]
+    fn old_wire_format_is_rejected_by_version() {
+        let dh_key = StaticSecret::random_from_rng(OsRng);
+        let header = MessageHeader {
+            dh_public_key: X25519PublicKey::from(&dh_key),
+            previous_chain_length: 0,
+            message_number: 0,
+        };
+
+        // Exactly what the previous format produced: u32 BE header length, then the body.
+        let header_bytes = header.to_bytes();
+        let mut legacy = Vec::new();
+        legacy.extend_from_slice(&(header_bytes.len() as u32).to_be_bytes());
+        legacy.extend_from_slice(&header_bytes);
+        legacy.extend_from_slice(&[9u8; 28]);
+
+        // `expect_err` would require `Debug` on EncryptedMessage, and ZK-DEBUG forbids
+        // deriving it on a type that holds ciphertext.
+        match EncryptedMessage::from_bytes(&legacy) {
+            Ok(_) => panic!("the unversioned format must not parse"),
+            Err(e) => assert!(
+                format!("{e}").contains("Unsupported ratchet message version"),
+                "expected a version error, got: {e}"
+            ),
+        }
+    }
+
+    /// `previous_chain_length` is the one header field that does **not** feed key
+    /// derivation - `dh_ratchet_receive` only stores it, and `skip_message_keys` keys off
+    /// `message_number`. So the receiver derives the *same* message key whether or not it
+    /// was tampered with, and the only thing that can reject it is the AEAD tag.
+    ///
+    /// That makes this the isolating test for #105. Tampering `dh_public_key` or
+    /// `message_number` also fails without the fix, because both change which key is
+    /// derived - asserting on those would pass vacuously and prove nothing.
+    #[test]
+    fn tampered_previous_chain_length_fails_to_decrypt() {
+        let shared_secret = [7u8; 32];
+        let bob_prekey = StaticSecret::random_from_rng(OsRng);
+        let bob_public = X25519PublicKey::from(&bob_prekey);
+
+        let mut alice = DoubleRatchet::init_alice(&shared_secret, bob_public).expect("init alice");
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_prekey).expect("init bob");
+
+        let ad = b"alice|bob";
+        let msg = alice.encrypt(b"hello", ad).expect("encrypt");
+
+        let tampered = EncryptedMessage {
+            header: MessageHeader {
+                previous_chain_length: msg.header.previous_chain_length.wrapping_add(3),
+                ..msg.header.clone()
+            },
+            ciphertext: msg.ciphertext.clone(),
+        };
+
+        assert!(
+            bob.decrypt(&tampered, ad).is_err(),
+            "a rewritten previous_chain_length must not authenticate"
+        );
+    }
+
+    /// The honest path still round-trips with the header bound in.
+    #[test]
+    fn header_binding_preserves_round_trip() {
+        let shared_secret = [11u8; 32];
+        let bob_prekey = StaticSecret::random_from_rng(OsRng);
+        let bob_public = X25519PublicKey::from(&bob_prekey);
+
+        let mut alice = DoubleRatchet::init_alice(&shared_secret, bob_public).expect("init alice");
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_prekey).expect("init bob");
+
+        let ad = b"alice|bob";
+        let msg = alice
+            .encrypt(b"the header is authenticated now", ad)
+            .expect("encrypt");
+        let out = bob.decrypt(&msg, ad).expect("decrypt");
+        assert_eq!(out, b"the header is authenticated now");
     }
 
     #[test]

--- a/docs/adr/ADR-0011-ratchet-header-authentication.md
+++ b/docs/adr/ADR-0011-ratchet-header-authentication.md
@@ -1,0 +1,86 @@
+---
+id: adr-0011
+type: adr
+status: accepted
+owns: [backend/crates/crypto/src/double_ratchet.rs]
+read_when: [changing the ratchet wire format, implementing a client Double Ratchet, debugging a decryption failure across versions]
+tokens: 0
+supersedes: []
+---
+
+# ADR-0011 · Bind the ratchet header into the AEAD, and version the wire format
+
+## Status
+
+`accepted`
+
+## Context
+
+`MessageHeader::to_bytes()` was never fed into the AEAD associated data. Both
+`DoubleRatchet::encrypt` and `decrypt` passed only the caller-supplied `associated_data`, so
+the 40 bytes of header — `dh_public_key` (32), `previous_chain_length` (4), `message_number`
+(4) — travelled unauthenticated.
+
+The code was symmetric, so round-trips succeeded and no test failed. It was an authentication
+gap, not a bug that announced itself, and it was filed as
+[#105](https://github.com/guardyn/guardyn/issues/105) rather than fixed on the spot because the
+repair is a non-additive wire change and `AGENTS.md` §10 requires sign-off for those.
+
+The Signal Double Ratchet binds the header for exactly this reason: `AD = AD_initial || header`.
+
+`message_number` is the field that makes this more than theoretical. It drives
+`skip_message_keys`, which walks the receiving chain forward and inserts one key per skipped
+index, up to `MAX_SKIP` (1000). An attacker who can rewrite that counter drives that loop
+(see [#106](https://github.com/guardyn/guardyn/issues/106)).
+
+## Decision
+
+**1. Bind the header into the associated data.** `AD = AD_caller || header.to_bytes()`, applied
+on encrypt, on decrypt, and on the skipped-message-key path — which is easy to miss, because it
+returns before reaching the main decrypt.
+
+**2. Version the wire format.** A serialized message becomes:
+
+```
+version(1) || header_len:u32 BE || header(40) || nonce(12) || ciphertext || tag(16)
+```
+
+The version byte is `1`. The previous format had none and began with the high byte of
+`header_len` — always `0x00` for a 40-byte header — so `0x01` cannot collide with anything the
+old format could emit.
+
+**3. Accept the break at G3, not in Phase 4.** The change is deliberately non-additive.
+
+## Consequences
+
+**Deployed v1.0.1 clients stop decrypting.** This is the cost, and it was taken knowingly.
+`implementation_plan.md:597` anticipated a break of exactly this shape and required behaviour-
+change sign-off at gate G3; that sign-off covers this.
+
+**The failure is diagnosable.** Without the version byte an old message would fail as a bad
+AEAD tag — indistinguishable from tampering, key desynchronisation, or a corrupted store. With
+it, the sender is told the version is unsupported.
+
+**The clients must change in step.** There are two independent Double Ratchet implementations
+besides this one: `client-mobile/lib/core/crypto/double_ratchet.dart`, and the desktop, which
+consumes this crate through `client-desktop/src-tauri/src/commands/crypto.rs`. Both must bind
+the header and emit the version byte, or messages will not cross platforms.
+
+**It does not close #106.** Binding the header authenticates the counter that drives
+`skip_message_keys`, which narrows the exposure but does not remove it: a replayed genuine
+header still drives the loop, and `dh_ratchet_receive` mutates `dh_self`, `root_key` and both
+chain keys before any tag is verified. That is a separate step.
+
+## Alternatives rejected
+
+**Bind the header without a version byte.** Smaller diff, and the AEAD would reject old
+messages anyway. Rejected because it converts a version mismatch into an authentication
+failure, and an operator cannot tell those apart — the wrong error is worse than no error.
+
+**Negotiate the version per session.** Correct in general, and unnecessary here: there is one
+old format and one new one, and the deployment is being broken deliberately at a gate. A
+negotiation mechanism with a single legacy peer to negotiate with is speculative machinery.
+
+**Defer to Phase 4 with the PQ wire work (PR-36).** That was the original plan. It was rejected
+because the E2EE repair already breaks the ciphertext format, so deferring would force every
+client to re-parse twice.

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -81,15 +81,30 @@ A replayed prekey message fails because the one-time key is already consumed.
    attacker-chosen counter drive unbounded memory growth.
 4. Every parser reachable from attacker-controlled bytes — prekey message, ratchet header,
    sealed-sender envelope, PADMÉ unpad — requires a fuzz target (PR-33).
+5. **The header is bound into the AEAD associated data**: `AD = AD_caller || header`, as the
+   Signal specification requires. `dh_public_key`, `previous_chain_length` and
+   `message_number` are therefore covered by the tag and cannot be rewritten in flight.
 
 **Edge cases.** A padded length below `MIN_PADDED_LENGTH` (32) is invalid. Plaintext above
 `MAX_MESSAGE_LENGTH` (16 MiB) is rejected before encryption. A header claiming a counter
 more than `MAX_SKIP` ahead is rejected, not accommodated.
 
-**Known gaps.** The ratchet header is not covered by the AEAD associated data, so an attacker
-may rewrite the sender's public key and counters without invalidating the tag (#105) - the
-specification requires it to be bound. Skipped-key derivation also advances the receiving
-chain before the tag is verified, so a forged header can poison a session (#106).
+**Wire format.** A serialized message is
+`version(1) || header_len:u32 BE || header(40) || nonce(12) || ciphertext || tag(16)`. The
+version byte is 1. The previous format had no version byte and began with the high byte of
+`header_len`, always `0x00` for a 40-byte header, so a leading `0x01` is unambiguous against
+anything the old format could emit: an un-upgraded peer gets an explicit version error rather
+than an opaque authentication failure.
+
+Binding the header changed the ciphertext format non-additively. Deployed clients that predate
+it cannot decrypt, and this was accepted deliberately at gate G3 rather than carried into
+Phase 4, where #105 and #106 would have forced the clients to re-parse a second time.
+
+**Known gaps.** Skipped-key derivation advances the receiving chain before the tag is verified,
+so a forged header can poison a session (#106). Binding the header reduces that exposure - the
+counter driving the loop is now authenticated - but does not remove it: a replayed genuine
+header still drives `skip_message_keys`, and `dh_ratchet_receive` likewise mutates
+`dh_self`, `root_key` and both chain keys before any tag is checked.
 
 ## Groups (MLS)
 


### PR DESCRIPTION
`MessageHeader::to_bytes()` was never fed into the AEAD associated data. Both
`DoubleRatchet::encrypt` and `decrypt` passed only the caller's `associated_data`, leaving all
40 header bytes — `dh_public_key`, `previous_chain_length`, `message_number` — unauthenticated.
The code was symmetric, so round-trips succeeded and no test failed. It was an authentication
gap, not a bug that announced itself.

The Signal Double Ratchet binds the header for exactly this reason: `AD = AD_initial || header`.

## Change

**Three call sites, not two.** `encrypt`, `decrypt`, and the **skipped-message-key path**,
which returns before reaching the main decrypt and is the easy one to miss. The issue text does
not mention it.

**A leading version byte**, now `1`:

```
version(1) || header_len:u32 BE || header(40) || nonce(12) || ciphertext || tag(16)
```

The old format had no version byte and began with the high byte of `header_len` — always `0x00`
for a 40-byte header — so `0x01` cannot collide with anything it could emit. Without it, an old
message fails as a bad AEAD tag: indistinguishable from tampering, key desynchronisation, or a
corrupted store.

## The regression test is not vacuous, and that took a second attempt

My first test tampered `dh_public_key` and `message_number`. **It passed with the fix removed** —
both fields change *which key is derived*, so decryption fails regardless of the AAD. It proved
nothing.

`previous_chain_length` is the only header field that does **not** feed derivation:
`dh_ratchet_receive` merely stores it, and `skip_message_keys` keys off `message_number`. The
receiver therefore derives the *same* message key whether or not it was tampered with, and the
only thing that can reject it is the tag.

Verified by inversion, as `AGENTS.md` §8 requires:

| | result |
|---|---|
| binding removed | `FAILED` — `a rewritten previous_chain_length must not authenticate` |
| binding present | `ok` |

Full suite: **112 passed, 0 failed**. `cargo fmt` and `cargo clippy -p guardyn-crypto
--all-targets -- -D warnings` clean. `rules-verify` and `docs-verify` pass.

## Breaking change — deliberate

**Deployed v1.0.1 clients stop decrypting.** `implementation_plan.md:597` anticipated a break of
this shape and required behaviour-change sign-off at gate G3; that sign-off covers this. Landing
it now rather than in Phase 4 means clients re-parse the format once, not twice.

Recorded in **ADR-0011**, including the two rejected alternatives (bind without a version byte;
negotiate the version per session).

## Deliberately out of scope

- **#106 is not closed by this.** The counter that drives `skip_message_keys` is now
  authenticated, which narrows the exposure but does not remove it: a replayed *genuine* header
  still drives the loop, and `dh_ratchet_receive` mutates `dh_self`, `root_key` and both chain
  keys before any tag is verified. Note that is **broader than #106 states** — the issue blames
  `skip_message_keys` alone.
- **The two client implementations.** `client-mobile/lib/core/crypto/double_ratchet.dart` and
  the desktop path through `client-desktop/src-tauri/src/commands/crypto.rs` must both bind the
  header and emit the version byte, or messages will not cross platforms. Separate steps.
- The AAD strings themselves still differ per platform (desktop uses a bare peer id, mobile
  `sender|recipient`); reconciling them is its own step.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
