### PR TITLE
chore(mobile): un-gate the crypto suite so it runs under flutter test

### DIFF
--- a/client-mobile/test/core/crypto/crypto_test_helper.dart
+++ b/client-mobile/test/core/crypto/crypto_test_helper.dart
@@ -1,8 +1,18 @@
-/// Test helper for crypto tests that require native FFI
+/// Test helpers for the crypto suite.
 ///
-/// Native crypto tests require the Rust FFI library (libguardyn_crypto_ffi.so)
-/// which is only available when running on real devices or integration tests.
-/// Unit tests (flutter test) run in a headless VM without native library support.
+/// The suite used to skip in its entirety under `flutter test`: every test was written with
+/// [nativeCryptoTest], which skipped whenever the Rust FFI was unavailable - and it is always
+/// unavailable in a headless VM. That left the Double Ratchet, X3DH and sealed sender with no
+/// automated coverage at all, so a green mobile job proved nothing about them.
+///
+/// Almost none of it needs the FFI. [DartCryptoBridge] supplies real AES-GCM, HKDF, X25519 and
+/// Ed25519 through `cryptography` and `pinenacl`, which is enough to exercise every protocol
+/// concern: framing, the wire format, key schedules, skipped-message keys and AAD.
+///
+/// So the default is now [cryptoTest], which always runs. [ffiOnlyCryptoTest] is reserved for
+/// the handful of assertions that genuinely cannot hold without the real library - currently
+/// the cross-platform Ed25519 to X25519 vectors, because `DartCryptoBridge` derives that key
+/// from a seed rather than performing the birational map, and says so in its own comment.
 library;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -30,27 +40,46 @@ Future<void> initializeCryptoForTests() async {
   if (!nativeCryptoAvailable) {
     // ignore: avoid_print
     print(
-      '⚠️ Native crypto not available in test environment. '
-      'Crypto tests will be skipped. '
-      'Run integration tests on real device for full coverage.',
+      'ℹ️ Native crypto (FFI) not loaded; running the suite on DartCryptoBridge. '
+      'Only ffiOnlyCryptoTest cases are skipped.',
     );
   }
 }
 
-/// Creates a test with conditional skip based on native crypto availability.
+/// A crypto test that runs on whichever bridge is present.
 ///
-/// Use this instead of [test] for tests that require native crypto.
-/// The test will be skipped with proper message if native crypto is unavailable.
-///
-/// Example:
-/// ```dart
-/// nativeCryptoTest('encrypts message', () async {
-///   final result = await CryptoPrimitives.encrypt(...);
-///   expect(result, isNotNull);
-/// });
-/// ```
+/// This is the default. Use it for anything that exercises protocol behaviour rather than the
+/// FFI boundary itself.
 @isTest
