### PR TITLE
security(crypto): make ratchet decryption atomic

### DIFF
--- a/backend/crates/crypto/src/double_ratchet.rs
+++ b/backend/crates/crypto/src/double_ratchet.rs
@@ -393,94 +393,54 @@ impl DoubleRatchet {
 
         // Check if we have a skipped message key
         let key = (message.header.dh_public_key, message.header.message_number);
-        if let Some(message_key) = self.skipped_message_keys.remove(&key) {
-            return message_key.decrypt(&message.ciphertext, &aad);
+        if let Some(message_key) = self.skipped_message_keys.get(&key) {
+            // Decrypt first: a failure must not consume the stored key, or one forged
+            // message would destroy the ability to read the genuine one it names.
+            let plaintext = message_key.decrypt(&message.ciphertext, &aad)?;
+            self.skipped_message_keys.remove(&key);
+            return Ok(plaintext);
         }
 
+        // Everything below is staged. `self` is not touched until the tag verifies, so an
+        // authentication failure - or a forged header that trips MAX_SKIP - leaves the
+        // session exactly as it was.
+        let mut staged = ReceiveStaging::from_ratchet(self);
+        let mut newly_skipped = Vec::new();
+
         // Check if we need to perform DH ratchet
-        if let Some(remote_key) = self.dh_remote {
-            if message.header.dh_public_key.as_bytes() != remote_key.as_bytes() {
-                self.dh_ratchet_receive(&message.header)?;
-            }
-        } else {
-            // First message from remote
-            self.dh_ratchet_receive(&message.header)?;
+        match staged.dh_remote {
+            Some(remote_key)
+                if message.header.dh_public_key.as_bytes() == remote_key.as_bytes() => {}
+            // Either the remote rotated its key, or this is the first message from it.
+            _ => staged.dh_ratchet_receive(&message.header)?,
         }
 
         // Skip messages if needed
-        self.skip_message_keys(message.header.message_number)?;
+        staged.skip_message_keys(
+            message.header.message_number,
+            self.skipped_message_keys.len(),
+            &mut newly_skipped,
+        )?;
 
         // Decrypt the message
-        let chain_key = self
+        let chain_key = staged
             .receiving_chain_key
             .as_ref()
-            .ok_or_else(|| CryptoError::Protocol("No receiving chain key".to_string()))?;
+            .ok_or_else(|| CryptoError::Protocol("No receiving chain key".to_string()))?
+            .clone();
 
         let message_key = chain_key.message_key()?;
+
+        // The gate. Nothing above this line has been committed.
         let plaintext = message_key.decrypt(&message.ciphertext, &aad)?;
 
-        // Advance receiving chain
-        self.receiving_chain_key = Some(chain_key.next()?);
-        self.receiving_message_number += 1;
+        // Advance receiving chain, then commit.
+        staged.receiving_chain_key = Some(chain_key.next()?);
+        staged.receiving_message_number += 1;
+        staged.commit_into(self);
+        self.skipped_message_keys.extend(newly_skipped);
 
         Ok(plaintext)
-    }
-
-    /// Perform DH ratchet when receiving new public key
-    fn dh_ratchet_receive(&mut self, header: &MessageHeader) -> Result<()> {
-        // Store previous chain length
-        self.previous_chain_length = self.sending_message_number;
-        self.sending_message_number = 0;
-        self.receiving_message_number = 0;
-
-        // Update remote DH key
-        self.dh_remote = Some(header.dh_public_key);
-
-        // Perform DH and derive new receiving chain
-        let dh_output = self.dh_self.diffie_hellman(&header.dh_public_key);
-        let (new_root_key, receiving_chain_key) = self.root_key.dh_ratchet(dh_output.as_bytes())?;
-        self.root_key = new_root_key;
-        self.receiving_chain_key = Some(receiving_chain_key);
-
-        // Generate new DH key pair and derive new sending chain
-        self.dh_self = StaticSecret::random_from_rng(OsRng);
-        let dh_output = self.dh_self.diffie_hellman(&header.dh_public_key);
-        let (new_root_key, sending_chain_key) = self.root_key.dh_ratchet(dh_output.as_bytes())?;
-        self.root_key = new_root_key;
-        self.sending_chain_key = Some(sending_chain_key);
-
-        Ok(())
-    }
-
-    /// Skip message keys for out-of-order handling
-    fn skip_message_keys(&mut self, until: u32) -> Result<()> {
-        if let Some(chain_key) = &self.receiving_chain_key {
-            let mut current_chain_key = chain_key.clone();
-
-            while self.receiving_message_number < until {
-                if self.skipped_message_keys.len() >= MAX_SKIP {
-                    return Err(CryptoError::Protocol(format!(
-                        "Too many skipped messages (max: {})",
-                        MAX_SKIP
-                    )));
-                }
-
-                let message_key = current_chain_key.message_key()?;
-                let remote_key = self
-                    .dh_remote
-                    .ok_or_else(|| CryptoError::Protocol("No remote key".to_string()))?;
-
-                self.skipped_message_keys
-                    .insert((remote_key, self.receiving_message_number), message_key);
-
-                current_chain_key = current_chain_key.next()?;
-                self.receiving_message_number += 1;
-            }
-
-            self.receiving_chain_key = Some(current_chain_key);
-        }
-
-        Ok(())
     }
 
     /// Get number of skipped messages in cache
@@ -681,6 +641,122 @@ impl DoubleRatchet {
     }
 }
 
+/// The receive-side state a single `decrypt` may advance.
+///
+/// `decrypt` used to mutate `DoubleRatchet` in place **before** the AEAD tag was verified:
+/// `dh_ratchet_receive` rotated `dh_self`, `root_key` and both chain keys, and
+/// `skip_message_keys` walked the receiving chain forward, inserting a key per skipped index.
+/// None of it was rolled back when decryption then failed, so one forged message could advance
+/// the chain past every genuine one and leave the session unrecoverable without a new handshake.
+///
+/// Staging the transition here and swapping it in only on success makes the operation atomic.
+/// Cloning `DoubleRatchet` wholesale would have been simpler, but it carries
+/// `skipped_message_keys` - up to `MAX_SKIP` (1000) entries - and allocating that on every
+/// message to guard against a rare failure is the wrong trade. Every field below is fixed-size.
+#[derive(Clone)]
+struct ReceiveStaging {
+    dh_self: StaticSecret,
+    dh_remote: Option<X25519PublicKey>,
+    root_key: RootKey,
+    sending_chain_key: Option<ChainKey>,
+    sending_message_number: u32,
+    receiving_chain_key: Option<ChainKey>,
+    receiving_message_number: u32,
+    previous_chain_length: u32,
+}
+
+impl ReceiveStaging {
+    fn from_ratchet(r: &DoubleRatchet) -> Self {
+        Self {
+            dh_self: r.dh_self.clone(),
+            dh_remote: r.dh_remote,
+            root_key: r.root_key.clone(),
+            sending_chain_key: r.sending_chain_key.clone(),
+            sending_message_number: r.sending_message_number,
+            receiving_chain_key: r.receiving_chain_key.clone(),
+            receiving_message_number: r.receiving_message_number,
+            previous_chain_length: r.previous_chain_length,
+        }
+    }
+
+    fn commit_into(self, r: &mut DoubleRatchet) {
+        r.dh_self = self.dh_self;
+        r.dh_remote = self.dh_remote;
+        r.root_key = self.root_key;
+        r.sending_chain_key = self.sending_chain_key;
+        r.sending_message_number = self.sending_message_number;
+        r.receiving_chain_key = self.receiving_chain_key;
+        r.receiving_message_number = self.receiving_message_number;
+        r.previous_chain_length = self.previous_chain_length;
+    }
+
+    /// Perform DH ratchet when receiving a new public key.
+    fn dh_ratchet_receive(&mut self, header: &MessageHeader) -> Result<()> {
+        // Store previous chain length
+        self.previous_chain_length = self.sending_message_number;
+        self.sending_message_number = 0;
+        self.receiving_message_number = 0;
+
+        // Update remote DH key
+        self.dh_remote = Some(header.dh_public_key);
+
+        // Perform DH and derive new receiving chain
+        let dh_output = self.dh_self.diffie_hellman(&header.dh_public_key);
+        let (new_root_key, receiving_chain_key) = self.root_key.dh_ratchet(dh_output.as_bytes())?;
+        self.root_key = new_root_key;
+        self.receiving_chain_key = Some(receiving_chain_key);
+
+        // Generate new DH key pair and derive new sending chain
+        self.dh_self = StaticSecret::random_from_rng(OsRng);
+        let dh_output = self.dh_self.diffie_hellman(&header.dh_public_key);
+        let (new_root_key, sending_chain_key) = self.root_key.dh_ratchet(dh_output.as_bytes())?;
+        self.root_key = new_root_key;
+        self.sending_chain_key = Some(sending_chain_key);
+
+        Ok(())
+    }
+
+    /// Derive the message keys for indices skipped by an out-of-order message.
+    ///
+    /// Keys are collected into `out` rather than inserted, so the caller can discard them if
+    /// the tag then fails. `already_stored` is the committed map's length, which the
+    /// `MAX_SKIP` bound counts against - otherwise each forged message could stage up to the
+    /// limit afresh and the bound would mean nothing.
+    fn skip_message_keys(
+        &mut self,
+        until: u32,
+        already_stored: usize,
+        out: &mut Vec<((X25519PublicKey, u32), MessageKey)>,
+    ) -> Result<()> {
+        if let Some(chain_key) = &self.receiving_chain_key {
+            let mut current_chain_key = chain_key.clone();
+
+            while self.receiving_message_number < until {
+                if already_stored + out.len() >= MAX_SKIP {
+                    return Err(CryptoError::Protocol(format!(
+                        "Too many skipped messages (max: {})",
+                        MAX_SKIP
+                    )));
+                }
+
+                let message_key = current_chain_key.message_key()?;
+                let remote_key = self
+                    .dh_remote
+                    .ok_or_else(|| CryptoError::Protocol("No remote key".to_string()))?;
+
+                out.push(((remote_key, self.receiving_message_number), message_key));
+
+                current_chain_key = current_chain_key.next()?;
+                self.receiving_message_number += 1;
+            }
+
+            self.receiving_chain_key = Some(current_chain_key);
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -847,6 +923,99 @@ mod tests {
             bob.decrypt(&tampered, ad).is_err(),
             "a rewritten previous_chain_length must not authenticate"
         );
+    }
+
+    /// A forged message must leave the session able to read the next genuine one.
+    ///
+    /// This is the property #106 was filed for. `skip_message_keys` walked the receiving
+    /// chain forward from an unauthenticated `message_number` *before* the tag was checked,
+    /// and nothing rolled it back, so one forged header permanently desynchronised the
+    /// session - the attacker did not need any key material to do it.
+    #[test]
+    fn forged_message_does_not_poison_the_session() {
+        let shared_secret = [23u8; 32];
+        let bob_prekey = StaticSecret::random_from_rng(OsRng);
+        let bob_public = X25519PublicKey::from(&bob_prekey);
+
+        let mut alice = DoubleRatchet::init_alice(&shared_secret, bob_public).expect("init alice");
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_prekey).expect("init bob");
+
+        let ad = b"alice|bob";
+
+        // A genuine message, rewritten to claim a counter far ahead.
+        let genuine = alice.encrypt(b"first", ad).expect("encrypt");
+        let forged = EncryptedMessage {
+            header: MessageHeader {
+                message_number: 500,
+                ..genuine.header.clone()
+            },
+            ciphertext: genuine.ciphertext.clone(),
+        };
+
+        assert!(
+            bob.decrypt(&forged, ad).is_err(),
+            "the forged message must not decrypt"
+        );
+        assert_eq!(
+            bob.skipped_messages_count(),
+            0,
+            "a rejected message must not leave skipped keys behind"
+        );
+
+        // The genuine message it was derived from must still arrive.
+        let out = bob
+            .decrypt(&genuine, ad)
+            .expect("the session must still work");
+        assert_eq!(out, b"first");
+
+        // And the conversation continues.
+        let second = alice.encrypt(b"second", ad).expect("encrypt");
+        assert_eq!(bob.decrypt(&second, ad).expect("decrypt"), b"second");
+    }
+
+    /// A failed decrypt on the skipped-key path must not consume the stored key: otherwise
+    /// one forged message destroys the ability to read the genuine message it names.
+    #[test]
+    fn failed_skipped_key_decrypt_keeps_the_key() {
+        let shared_secret = [31u8; 32];
+        let bob_prekey = StaticSecret::random_from_rng(OsRng);
+        let bob_public = X25519PublicKey::from(&bob_prekey);
+
+        let mut alice = DoubleRatchet::init_alice(&shared_secret, bob_public).expect("init alice");
+        let mut bob = DoubleRatchet::init_bob(&shared_secret, bob_prekey).expect("init bob");
+
+        let ad = b"alice|bob";
+
+        // Alice sends three; Bob receives the third first, so keys 0 and 1 are stored.
+        let m0 = alice.encrypt(b"zero", ad).expect("encrypt");
+        let _m1 = alice.encrypt(b"one", ad).expect("encrypt");
+        let m2 = alice.encrypt(b"two", ad).expect("encrypt");
+
+        bob.decrypt(&m2, ad).expect("out-of-order delivery");
+        assert_eq!(bob.skipped_messages_count(), 2);
+
+        // A corrupted copy of m0 targets a stored key and must fail without spending it.
+        let mut broken_ct = m0.ciphertext.clone();
+        let last = broken_ct.len() - 1;
+        broken_ct[last] ^= 0xff;
+        let corrupted = EncryptedMessage {
+            header: m0.header.clone(),
+            ciphertext: broken_ct,
+        };
+
+        assert!(
+            bob.decrypt(&corrupted, ad).is_err(),
+            "corrupted must not decrypt"
+        );
+        assert_eq!(
+            bob.skipped_messages_count(),
+            2,
+            "a failed decrypt must not consume the skipped key"
+        );
+
+        // The genuine message still arrives.
+        assert_eq!(bob.decrypt(&m0, ad).expect("decrypt"), b"zero");
+        assert_eq!(bob.skipped_messages_count(), 1);
     }
 
     /// The honest path still round-trips with the header bound in.

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -84,10 +84,17 @@ A replayed prekey message fails because the one-time key is already consumed.
 5. **The header is bound into the AEAD associated data**: `AD = AD_caller || header`, as the
    Signal specification requires. `dh_public_key`, `previous_chain_length` and
    `message_number` are therefore covered by the tag and cannot be rewritten in flight.
+6. **Decryption is atomic.** No receive-side state is committed until the AEAD tag verifies.
+   The DH ratchet step, the skipped-key derivation and the chain advance are staged and
+   swapped in only on success, so a rejected message - forged, corrupted or merely
+   mis-delivered - leaves the session exactly as it was. A failed decrypt on the skipped-key
+   path likewise does not consume the stored key.
 
 **Edge cases.** A padded length below `MIN_PADDED_LENGTH` (32) is invalid. Plaintext above
 `MAX_MESSAGE_LENGTH` (16 MiB) is rejected before encryption. A header claiming a counter
-more than `MAX_SKIP` ahead is rejected, not accommodated.
+more than `MAX_SKIP` ahead is rejected, not accommodated - and the bound counts staged keys
+against those already stored, so a sequence of rejected messages cannot each stage up to the
+limit afresh.
 
 **Wire format.** A serialized message is
 `version(1) || header_len:u32 BE || header(40) || nonce(12) || ciphertext || tag(16)`. The
@@ -99,12 +106,6 @@ than an opaque authentication failure.
 Binding the header changed the ciphertext format non-additively. Deployed clients that predate
 it cannot decrypt, and this was accepted deliberately at gate G3 rather than carried into
 Phase 4, where #105 and #106 would have forced the clients to re-parse a second time.
-
-**Known gaps.** Skipped-key derivation advances the receiving chain before the tag is verified,
-so a forged header can poison a session (#106). Binding the header reduces that exposure - the
-counter driving the loop is now authenticated - but does not remove it: a replayed genuine
-header still drives `skip_message_keys`, and `dh_ratchet_receive` likewise mutates
-`dh_self`, `root_key` and both chain keys before any tag is checked.
 
 ## Groups (MLS)
 


### PR DESCRIPTION
> Stacked on #105. Review that first; this PR's diff assumes the header binding.

`decrypt` mutated the ratchet **before** the AEAD tag was verified, and nothing rolled it back
on failure.

## The issue understates the problem

It blames `skip_message_keys`. There are **two** pre-authentication mutations:

| | what it changed |
|---|---|
| `skip_message_keys` | walked the receiving chain forward from an unauthenticated `message_number`, inserting a key per skipped index |
| `dh_ratchet_receive` | rotated `dh_self`, `root_key` **and both chain keys** whenever the header carried an unfamiliar public key |

The second is the worse one, and it is not mentioned in #106: a forged header with an unknown
`dh_public_key` destroyed the session **even when the skip loop never ran**. So the suggested
fix in the issue — "operate on a clone of the receiving-chain state" — would not have been
sufficient.

An attacker needed no key material for either. Only the ability to modify a message in flight.

## Change

The receive-side transition is staged on a `ReceiveStaging` value and committed only after the
tag verifies. Every early return leaves `self` untouched.

**Why not `#[derive(Clone)]` on `DoubleRatchet` and swap?** Simpler, and it was my first
instinct — but the struct carries `skipped_message_keys`, up to `MAX_SKIP` (1000) entries.
Allocating that on every message to guard against a rare failure is the wrong trade. The staged
fields are all fixed-size; skipped keys are collected into a `Vec` the caller discards on
failure.

**The `MAX_SKIP` bound now counts staged keys against those already stored.** Counting only the
staged ones would let each rejected message stage up to the limit afresh — no bound at all.

**The skipped-key path stopped consuming its key on failure.** It used to `remove` *before*
decrypting, so one corrupted copy of a message destroyed the ability to read the genuine one it
named.

## Verification by inversion

Both tests were checked against the old behaviour, per `AGENTS.md` §8:

| test | commit moved before the tag check | as written |
|---|---|---|
| `forged_message_does_not_poison_the_session` | `FAILED` | `ok` |
| `failed_skipped_key_decrypt_keeps_the_key` | `FAILED` | `ok` |

Full suite **114 passed, 0 failed**. `cargo fmt`, `cargo clippy --all-targets -- -D warnings`,
`rules-verify` and `docs-verify` all clean.

## Deliberately out of scope

- **The two client implementations.** `client-mobile/lib/core/crypto/double_ratchet.dart` has
  the identical defect and is a separate step.
- Zeroizing the staged secrets on drop. Neither the staged copy nor the original is zeroized
  today; that is a pre-existing gap, not one this PR introduces.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
