### PR TITLE
fix(mobile): correct the Dart skip-message-keys counter and bound

### DIFF
--- a/client-mobile/lib/core/crypto/double_ratchet.dart
+++ b/client-mobile/lib/core/crypto/double_ratchet.dart
@@ -484,17 +484,27 @@ class DoubleRatchet {
     _sendingChainKey = sendingChainKey;
   }
 
-  /// Skip message keys for out-of-order handling
+  /// Derive and store message keys for messages that arrived out of order.
+  ///
+  /// Mirrors `skip_message_keys` in `backend/crates/crypto/src/double_ratchet.rs`.
+  ///
+  /// The bound counts the **size of the stored map**, not the size of the gap, and is checked
+  /// inside the loop. Bounding the gap lets many small-gap messages grow
+  /// [_skippedMessageKeys] without limit, which is the memory exhaustion the bound exists to
+  /// prevent.
+  ///
+  /// On return `_receivingMessageNumber` is `until`, so the caller's own increment leaves it
+  /// at `until + 1`.
   Future<void> _skipMessageKeys(int until) async {
-    if (_receivingMessageNumber + _maxSkip < until) {
-      throw ProtocolException('Too many skipped messages');
-    }
-
     final chainKey = _receivingChainKey;
     if (chainKey == null) return;
 
     var currentKey = chainKey;
     while (_receivingMessageNumber < until) {
+      if (_skippedMessageKeys.length >= _maxSkip) {
+        throw ProtocolException('Too many skipped messages (max: $_maxSkip)');
+      }
+
       final messageKey = await currentKey.messageKey();
       final skipKey = _makeSkipKey(_dhRemote!, _receivingMessageNumber);
       _skippedMessageKeys[skipKey] = messageKey;
@@ -502,7 +512,6 @@ class DoubleRatchet {
       _receivingMessageNumber++;
     }
     _receivingChainKey = currentKey;
-    _receivingMessageNumber = 0;
   }
 
   String _makeSkipKey(Uint8List dhKey, int messageNumber) {

--- a/client-mobile/test/core/crypto/double_ratchet_ordering_test.dart
+++ b/client-mobile/test/core/crypto/double_ratchet_ordering_test.dart
@@ -1,0 +1,124 @@
+/// Out-of-order delivery tests for the Double Ratchet.
+///
+/// These are regression tests for #198. The suite had no coverage of skipped message keys at
+/// all - nothing in `double_ratchet_test.dart` mentions `skip` or reordering - which is how
+/// two defects in `_skipMessageKeys` survived: the loop advanced `_receivingMessageNumber` to
+/// `until` and then discarded it with `= 0`, and the `MAX_SKIP` bound counted the size of the
+/// *gap* rather than the size of the stored map.
+///
+/// They also exercise the only realistic Alice/Bob pairing: `initBob` generates its own DH
+/// key pair, so Alice must be initialised from `bob.publicKey` for the first DH ratchet on
+/// Bob's side to succeed.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guardyn_client/core/crypto/crypto_exceptions.dart';
+import 'package:guardyn_client/core/crypto/double_ratchet.dart';
+
+import 'crypto_test_helper.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeCryptoForTests();
+  });
+
+  final ad = Uint8List.fromList(utf8.encode('alice|bob'));
+  late Uint8List sharedSecret;
+
+  setUp(() {
+    sharedSecret = Uint8List.fromList(List.generate(32, (i) => i));
+  });
+
+  Future<(DoubleRatchet alice, DoubleRatchet bob)> pair() async {
+    final bob = await DoubleRatchet.initBob(sharedSecret);
+    final alice = await DoubleRatchet.initAlice(sharedSecret, bob.publicKey);
+    return (alice, bob);
+  }
+
+  cryptoGroup('out-of-order delivery', () {
+    test('in-order delivery still works', () async {
+      final (alice, bob) = await pair();
+
+      for (var i = 0; i < 5; i++) {
+        final msg = await alice.encrypt(
+          Uint8List.fromList(utf8.encode('message $i')),
+          ad,
+        );
+        final got = await bob.decrypt(msg, ad);
+        expect(utf8.decode(got), equals('message $i'));
+      }
+    });
+
+    test('a later message decrypts before the ones it skipped', () async {
+      final (alice, bob) = await pair();
+
+      final m0 = await alice.encrypt(Uint8List.fromList(utf8.encode('zero')), ad);
+      final m1 = await alice.encrypt(Uint8List.fromList(utf8.encode('one')), ad);
+      final m2 = await alice.encrypt(Uint8List.fromList(utf8.encode('two')), ad);
+
+      // Bob sees the third message first; 0 and 1 are staged as skipped keys.
+      expect(utf8.decode(await bob.decrypt(m2, ad)), equals('two'));
+
+      // Then the stragglers arrive, in the wrong order relative to each other.
+      expect(utf8.decode(await bob.decrypt(m1, ad)), equals('one'));
+      expect(utf8.decode(await bob.decrypt(m0, ad)), equals('zero'));
+    });
+
+    test('the receive counter is not reset after skipping', () async {
+      // The regression that #198 names. `_skipMessageKeys` used to finish with
+      // `_receivingMessageNumber = 0`, throwing away the position it had just walked to. The
+      // next in-order message then re-entered the skip loop from 1, re-derived keys for
+      // indices it had already stored, and walked the receiving chain past the key it needed.
+      final (alice, bob) = await pair();
+
+      final msgs = <EncryptedMessage>[];
+      for (var i = 0; i < 4; i++) {
+        msgs.add(
+          await alice.encrypt(Uint8List.fromList(utf8.encode('m$i')), ad),
+        );
+      }
+
+      // Skip ahead to index 2, then continue in order with index 3.
+      expect(utf8.decode(await bob.decrypt(msgs[2], ad)), equals('m2'));
+      expect(utf8.decode(await bob.decrypt(msgs[3], ad)), equals('m3'));
+
+      // And the skipped ones are still recoverable.
+      expect(utf8.decode(await bob.decrypt(msgs[0], ad)), equals('m0'));
+      expect(utf8.decode(await bob.decrypt(msgs[1], ad)), equals('m1'));
+    });
+
+    test('a skipped key is consumed exactly once', () async {
+      final (alice, bob) = await pair();
+
+      final m0 = await alice.encrypt(Uint8List.fromList(utf8.encode('zero')), ad);
+      final m1 = await alice.encrypt(Uint8List.fromList(utf8.encode('one')), ad);
+
+      expect(utf8.decode(await bob.decrypt(m1, ad)), equals('one'));
+      expect(utf8.decode(await bob.decrypt(m0, ad)), equals('zero'));
+
+      // Replaying m0 must not succeed - its key was removed when it was used.
+      await expectLater(bob.decrypt(m0, ad), throwsA(isA<Exception>()));
+    });
+
+    test('the bound counts stored keys, not the size of one gap', () async {
+      // The second #198 defect. The old guard was
+      //   if (_receivingMessageNumber + _maxSkip < until) throw
+      // which bounds a single gap. Many small gaps could therefore grow the stored map
+      // without limit - exactly the memory exhaustion the bound exists to prevent. The bound
+      // now counts the map itself, and is checked inside the loop.
+      final (alice, bob) = await pair();
+
+      // Produce more messages than the ratchet is willing to stage keys for.
+      const overshoot = 1200; // > _maxSkip (1000)
+      late EncryptedMessage far;
+      for (var i = 0; i <= overshoot; i++) {
+        far = await alice.encrypt(Uint8List.fromList(utf8.encode('m$i')), ad);
+      }
+
+      await expectLater(bob.decrypt(far, ad), throwsA(isA<ProtocolException>()));
+    });
+  });
+}


