### PR TITLE
chore(roadmap): reconcile after the ciphertext format break

### DIFF
--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -100,7 +100,18 @@ steps:
   - {id: PR-52, issue: 179, phase: 3, type: chore, status: done, title: "Mark eight completed roadmap steps as done"}
   - {id: PR-53, issue: 181, phase: 3, type: fix, status: done, title: "Run the desktop workflows on ubuntu-latest"}
   - {id: PR-54, issue: 186, phase: 3, type: fix, status: done, title: "Add the missing icon.icns bundle asset"}
-  - {id: PR-55, issue: 182, phase: 3, type: chore, status: todo, title: "Remove continue-on-error from the desktop workflows"}
+  - {id: PR-55, issue: 182, phase: 3, type: chore, status: done, title: "Remove continue-on-error from the desktop workflows"}
   - {id: PR-56, issue: 188, phase: 3, type: fix, status: todo, title: "Regenerate or drop the stale client-desktop protobuf"}
   - {id: PR-57, issue: 180, phase: 3, type: fix, status: todo, title: "Make roadmap-sync detect drift and create issues"}
   - {id: PR-58, issue: 189, phase: 3, type: chore, status: todo, title: "Reconcile roadmap.yaml after the G3 merge wave"}
+  # The ciphertext format break. #105 and #106 were Phase-3 security issues with no step,
+  # so G3 would have passed over them; folding them in was a G3 sign-off decision.
+  - {id: PR-59, issue: 105, phase: 3, type: security, status: done, title: "Bind the ratchet header into the AEAD and version the wire"}
+  - {id: PR-60, issue: 106, phase: 3, type: security, status: done, title: "Make ratchet decryption atomic"}
+  - {id: PR-61, issue: 194, phase: 3, type: fix, status: done, title: "Install the cross targets on the pinned toolchain"}
+  # Debt measured while removing continue-on-error, each too large for that step.
+  - {id: PR-62, issue: 191, phase: 3, type: chore, status: todo, title: "Clear the 132 client-desktop clippy errors"}
+  - {id: PR-63, issue: 192, phase: 3, type: chore, status: todo, title: "Reconcile the desktop coverage thresholds with reality"}
+  - {id: PR-64, issue: 198, phase: 3, type: fix, status: todo, title: "Fix the Dart skip-message-keys counter and bound"}
+  - {id: PR-65, issue: 199, phase: 3, type: fix, status: todo, title: "Stop Build Linux flaking in linuxdeploy"}
+  - {id: PR-66, issue: 200, phase: 3, type: chore, status: todo, title: "Reconcile roadmap.yaml after the ciphertext format break"}


### PR DESCRIPTION
Second reconciliation of the G3 close-out, after #105 and #106 landed.

## 1. One stale status

`PR-55` (#182) recorded `todo` against a closed issue. `roadmap-sync.sh:157-172` reconciles
issue state **from** this file, so the next write-mode run would have reopened it.

## 2. Seven session issues had no step

| step | issue | |
|---|---|---|
| PR-59 | #105 | header bound into the AEAD — **done** |
| PR-60 | #106 | atomic decryption — **done** |
| PR-61 | #194 | cross targets on the pinned toolchain — **done** |
| PR-62 | #191 | 132 desktop clippy errors |
| PR-63 | #192 | desktop coverage asserts 70%, measures 43% |
| PR-64 | #198 | Dart skip-keys counter and bound |
| PR-65 | #199 | `linuxdeploy` flake |
| PR-66 | #200 | this reconciliation |

**PR-59 and PR-60 are the ones that mattered.** #105 and #106 were Phase-3 `type:security`
issues with no step id and no PR — G3 would have passed over both silently.

## 3. Thirteen pre-existing unmapped issues, deliberately left

`#107`, `#113`, `#118`, `#128`, `#141`, `#142`, `#145`, `#158`, `#163`, `#166`, `#172`, `#173`,
`#177` predate this session. Deciding which are still live is a judgement call, not a mechanical
reconciliation, so it belongs in its own step.

## Verification

All **75** steps agree with GitHub — **0 drift** — no duplicate step id, no issue claimed by two
steps.

## The recurring cost

This is the **second** reconciliation in one session. `roadmap-sync`'s dry run never reads
GitHub (#180), so nothing surfaces this drift except a manual audit, and it returns after every
merge wave. Advancing a step's `status` in the PR that closes its issue would remove the need
for these passes entirely — worth considering when #180 is picked up.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
