### PR TITLE
fix(mobile): repair the nine failing Dart tests and the analyzer error

### DIFF
--- a/client-mobile/lib/features/messaging/data/repositories/message_repository_impl.dart
+++ b/client-mobile/lib/features/messaging/data/repositories/message_repository_impl.dart
@@ -490,22 +490,6 @@ class MessageRepositoryImpl implements MessageRepository {
     }
   }
 
-  /// Legacy encryption method for backward compatibility
-  Future<String> _encryptMessage({
-    required String plaintext,
-    required String recipientUserId,
-    required String recipientDeviceId,
-    required String currentUserId,
-  }) async {
-    final (encryptedContent, _) = await _encryptMessageWithPrekey(
-      plaintext: plaintext,
-      recipientUserId: recipientUserId,
-      recipientDeviceId: recipientDeviceId,
-      currentUserId: currentUserId,
-    );
-    return encryptedContent;
-  }
-
   /// Create E2EE session via X3DH key exchange
   /// Returns X3DH prekey message to include in first message
   Future<X3DHPrekeyMessage?> _createE2ESessionWithPrekey({
@@ -533,17 +517,6 @@ class MessageRepositoryImpl implements MessageRepository {
     );
 
     return prekeyMessage;
-  }
-
-  /// Legacy session creation for backward compatibility
-  Future<void> _createE2ESession({
-    required String recipientUserId,
-    required String recipientDeviceId,
-  }) async {
-    await _createE2ESessionWithPrekey(
-      recipientUserId: recipientUserId,
-      recipientDeviceId: recipientDeviceId,
-    );
   }
 
   /// Decrypt message content with Double Ratchet

--- a/client-mobile/test/features/groups/presentation/pages/user_profile_page_test.dart
+++ b/client-mobile/test/features/groups/presentation/pages/user_profile_page_test.dart
@@ -1,8 +1,59 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:guardyn_client/core/error/failures.dart';
+import 'package:guardyn_client/features/contacts/presentation/bloc/contacts_bloc.dart';
 import 'package:guardyn_client/features/groups/presentation/pages/user_profile_page.dart';
+import 'package:guardyn_client/features/messaging/domain/usecases/block_user.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockContactsBloc extends MockBloc<ContactsEvent, ContactsState>
+    implements ContactsBloc {}
+
+class MockBlockUser extends Mock implements BlockUser {}
+
+class MockUnblockUser extends Mock implements UnblockUser {}
+
+class MockGetBlockedUsers extends Mock implements GetBlockedUsers {}
 
 void main() {
+  late MockContactsBloc mockContactsBloc;
+  late MockBlockUser mockBlockUser;
+  late MockUnblockUser mockUnblockUser;
+  late MockGetBlockedUsers mockGetBlockedUsers;
+
+  // UserProfilePage resolves all four of these from GetIt in initState, so the
+  // page cannot build at all without them. Before this registration every test
+  // in the file failed with "GetIt: Object/factory with type ContactsBloc is
+  // not registered", and every finder reported 0 widgets as a consequence.
+  setUp(() {
+    mockContactsBloc = MockContactsBloc();
+    mockBlockUser = MockBlockUser();
+    mockUnblockUser = MockUnblockUser();
+    mockGetBlockedUsers = MockGetBlockedUsers();
+
+    whenListen(
+      mockContactsBloc,
+      const Stream<ContactsState>.empty(),
+      initialState: ContactsInitial(),
+    );
+
+    // _checkIsBlocked() awaits this during initState.
+    when(() => mockGetBlockedUsers()).thenAnswer(
+      (_) async => const Right<Failure, List<BlockedUser>>(<BlockedUser>[]),
+    );
+
+    final getIt = GetIt.instance;
+    getIt.registerFactory<ContactsBloc>(() => mockContactsBloc);
+    getIt.registerFactory<BlockUser>(() => mockBlockUser);
+    getIt.registerFactory<UnblockUser>(() => mockUnblockUser);
+    getIt.registerFactory<GetBlockedUsers>(() => mockGetBlockedUsers);
+  });
+
+  tearDown(() => GetIt.instance.reset());
+
   group('UserProfilePage', () {
     testWidgets('displays user information correctly', (tester) async {
       await tester.pumpWidget(

--- a/client-mobile/test/features/media/data/datasources/media_remote_datasource_test.dart
+++ b/client-mobile/test/features/media/data/datasources/media_remote_datasource_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:guardyn_client/core/auth/token_manager.dart';
 import 'package:guardyn_client/core/network/grpc_clients.dart';
 import 'package:guardyn_client/features/media/data/datasources/media_remote_datasource.dart';
 import 'package:guardyn_client/features/media/domain/repositories/media_repository.dart';
@@ -15,6 +16,8 @@ class MockMediaServiceClient extends Mock implements MediaServiceClient {}
 
 class MockHttpClient extends Mock implements http.Client {}
 
+class MockTokenManager extends Mock implements TokenManager {}
+
 // Fake classes for mocktail
 class FakeHttpRequest extends Fake implements http.Request {}
 
@@ -24,6 +27,7 @@ void main() {
   late MockGrpcClients mockGrpcClients;
   late MockMediaServiceClient mockMediaClient;
   late MockHttpClient mockHttpClient;
+  late MockTokenManager mockTokenManager;
   late MediaRemoteDatasource datasource;
 
   setUpAll(() {
@@ -35,10 +39,15 @@ void main() {
     mockGrpcClients = MockGrpcClients();
     mockMediaClient = MockMediaServiceClient();
     mockHttpClient = MockHttpClient();
+    mockTokenManager = MockTokenManager();
 
     when(() => mockGrpcClients.mediaClient).thenReturn(mockMediaClient);
 
-    datasource = MediaRemoteDatasource(mockGrpcClients, mockHttpClient);
+    datasource = MediaRemoteDatasource(
+      mockGrpcClients,
+      mockHttpClient,
+      mockTokenManager,
+    );
   });
 
   group('MediaRemoteDatasource', () {


### PR DESCRIPTION
Closes #202

Prerequisite for #203 — the mobile CI workflow cannot land while the suite is red.

## Baseline

`client-mobile` has no CI (`grep -rn "flutter" .github/workflows/` returns nothing), so the suite
rotted unnoticed. Measured on Flutter 3.38.4 / Dart 3.10.3:

```
before:  flutter test -> 521 pass, 40 skip, 9 fail
         flutter analyze -> 1 error, 2 warnings, 314 info   (exit 1)

after:   flutter test -> 539 pass, 40 skip, 0 fail
         flutter analyze --no-fatal-infos -> exit 0
```

## Two causes, both mechanical

**`media_remote_datasource_test.dart` never compiled.** `MediaRemoteDatasource` takes three
positional arguments (`grpcClients, httpClient, tokenManager`) and the test passed two —
`tokenManager` was added to the constructor and the test was not updated. The file therefore never
loaded, which is *also* where the single `flutter analyze` error came from, so one defect blocked
both gates. All ten of its tests exercise the HTTP paths (`uploadToPresignedUrl`,
`downloadFromPresignedUrl`) only, so a bare mock suffices — no stubbing needed.

**`user_profile_page_test.dart` built no widget at all.** `UserProfilePage` resolves
`ContactsBloc`, `BlockUser`, `UnblockUser` and `GetBlockedUsers` from GetIt in `initState`
(`user_profile_page.dart:44-47`), and the test registered none of them. Every test failed with:

```
Bad state: GetIt: Object/factory with type ContactsBloc is not registered inside GetIt.
```

The "8 widget-finder failures" were a symptom — the finders reported 0 widgets because the page
never built. Registration follows the pattern already in
`chat_page_call_buttons_test.dart:63-79`. `GetBlockedUsers` is stubbed because `_checkIsBlocked()`
awaits it during `initState`.

## Also

Deletes `_encryptMessage` and `_createE2ESession`
(`message_repository_impl.dart:494,539`) — the two unreferenced wrappers that produced the only
two analyzer **warnings**. They were dead, not merely unused: the live send path calls the
`…WithPrekey` variants directly.

## No test was weakened

No `skip:` was added and no assertion was loosened — AGENTS.md §8. Every one of the nine now
genuinely passes.

## Verification

```
flutter test                          539 pass, 40 skip, 0 fail
flutter analyze --no-fatal-infos      exit 0
rules-verify                          all checks passed
docs-verify                           all checks passed (0 mapped source paths changed)
budget                                3 files, 89 lines
```

## Deliberately out of scope

- **The 40 skips.** They are the entire crypto suite, auto-skipped whenever the FFI is absent —
  a distinct and more serious defect, tracked as #204. Un-gating them here would mix two concerns.
- **The 314 remaining `info` diagnostics** (mostly `withOpacity` deprecations). Tracked separately;
  `--no-fatal-infos` is the honest gate for today.
- Any change to the *production* messaging path beyond deleting proven-dead code. The plaintext
  fallbacks in this same file are I-2 breaches with their own steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)