### PR DESCRIPTION
Closes #198

## The two defects #198 names

**1. The counter was discarded.** `_skipMessageKeys` advanced `_receivingMessageNumber` to
`until` and then finished with `_receivingMessageNumber = 0`, throwing away the position it had
just walked to. Rust leaves it at `until` (`double_ratchet.rs:725`).

**2. The bound counted the wrong quantity.** `_receivingMessageNumber + _maxSkip < until` bounds
the size of a *single gap*, so many small-gap messages could grow `_skippedMessageKeys` without
limit — precisely the memory exhaustion the bound exists to prevent. It now counts the stored map
and is checked **inside** the loop, matching `already_stored + out.len() >= MAX_SKIP`
(`double_ratchet.rs:735`).

## This was worse than the issue describes

The reset ran **unconditionally** — after the early return for a null chain key, but outside the
loop — so it fired even when nothing was skipped.

That means ordinary in-order delivery desynchronised from the **third message onward**: `msg2`
found the counter at 1 instead of 2, entered the skip loop it should have bypassed, stored a bogus
skipped key and walked the receiving chain past the key it actually needed.

The new in-order test fails against the previous implementation with:

```
DecryptionException: AES-GCM decryption failed:
  SecretBoxAuthenticationError: SecretBox has wrong message authentication code (MAC)
```

So this was never just an out-of-order bug — **it broke 1:1 messaging on mobile after two
messages**. That is worth stating plainly, because it makes the plaintext fallbacks in
`message_repository_impl.dart` (`'Encryption failed: $e. Sending plaintext.'`) far more likely to
have fired in practice than anyone would have assumed.

## There was no coverage of any of this

Nothing in `double_ratchet_test.dart` mentions skipping or reordering, and **no test ever paired a
real Alice and Bob** — the existing "basic encryption/decryption" case constructs Bob and then
marks him `// ignore: unused_local_variable`.

`double_ratchet_ordering_test.dart` adds that pairing (`initBob` first, then `initAlice` from
`bob.publicKey`) plus five cases. **Two fail against the previous implementation**, as AGENTS.md §8
requires:

```
$ git checkout origin/main -- lib/core/crypto/double_ratchet.dart
$ flutter test test/core/crypto/double_ratchet_ordering_test.dart
+3 -2: Some tests failed.
```

## Verification

```
flutter test                      591 pass, 4 skip, 0 fail   (was 586/4/0)
flutter analyze --no-fatal-infos  exit 0
rules-verify                      all checks passed
docs-verify                       all checks passed
budget                            2 files, 145 lines
```

## Deliberately out of scope

**Decrypt is still not atomic.** `_dhRatchetReceive` mutates `_dhRemote`, `_rootKey` and both
chain keys **before** any tag is verified, and skipped keys are removed before decrypting rather
than after. That is the Dart mirror of #106 and is the next step — folding it in here would have
made "verified red before green" unprovable for either change, since both live in `decrypt`.

Also untouched: the AAD content and its `codeUnits` encoding, PADMÉ on the mobile path, and the
plaintext fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)