-void nativeCryptoTest(
+void cryptoTest(
+  String description,
+  dynamic Function() body, {
+  String? testOn,
+  Timeout? timeout,
+  dynamic skip,
+  dynamic tags,
+  Map<String, dynamic>? onPlatform,
+  int? retry,
+}) {
+  test(
+    description,
+    body,
+    testOn: testOn,
+    timeout: timeout,
+    skip: skip,
+    tags: tags,
+    onPlatform: onPlatform,
+    retry: retry,
+  );
+}
+
+/// A crypto test that is skipped unless the real Rust FFI is loaded.
+///
+/// Reserve this for assertions that cannot hold on [DartCryptoBridge]. Every use is a claim
+/// that the pure-Dart implementation is not merely slower but *different*, so it needs a
+/// reason at the call site.
+@isTest
+void ffiOnlyCryptoTest(
   String description,
   dynamic Function() body, {
   String? testOn,
@@ -72,11 +101,15 @@ void nativeCryptoTest(
   );
 }
 
-/// Creates a test group with conditional skip based on native crypto availability.
-///
-/// Use this instead of [group] for test groups that require native crypto.
+/// A crypto group that runs on whichever bridge is present.
 @isTestGroup
-void nativeCryptoGroup(String description, dynamic Function() body) {
+void cryptoGroup(String description, dynamic Function() body) {
+  group(description, body);
+}
+
+/// A crypto group skipped unless the real Rust FFI is loaded.
+@isTestGroup
+void ffiOnlyCryptoGroup(String description, dynamic Function() body) {
   group(
     description,
     body,

--- a/client-mobile/test/core/crypto/double_ratchet_test.dart
+++ b/client-mobile/test/core/crypto/double_ratchet_test.dart
@@ -20,7 +20,7 @@ void main() {
   });
 
   // This group requires native crypto for X25519KeyPair.generate()
-  nativeCryptoGroup('X25519KeyPair', () {
+  cryptoGroup('X25519KeyPair', () {
     test('generate creates valid key pair', () async {
       final keyPair = await X25519KeyPair.generate();
 
@@ -52,7 +52,7 @@ void main() {
   });
 
   // This group requires native crypto for X25519KeyPair.generate()
-  nativeCryptoGroup('MessageHeader', () {
+  cryptoGroup('MessageHeader', () {
     test('serialization roundtrip', () async {
       final keyPair = await X25519KeyPair.generate();
       final header = MessageHeader(
@@ -78,7 +78,7 @@ void main() {
   });
 
   // This group requires native crypto for X25519KeyPair.generate()
-  nativeCryptoGroup('EncryptedMessage', () {
+  cryptoGroup('EncryptedMessage', () {
     test('serialization roundtrip', () async {
       final keyPair = await X25519KeyPair.generate();
       final header = MessageHeader(
@@ -132,7 +132,7 @@ void main() {
   });
 
   // This group requires native crypto for key generation and encryption
-  nativeCryptoGroup('DoubleRatchet', () {
+  cryptoGroup('DoubleRatchet', () {
     late Uint8List sharedSecret;
     late Uint8List bobPublicKey;
 

--- a/client-mobile/test/core/crypto/sealed_sender_test.dart
+++ b/client-mobile/test/core/crypto/sealed_sender_test.dart
@@ -21,13 +21,12 @@ void main() {
     late Uint8List signingPublicKey;
 
     setUpAll(() async {
-      if (!nativeCryptoAvailable) return;
       final (pubKey, privKey) = await CryptoPrimitives.generateEd25519KeyPair();
       signingPublicKey = pubKey;
       signingPrivateKey = privKey;
     });
 
-    nativeCryptoTest('creates certificate with valid signature', () async {
+    cryptoTest('creates certificate with valid signature', () async {
       final expiresAt =
           (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 86400; // 24h
 
@@ -45,7 +44,7 @@ void main() {
       expect(cert.signature.length, 64);
     });
 
-    nativeCryptoTest('verifies valid certificate', () async {
+    cryptoTest('verifies valid certificate', () async {
       final expiresAt = (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 86400;
 
       final cert = await SenderCertificate.create(
@@ -60,7 +59,7 @@ void main() {
       expect(isValid, isTrue);
     });
 
-    nativeCryptoTest('detects expired certificate', () async {
+    cryptoTest('detects expired certificate', () async {
       final expiresAt =
           (DateTime.now().millisecondsSinceEpoch ~/ 1000) -
           3600; // Expired 1h ago
@@ -76,7 +75,7 @@ void main() {
       expect(cert.isExpired, isTrue);
     });
 
-    nativeCryptoTest('serializes and deserializes correctly', () async {
+    cryptoTest('serializes and deserializes correctly', () async {
       final expiresAt = (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 86400;
 
       final cert = await SenderCertificate.create(
@@ -144,7 +143,6 @@ void main() {
     late Uint8List recipientPrivateKey;
 
     setUpAll(() async {
-      if (!nativeCryptoAvailable) return;
       // Generate sender Ed25519 keys for signing
       final (senderPub, senderPriv) =
           await CryptoPrimitives.generateEd25519KeyPair();
@@ -158,7 +156,7 @@ void main() {
       recipientPrivateKey = recipientPriv;
     });
 
-    nativeCryptoTest('seals and unseals message successfully', () async {
+    cryptoTest('seals and unseals message successfully', () async {
       // Create sender certificate
       final expiresAt = (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 86400;
       final senderCert = await SenderCertificate.create(
@@ -192,7 +190,7 @@ void main() {
       expect(result.innerMessage, innerMessage);
     });
 
-    nativeCryptoTest('envelope serialization round trip works', () async {
+    cryptoTest('envelope serialization round trip works', () async {
       final expiresAt = (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 86400;
       final senderCert = await SenderCertificate.create(
         senderUserId: 'sender-user',
@@ -223,7 +221,7 @@ void main() {
       expect(result.innerMessage, innerMessage);
     });
 
-    nativeCryptoTest('rejects expired certificate during unseal', () async {
+    cryptoTest('rejects expired certificate during unseal', () async {
       final expiresAt =
           (DateTime.now().millisecondsSinceEpoch ~/ 1000) - 3600; // Expired
 
@@ -252,7 +250,7 @@ void main() {
       );
     });
 
-    nativeCryptoTest('wrong recipient cannot decrypt', () async {
+    cryptoTest('wrong recipient cannot decrypt', () async {
       // Generate a different recipient keypair
       final (_, wrongPrivateKey) =
           await CryptoPrimitives.generateX25519KeyPair();
@@ -284,7 +282,7 @@ void main() {
       );
     });
 
-    nativeCryptoTest('tampered envelope fails decryption', () async {
+    cryptoTest('tampered envelope fails decryption', () async {
       final expiresAt = (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 86400;
       final senderCert = await SenderCertificate.create(
         senderUserId: 'sender-user',

--- a/client-mobile/test/core/crypto/x3dh_test.dart
+++ b/client-mobile/test/core/crypto/x3dh_test.dart
@@ -20,14 +20,14 @@ void main() {
 
 
   group('IdentityKeyPair', () {
-    nativeCryptoTest('generate creates valid Ed25519 key pair', () async {
+    cryptoTest('generate creates valid Ed25519 key pair', () async {
       final keyPair = await IdentityKeyPair.generate();
 
       expect(keyPair.privateKey.length, equals(32));
       expect(keyPair.publicKey.length, equals(32));
     });
 
-    nativeCryptoTest('sign produces valid signature', () async {
+    cryptoTest('sign produces valid signature', () async {
       final keyPair = await IdentityKeyPair.generate();
       final data = Uint8List.fromList('test data'.codeUnits);
 
@@ -36,7 +36,7 @@ void main() {
       expect(signature.length, equals(64)); // Ed25519 signature is 64 bytes
     });
 
-    nativeCryptoTest('verify returns true for valid signature', () async {
+    cryptoTest('verify returns true for valid signature', () async {
       final keyPair = await IdentityKeyPair.generate();
       final data = Uint8List.fromList('test data'.codeUnits);
 
@@ -50,7 +50,7 @@ void main() {
       expect(isValid, isTrue);
     });
 
-    nativeCryptoTest('verify returns false for tampered data', () async {
+    cryptoTest('verify returns false for tampered data', () async {
       final keyPair = await IdentityKeyPair.generate();
       final data = Uint8List.fromList('original data'.codeUnits);
       final tamperedData = Uint8List.fromList('tampered data'.codeUnits);
@@ -67,7 +67,7 @@ void main() {
   });
 
   group('SignedPreKey', () {
-    nativeCryptoTest('generate creates valid signed pre-key', () async {
+    cryptoTest('generate creates valid signed pre-key', () async {
       final identity = await IdentityKeyPair.generate();
       final signedPreKey = await SignedPreKey.generate(
         identityKey: identity,
@@ -80,7 +80,7 @@ void main() {
       expect(signedPreKey.keyId, equals(1));
     });
 
-    nativeCryptoTest('verify returns true for valid signature', () async {
+    cryptoTest('verify returns true for valid signature', () async {
       final identity = await IdentityKeyPair.generate();
       final signedPreKey = await SignedPreKey.generate(
         identityKey: identity,
@@ -94,7 +94,7 @@ void main() {
   });
 
   group('OneTimePreKey', () {
-    nativeCryptoTest('generate creates valid one-time pre-key', () async {
+    cryptoTest('generate creates valid one-time pre-key', () async {
       final otpk = await OneTimePreKey.generate(42);
 
       expect(otpk.privateKey.length, equals(32));
@@ -104,7 +104,7 @@ void main() {
   });
 
   group('X3DHKeyBundle', () {
-    nativeCryptoTest('toJson/fromJson roundtrip', () async {
+    cryptoTest('toJson/fromJson roundtrip', () async {
       final identity = await IdentityKeyPair.generate();
       final signedPreKey = await SignedPreKey.generate(
         identityKey: identity,
@@ -132,7 +132,7 @@ void main() {
       expect(restored.oneTimePreKeyId, equals(bundle.oneTimePreKeyId));
     });
 
-    nativeCryptoTest('verify returns true for valid bundle', () async {
+    cryptoTest('verify returns true for valid bundle', () async {
       final identity = await IdentityKeyPair.generate();
       final signedPreKey = await SignedPreKey.generate(
         identityKey: identity,
@@ -153,7 +153,7 @@ void main() {
   });
 
   group('X3DHProtocol', () {
-    nativeCryptoTest('initialize creates valid protocol state', () async {
+    cryptoTest('initialize creates valid protocol state', () async {
       final protocol = await X3DHProtocol.initialize(oneTimePreKeyCount: 10);
 
       expect(protocol.identityKey.publicKey.length, equals(32));
@@ -161,7 +161,7 @@ void main() {
       expect(protocol.oneTimePreKeys.length, equals(10));
     });
 
-    nativeCryptoTest('exportKeyBundle returns valid bundle', () async {
+    cryptoTest('exportKeyBundle returns valid bundle', () async {
       final protocol = await X3DHProtocol.initialize(oneTimePreKeyCount: 10);
       final bundle = protocol.exportKeyBundle(oneTimePreKeyIndex: 0);
 
@@ -170,7 +170,7 @@ void main() {
       expect(bundle.oneTimePreKey, equals(protocol.oneTimePreKeys[0].publicKey));
     });
 
-    nativeCryptoTest('serialize/deserialize roundtrip', () async {
+    cryptoTest('serialize/deserialize roundtrip', () async {
       final protocol = await X3DHProtocol.initialize(oneTimePreKeyCount: 5);
       final serialized = protocol.serialize();
       final restored = X3DHProtocol.deserialize(serialized);
@@ -189,7 +189,7 @@ void main() {
       );
     });
 
-    nativeCryptoTest('initiateKeyAgreement produces shared secret', () async {
+    cryptoTest('initiateKeyAgreement produces shared secret', () async {
       final alice = await X3DHProtocol.initialize(oneTimePreKeyCount: 10);
       final bob = await X3DHProtocol.initialize(oneTimePreKeyCount: 10);
 
@@ -204,7 +204,7 @@ void main() {
       expect(ephemeralKey.length, equals(32));
     });
 
-    nativeCryptoTest('completeKeyAgreement produces shared secret', () async {
+    cryptoTest('completeKeyAgreement produces shared secret', () async {
       final alice = await X3DHProtocol.initialize(oneTimePreKeyCount: 10);
       final bob = await X3DHProtocol.initialize(oneTimePreKeyCount: 10);
 
@@ -231,8 +231,14 @@ void main() {
   ///
   /// The vectors verify that Ed25519 → X25519 key conversion produces identical
   /// results in both Rust (ed25519-dalek + curve25519-dalek) and Dart (via Rust FFI).
-  group('Cross-platform Ed25519→X25519 Compatibility', () {
-    nativeCryptoTest('all_zeros seed produces correct X25519 keys', () async {
+  // FFI-only, and this is the one place where that is a statement about correctness rather
+  // than convenience. These cases assert byte-equality against vectors produced by the Rust
+  // implementation, and DartCryptoBridge does not perform the Ed25519 to X25519 birational
+  // map at all - it derives an X25519 key from the Ed25519 bytes as a seed and documents
+  // itself as "NOT cryptographically equivalent" (dart_crypto_bridge.dart). Running these on
+  // the Dart bridge would not be a weaker test, it would be a test of a different function.
+  ffiOnlyCryptoGroup('Cross-platform Ed25519→X25519 Compatibility', () {
+    cryptoTest('all_zeros seed produces correct X25519 keys', () async {
       final seed = Uint8List.fromList(List.filled(32, 0x00));
 
       final expectedX25519Public = Uint8List.fromList([
@@ -321,7 +327,7 @@ void main() {
       );
     });
 
-    nativeCryptoTest('sequential seed produces correct X25519 keys', () async {
+    cryptoTest('sequential seed produces correct X25519 keys', () async {
       final seed = Uint8List.fromList(List.generate(32, (i) => i));
 
       final expectedX25519Public = Uint8List.fromList([
@@ -410,7 +416,7 @@ void main() {
       );
     });
 
-    nativeCryptoTest('random_pattern seed produces correct X25519 keys', () async {
+    cryptoTest('random_pattern seed produces correct X25519 keys', () async {
       final seed = Uint8List.fromList([
         0x9d,
         0x61,
@@ -532,10 +538,9 @@ void main() {
       );
     });
 
-    nativeCryptoTest(
+    cryptoTest(
       'X25519 DH produces identical shared secrets cross-platform',
       () async {
-        if (!nativeCryptoAvailable) return; // Double guard
         // Alice's seed (sequential)
         final aliceSeed = Uint8List.fromList(List.generate(32, (i) => i));
         // Bob's seed (random_pattern)

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -135,7 +135,7 @@ steps:
   - {id: PR-80, issue: null, phase: 3, type: feat, status: todo, title: "client-desktop - implement the X3DH responder path"}
   - {id: PR-81, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - restore the ratchet store from persisted state"}
   # Deferred deliberately, each with a stated reason in its step above.
-  - {id: PR-82, issue: null, phase: 3, type: chore, status: todo, title: "Add an FFI-backed mobile CI job"}
+  - {id: PR-82, issue: 211, phase: 3, type: chore, status: todo, title: "Add an FFI-backed mobile CI job"}
   - {id: PR-83, issue: null, phase: 3, type: chore, status: todo, title: "Clear the 314 flutter analyze info diagnostics"}
   - {id: PR-84, issue: 205, phase: 3, type: chore, status: todo, title: "Record the client-side E2EE repair steps in roadmap.yaml"}
   - {id: PR-85, issue: 208, phase: 3, type: fix, status: todo, title: "Pin the Flutter toolchain to 3.47.3 so flutter pub get resolves"}


### PR DESCRIPTION
Closes #204

## The defect

`flutter test` reported 40 skips. **Those 40 were the entire crypto suite.**

`crypto_test_helper.dart` skipped every case whenever `CryptoPrimitives.isNativeAvailable` was
false, and under `flutter test` the FFI never initialises (`flutter_rust_bridge has not been
initialized`), so it was *always* false. The Double Ratchet, X3DH and sealed sender had **no
automated coverage at all** — and the mobile job added in #203 would have gone green while
protecting none of the code the client-side E2EE repair is about to rewrite.

## Almost none of it needed the FFI

`DartCryptoBridge` supplies real AES-GCM, HKDF, X25519 and Ed25519 through `cryptography` and
`pinenacl`. That is enough to exercise every protocol concern: framing, the wire format, key
schedules, skipped-message keys, AAD construction.

So the default is now `cryptoTest`, which always runs. `ffiOnlyCryptoTest` / `ffiOnlyCryptoGroup`
are reserved for cases that genuinely cannot hold on the Dart bridge, and every use is expected to
justify itself at the call site.

**Exactly one group qualifies.** `Cross-platform Ed25519→X25519 Compatibility` asserts
byte-equality against vectors produced by the Rust implementation, and `DartCryptoBridge` does not
perform the birational map at all — it derives an X25519 key from the Ed25519 bytes as a seed, and
says so itself:

> `// This is NOT cryptographically equivalent but works for testing.`

Running those on the Dart bridge would not be a weaker test; it would be a test of a **different
function**. They stay gated, with that reasoning written at the call site.

## A trap worth naming

Three `setUpAll` bodies carried `if (!nativeCryptoAvailable) return;`. Once the tests stopped
being skipped, those guards left `late` variables unassigned, so `sealed_sender_test.dart` failed
with `LateInitializationError: Local 'signingPrivateKey' has not been initialized` — a *test
harness* failure wearing the costume of a crypto failure. Removed; all twelve of its cases then
pass on the Dart bridge.

## Result

```
before:  539 pass, 40 skip, 0 fail
after:   575 pass,  4 skip, 0 fail
```

36 tests un-gated. No assertion was loosened and nothing was marked `skip` to get here
(AGENTS.md §8).

## What this does NOT establish

Two things, stated plainly because a green crypto suite is easy to over-read:

1. **The FFI path is still untested** — CI exercises `DartCryptoBridge`, production uses
   `NativeRustCryptoBridge`. Tracked as **#211**.
2. **These tests are Dart-vs-Dart.** They cannot detect that the Dart ratchet is still on the
   pre-ADR-0011 unversioned wire format, because both sides of every round-trip share the bug.
   Catching that needs Rust-derived known-answer vectors, which land with the wire-format-v1 step
   (PR-70) where they go red → green — and ultimately
   `just test-two-client-messaging`, the only check that proves the two clients agree.

## Verification

```
flutter test                      575 pass, 4 skip, 0 fail
flutter analyze --no-fatal-infos  exit 0
rules-verify                      all checks passed
docs-verify                       all checks passed
budget                            5 files, 152 lines
```

## Deliberately out of scope

- **Adding the Rust known-answer vectors.** They would land red today, since the Dart wire format
  has not been migrated yet. AGENTS.md §8 wants a regression test that fails *before* its fix, so
  they belong with PR-70, not here.
- Building the FFI in CI (#211).
- Any change to the crypto implementation itself. This PR changes test gating only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)