### PR TITLE
chore(roadmap): record the client-side E2EE repair steps

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -56,11 +56,20 @@ reason phases 3 and 4 exist.
 
 | Invariant | State | Closed by |
 |---|---|---|
-| **I-2** Always-On E2EE | server-side encryption removed and no flag remains; `client-desktop` still sends plaintext | PR-30′, PR-31a–d, PR-32a–c (Phase 3) + #163 |
+| **I-2** Always-On E2EE | server-side encryption removed and no flag remains; **both clients still transmit plaintext** | PR-30′, PR-31a–d, PR-32a–c, PR-75–PR-81 (Phase 3) |
 | **I-3** Post-Quantum | `pq` is off by default and no proto field carries an ML-KEM key, so no server can publish one | PR-36…PR-40 (Phase 4) |
 
 Until those land, **the product must not be described as always-encrypted or
 post-quantum protected.**
+
+**I-2 is a client problem now.** The server became a pure relay in Phase 3
+([ADR-0010](../adr/ADR-0010-pure-relay-server.md)), which moved the whole burden onto the
+clients — and neither carries it. `client-desktop` sends plaintext in `encrypted_content`
+(#163) and a second plaintext copy over WebSocket; `client-mobile` *falls back* to plaintext
+whenever encryption fails, and sends group messages unencrypted while the UI renders an MLS
+padlock over them. The Dart client is also still on the pre-[ADR-0011](../adr/ADR-0011-ratchet-header-authentication.md)
+wire format, so Dart and Rust cannot decrypt each other at all. PR-67…PR-83 repair this, and
+mobile CI is pulled forward out of PR-44 because none of it was under test.
 
 **I-2's scope changed during Phase 3.** The row above used to read "`GUARDYN_E2EE_ENABLED` still
 exists and the non-E2EE handler is the registered one", which had the fix backwards: the `_e2ee`

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -22,7 +22,7 @@ project_sync_enabled: true
 
 invariants:
   - {id: I-1, name: Zero-Knowledge,   met: partial, note: "rate_limit.rs logs a raw IP; span fields are not redacted"}
-  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c], note: "E2EE-DUP and E2EE-FLAG pass; PR-32c blocked on #163 - client-desktop sends plaintext"}
+  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-78], note: "server side is done; both clients still transmit plaintext, so PR-32c stays blocked on #163 (now owned by PR-78)"}
   - {id: I-3, name: Post-Quantum,     met: false,   closed_by: [PR-36, PR-37, PR-38, PR-39, PR-40]}
   - {id: I-4, name: Data Sovereignty, met: partial, note: "envoy/ingress.yaml hardcodes a domain"}
 
@@ -87,7 +87,7 @@ steps:
   - {id: PR-41, issue: 52, phase: 4, type: refactor, status: todo, title: "Make rate limiting distributed or document the single-replica constraint"}
   - {id: PR-42, issue: 53, phase: 4, type: security, status: todo, title: "Fix the inverted secrets gitignore"}
   - {id: PR-43, issue: 54, phase: 4, type: feat, status: todo, title: "Wire the compose observability stack"}
-  - {id: PR-44, issue: 55, phase: 4, type: chore, status: todo, gate: G4, title: "Deployment parity - call-service k8s, digest pins, mobile CI"}
+  - {id: PR-44, issue: 55, phase: 4, type: chore, status: todo, gate: G4, title: "Deployment parity - call-service k8s Deployment and image digest pins"}
   - {id: PR-45, issue: 60, phase: 1, type: chore, status: done, title: "Untrack the 18.4 MB committed ChromeDriver binary"}
   - {id: PR-46, issue: 132, phase: 3, type: fix, status: done, title: "Adapt to the rdkafka 0.39 Delivery type and vendor libcurl"}
   - {id: PR-47, issue: 137, phase: 3, type: chore, status: done, title: "Record the G2 hotfix steps in roadmap.yaml"}
@@ -115,3 +115,26 @@ steps:
   - {id: PR-64, issue: 198, phase: 3, type: fix, status: todo, title: "Fix the Dart skip-message-keys counter and bound"}
   - {id: PR-65, issue: 199, phase: 3, type: fix, status: todo, title: "Stop Build Linux flaking in linuxdeploy"}
   - {id: PR-66, issue: 200, phase: 3, type: chore, status: todo, title: "Reconcile roadmap.yaml after the ciphertext format break"}
