### PR TITLE
chore(ci): add the mobile CI workflow

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,63 @@
+name: mobile
+
+# What CI does for client-mobile, which until now had none at all: `grep -rn "flutter"
+# .github/workflows/` returned nothing, and that is why nine failing tests and an analyzer
+# error sat on main undetected.
+#
+# Pulled forward out of PR-44 (#55). That step gates on G4, and the client-side E2EE repair
+# rewrites the Dart crypto layer well before then - refactoring cryptography with no test
+# signal is the thing this workflow exists to prevent.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'client-mobile/**'
+      - 'backend/crates/crypto-ffi/**'
+      - '.github/workflows/mobile.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'client-mobile/**'
+      - 'backend/crates/crypto-ffi/**'
+      - '.github/workflows/mobile.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # pubspec.yaml can only express a Flutter floor, and there is no .fvmrc or .tool-versions,
+  # so without an explicit pin here CI would drift to whatever is newest. Below 3.47.3 the
+  # dependency graph does not resolve at all - see #208.
+  FLUTTER_VERSION: '3.47.3'
+
+jobs:
+  mobile-verify:
+    name: mobile-verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Resolve dependencies
+        working-directory: client-mobile
+        run: flutter pub get
+
+      # --no-fatal-infos is deliberate and temporary. 314 info-level diagnostics predate this
+      # workflow, most of them `withOpacity` deprecations. Errors and warnings DO fail the
+      # build, which is the gate that matters; clearing the infos is tracked separately.
+      - name: Analyze
+        working-directory: client-mobile
+        run: flutter analyze --no-fatal-infos
+
+      - name: Test
+        working-directory: client-mobile
+        run: flutter test

--- a/Justfile
+++ b/Justfile
@@ -442,6 +442,16 @@ test-auth-android-validation:
     client-mobile/scripts/run-auth-test-android.sh --validation
 
 # =============================================================================
+# Mobile Client Tests
+# =============================================================================
+
+# Run the mobile checks exactly as .github/workflows/mobile.yml runs them
+test-mobile:
+    @echo "[test] Running mobile analyze and tests..."
+    cd client-mobile && flutter analyze --no-fatal-infos
+    cd client-mobile && flutter test
+
+# =============================================================================
 # Desktop Client Tests
 # =============================================================================
 

--- a/client-mobile/pubspec.lock
+++ b/client-mobile/pubspec.lock
@@ -1763,4 +1763,4 @@ packages:
     version: "2.2.3"
 sdks:
   dart: ">=3.11.0-0 <4.0.0"
-  flutter: ">=3.38.1"
+  flutter: ">=3.47.3"

--- a/client-mobile/pubspec.yaml
+++ b/client-mobile/pubspec.yaml
@@ -6,6 +6,12 @@ version: 0.1.0+1
 
 environment:
   sdk: ^3.9.2
+  # Floor only - pub cannot pin Flutter exactly, so FLUTTER_VERSION in
+  # .github/workflows/mobile.yml is the authority. This floor is the version the graph was
+  # verified against: on 3.38.4 it is unsatisfiable, because that SDK pins test_api 0.7.7,
+  # which forces web_socket_channel ^2.x while grpc ^5.0.0 forces ^3.x (#208). Declaring the
+  # floor turns that into a clear constraint error instead of an opaque solver failure.
+  flutter: ">=3.47.3"
 
 dependencies:
   flutter:

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -147,6 +147,31 @@ raw IP under a neutral name, or one that reaches a log through a `Display` impl.
 `RateLimitError::IpBlocked` was exactly that second case and was found by reading the code,
 not by the check. Treat a `ZK-PII` pass as "no obvious breach", never as proof.
 
+## Mobile verification
+
+```sh
+just test-mobile
+```
+
+Runs exactly what [`mobile.yml`](../../.github/workflows/mobile.yml) runs — `flutter analyze
+--no-fatal-infos` then `flutter test` — so a green local run means a green job.
+
+**The Flutter version is pinned in the workflow, not in `pubspec.yaml`.** Pub can express a
+floor (`flutter: ">=3.47.3"`) but not an exact version, and there is no `.fvmrc` or
+`.tool-versions`, so `FLUTTER_VERSION` in `mobile.yml` is the authority. If a local run
+disagrees with CI, check your Flutter version first — and note that **below 3.47.3 the
+dependency graph does not resolve at all**, so a stale toolchain fails at `pub get` rather
+than at a test (#208).
+
+**`--no-fatal-infos` is temporary.** 314 info-level diagnostics predate the workflow, most of
+them `withOpacity` deprecations. Errors and warnings do fail the build. Clearing the infos is
+owned work, not something to fix opportunistically while chasing an unrelated failure.
+
+**40 tests skip, and that is a known defect, not a pass.** They are the entire crypto suite:
+`test/core/crypto/crypto_test_helper.dart` skips whenever the Rust FFI is unavailable, which
+it always is under `flutter test`. Do not read a green mobile job as evidence that the Dart
+ratchet, X3DH or sealed sender work.
+
 ## Fuzzing
 
 ```sh


### PR DESCRIPTION
Closes #203

Split out of **PR-44 / #55**, which gates on **G4**.

## Why now, and not at G4

`client-mobile` has **no CI at all**. `grep -rn "flutter" .github/workflows/` returns nothing, and
the only reference to the directory anywhere under `.github/` is `dependabot.yml:29`.

That is why three separate defects sat on `main` undetected: nine failing tests (#202), an
analyzer error (#202), and a dependency graph that could not resolve at all (#208).

The client-side E2EE repair is about to rewrite the Dart crypto layer. Refactoring cryptography
with no test signal is precisely what this workflow exists to prevent, so it cannot wait for G4.
`.claude/rules/10-git-workflow.md` forbids retro-fitting a second step onto an existing issue, so
this is its own step; PR-44 keeps the call-service k8s Deployment and digest pins.

## What lands

- **`.github/workflows/mobile.yml`** — `flutter pub get` → `flutter analyze --no-fatal-infos` →
  `flutter test`, on PRs and pushes to `main`, path-filtered to `client-mobile/**`,
  `backend/crates/crypto-ffi/**` and the workflow itself.
- **`just test-mobile`** — runs exactly what the workflow runs, so a green local run means a
  green job. No such recipe existed.
- **`docs/ops/RUNBOOK.md`** — the operational view (mapped to `Justfile` in `docs/.manifest.yaml`).

## Two decisions worth stating

**The Flutter version is pinned, and the floor is raised to match.** `pubspec.yaml` can only
express a floor and there is no `.fvmrc` or `.tool-versions`, so `FLUTTER_VERSION` in the workflow
is the authority. The pubspec floor moves to `>=3.47.3` because **below it the graph does not
resolve at all** (#208) — that turns a stale toolchain into a clear constraint error instead of an
opaque solver failure three layers down.

**`--no-fatal-infos` is deliberate and temporary.** Errors and warnings *do* fail the build, which
is the gate that matters. The 314 remaining `info` diagnostics (mostly `withOpacity` deprecations)
predate this workflow. A ratchet was considered and rejected as premature: the count has not yet
settled against a toolchain that moved 9 versions this week.

## The workflow will go green while protecting less than it appears to

RUNBOOK.md says so explicitly, because it matters:

> **40 tests skip, and that is a known defect, not a pass.** They are the entire crypto suite […]
> Do not read a green mobile job as evidence that the Dart ratchet, X3DH or sealed sender work.

Un-gating them is #204, the next step.

## Verification

```
just test-mobile   ->  analyze clean, 539 pass, 40 skip, 0 fail
rules-verify           all checks passed
docs-verify            all checks passed
budget                 5 files, 106 lines
```

## Deliberately out of scope

- **Un-gating the 40 skipped crypto tests** (#204) — a separate concern, and the reason this
  workflow is a floor rather than a finish line.
- The 314 `info` diagnostics.
- An FFI-backed job that builds `guardyn-crypto-ffi` so the real bridge is exercised: deferred,
  because it is unproven whether `RustLib.init()` succeeds under a host `flutter test` VM, and
  blocking the security refactor on that spike is the wrong trade.
- The rest of PR-44 / #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)