+  # Client-side E2EE repair. ADR-0010 made the server a pure relay and ADR-0011 broke the
+  # ciphertext format; neither client followed. Both transmit plaintext today, so these are
+  # I-2 repairs rather than catch-up work. PR-67..PR-69 pull mobile CI forward out of PR-44,
+  # because rewriting the Dart crypto layer with no CI is flying blind.
+  - {id: PR-67, issue: 202, phase: 3, type: fix, status: todo, title: "Repair the nine failing Dart tests and the analyzer error"}
+  - {id: PR-68, issue: 203, phase: 3, type: chore, status: todo, title: "Add the mobile CI workflow (split out of PR-44)"}
+  - {id: PR-69, issue: 204, phase: 3, type: chore, status: todo, title: "Un-gate the Dart crypto suite so it runs under flutter test"}
+  - {id: PR-70, issue: null, phase: 3, type: security, status: todo, title: "Dart - adopt ratchet wire format v1 and bind the header into the AEAD"}
+  - {id: PR-71, issue: null, phase: 3, type: security, status: todo, title: "Dart - make ratchet decryption atomic"}
+  - {id: PR-72, issue: null, phase: 3, type: security, status: todo, title: "Unify the client AAD convention and fix UTF-8 handling"}
+  - {id: PR-73, issue: null, phase: 3, type: security, status: todo, title: "Apply PADME padding on the mobile message path"}
+  - {id: PR-74, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - make the ratchet AAD symmetric"}
+  - {id: PR-75, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed instead of sending plaintext"}
+  - {id: PR-76, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed on group messaging"}
+  - {id: PR-77, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - refuse the native to Dart crypto downgrade"}
+  - {id: PR-78, issue: 163, phase: 3, type: security, status: todo, title: "client-desktop - encrypt on the send path"}
+  - {id: PR-79, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - retain private prekey material"}
+  - {id: PR-80, issue: null, phase: 3, type: feat, status: todo, title: "client-desktop - implement the X3DH responder path"}
+  - {id: PR-81, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - restore the ratchet store from persisted state"}
+  # Deferred deliberately, each with a stated reason in its step above.
+  - {id: PR-82, issue: null, phase: 3, type: chore, status: todo, title: "Add an FFI-backed mobile CI job"}
+  - {id: PR-83, issue: null, phase: 3, type: chore, status: todo, title: "Clear the 314 flutter analyze info diagnostics"}
+  - {id: PR-84, issue: 205, phase: 3, type: chore, status: todo, title: "Record the client-side E2EE repair steps in roadmap.yaml"}


### PR DESCRIPTION
Closes #205

Roadmap only. **No source changes** — `docs-verify` reports 0 mapped source paths changed.

## Why

Post-G3 the work shifts to the clients, and `roadmap.yaml` had no steps for any of it.

**Mobile CI had to come out of PR-44.** That step (#55) bundles the call-service k8s Deployment,
image digest pins and the missing mobile CI workflow behind **G4**. The client repair is about to
rewrite the Dart crypto layer, and nothing tests it — `grep -rn "flutter" .github/workflows/`
returns nothing. CI has to come first, so it cannot stay behind G4.
`.claude/rules/10-git-workflow.md` forbids retro-fitting a second step onto an existing issue, so
mobile CI becomes #202, #203 and #204, and PR-44 narrows to k8s parity + digest pins.

**The client repair steps did not exist.** ADR-0010 made the server a pure relay and ADR-0011
broke the ciphertext format. Neither client followed, and both transmit plaintext today:

| Defect | Evidence |
|---|---|
| desktop sends plaintext in `encrypted_content` | `commands/messaging.rs:86` — the real `encrypt_message` at `crypto.rs:613` has zero call sites |
| desktop sends a **second** plaintext copy over WebSocket | `Chat.tsx:266-282`, flagged `encrypted: false` |
| mobile **fails open** | `message_repository_impl.dart:458`, `:487` — `'…Sending plaintext.'; return (plaintext, null);` |
| mobile groups are unencrypted entirely | `group_remote_datasource.dart:226` — `encryptedContent: utf8.encode(textContent)` |
| mobile UI claims MLS over that cleartext | `group_chat_page.dart:242`, `group_info_page.dart:330` |
| Dart is on the pre-ADR-0011 wire format | `double_ratchet.dart:239-247` — no version byte, no header binding |

These are **I-2 repairs**, not catch-up work. #163 had no owning step at all; **PR-78** gives it
one, which is what eventually unblocks PR-32c/#155.

## Changes

- `roadmap.yaml` — narrow PR-44; add PR-67…PR-84 under `phase: 3`; update the I-2 note.
- `ROADMAP.md` — the I-2 row named only `client-desktop`, which is no longer true.

## Why PR-70 onward carry `issue: null`

`roadmap-sync` cannot create issues (#180, `roadmap-sync.sh:132-133` only prints
`"would create"`). Rather than opening fourteen issues nobody is working on yet, the later steps
are recorded as the plan of record and numbered just in time. The dry run lists them as
"would create"; that is the known limitation, not drift.

## Verification

```
docs-verify   all checks passed  (impact: 0 mapped source paths changed)
rules-verify  all checks passed  (RS-UNWRAP 49 and NAME-SH 5 at frozen budget)
roadmap-sync  237 already correct, 0 failed  — converged and idempotent
budget        2 files, 38 lines
```

## Deliberately out of scope

- **Any source change.** The repair itself is PR-67 onward.
- **The existing status drift** where PR-31b/#151, PR-31d/#153, PR-32b/#154 and PR-34/#45 are
  `todo` while their work has landed. That is owned by PR-58/#189 and PR-66/#200 — patching it
  here would poach another step's scope. Verified those issues are genuinely still open, so this
  sync reopens nothing.
- Narrowing #55's own body text; the YAML title is the SSOT and the sync does not reconcile
  issue bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)