### PR TITLE
security(mobile): make Dart ratchet decryption atomic

### DIFF
--- a/client-mobile/lib/core/crypto/double_ratchet.dart
+++ b/client-mobile/lib/core/crypto/double_ratchet.dart
@@ -312,6 +312,127 @@ Uint8List _aadWithHeader(Uint8List associatedData, MessageHeader header) {
   return aad;
 }
 
+String _makeSkipKey(Uint8List dhKey, int messageNumber) =>
+    '${base64Encode(dhKey)}:$messageNumber';
+
+bool _bytesEqual(Uint8List a, Uint8List b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}
+
+/// A pending receive-side ratchet transition, applied only once the tag verifies.
+///
+/// Mirrors `ReceiveStaging` in `backend/crates/crypto/src/double_ratchet.rs`.
+///
+/// Receiving a message can advance the DH ratchet and derive skipped message keys, and both
+/// used to happen before the AEAD tag was checked. A forged header naming an unknown DH
+/// public key therefore rotated the root key and both chain keys, which walks the chain past
+/// every genuine message and leaves the session unrecoverable without a new handshake.
+///
+/// Staging the transition and swapping it in only on success makes decryption atomic.
+/// Copying the ratchet wholesale would have been simpler, but it carries
+/// [DoubleRatchet._skippedMessageKeys] - up to `_maxSkip` entries - and allocating that on
+/// every message to guard against a rare failure is the wrong trade. Every field here is
+/// fixed-size, and the key types are immutable value objects, so copying references is a
+/// genuine snapshot rather than shared state.
+class _ReceiveStaging {
+  X25519KeyPair dhSelf;
+  Uint8List? dhRemote;
+  _RootKey rootKey;
+  _ChainKey? sendingChainKey;
+  int sendingMessageNumber;
+  _ChainKey? receivingChainKey;
+  int receivingMessageNumber;
+  int previousChainLength;
+
+  _ReceiveStaging({
+    required this.dhSelf,
+    required this.dhRemote,
+    required this.rootKey,
+    required this.sendingChainKey,
+    required this.sendingMessageNumber,
+    required this.receivingChainKey,
+    required this.receivingMessageNumber,
+    required this.previousChainLength,
+  });
+
+  factory _ReceiveStaging.fromRatchet(DoubleRatchet r) => _ReceiveStaging(
+        dhSelf: r._dhSelf,
+        dhRemote: r._dhRemote,
+        rootKey: r._rootKey,
+        sendingChainKey: r._sendingChainKey,
+        sendingMessageNumber: r._sendingMessageNumber,
+        receivingChainKey: r._receivingChainKey,
+        receivingMessageNumber: r._receivingMessageNumber,
+        previousChainLength: r._previousChainLength,
+      );
+
+  void commitInto(DoubleRatchet r) {
+    r._dhSelf = dhSelf;
+    r._dhRemote = dhRemote;
+    r._rootKey = rootKey;
+    r._sendingChainKey = sendingChainKey;
+    r._sendingMessageNumber = sendingMessageNumber;
+    r._receivingChainKey = receivingChainKey;
+    r._receivingMessageNumber = receivingMessageNumber;
+    r._previousChainLength = previousChainLength;
+  }
+
+  /// Perform the DH ratchet step for a newly seen remote public key.
+  Future<void> dhRatchetReceive(MessageHeader header) async {
+    previousChainLength = sendingMessageNumber;
+    sendingMessageNumber = 0;
+    receivingMessageNumber = 0;
+
+    dhRemote = header.dhPublicKey;
+
+    final dhOutput = await dhSelf.diffieHellman(header.dhPublicKey);
+    final (newRootKey, newReceivingChainKey) = await rootKey.dhRatchet(dhOutput);
+    rootKey = newRootKey;
+    receivingChainKey = newReceivingChainKey;
+
+    dhSelf = await X25519KeyPair.generate();
+    final dhOutput2 = await dhSelf.diffieHellman(header.dhPublicKey);
+    final (finalRootKey, newSendingChainKey) = await rootKey.dhRatchet(dhOutput2);
+    rootKey = finalRootKey;
+    sendingChainKey = newSendingChainKey;
+  }
+
+  /// Derive message keys for messages that arrived out of order.
+  ///
+  /// Keys are collected into [out] rather than inserted, so the caller can discard them if
+  /// the tag then fails. [alreadyStored] is the committed map's length, which the `_maxSkip`
+  /// bound counts against - otherwise each forged message could stage up to the limit afresh
+  /// and the bound would mean nothing.
+  ///
+  /// On return [receivingMessageNumber] is `until`, so the caller's own increment leaves it
+  /// at `until + 1`.
+  Future<void> skipMessageKeys(
+    int until,
+    int alreadyStored,
+    Map<String, _MessageKey> out,
+  ) async {
+    final chainKey = receivingChainKey;
+    if (chainKey == null) return;
+
+    var currentKey = chainKey;
+    while (receivingMessageNumber < until) {
+      if (alreadyStored + out.length >= _maxSkip) {
+        throw ProtocolException('Too many skipped messages (max: $_maxSkip)');
+      }
+
+      final messageKey = await currentKey.messageKey();
+      out[_makeSkipKey(dhRemote!, receivingMessageNumber)] = messageKey;
+      currentKey = await currentKey.next();
+      receivingMessageNumber++;
+    }
+    receivingChainKey = currentKey;
+  }
+}
+
 /// Double Ratchet state for E2EE messaging
 class DoubleRatchet {
   // DH ratchet state
@@ -425,106 +546,64 @@ class DoubleRatchet {
     final aad = _aadWithHeader(associatedData, message.header);
 
     // Check if we have a skipped message key
-    final skipKey = _makeSkipKey(message.header.dhPublicKey, message.header.messageNumber);
-    if (_skippedMessageKeys.containsKey(skipKey)) {
-      final messageKey = _skippedMessageKeys.remove(skipKey)!;
-      return messageKey.decrypt(message.ciphertext, aad);
+    final skipKey = _makeSkipKey(
+      message.header.dhPublicKey,
+      message.header.messageNumber,
+    );
+    final skipped = _skippedMessageKeys[skipKey];
+    if (skipped != null) {
+      // Decrypt first: a failure must not consume the stored key, or one forged message
+      // would destroy the ability to read the genuine one it names.
+      final plaintext = await skipped.decrypt(message.ciphertext, aad);
+      _skippedMessageKeys.remove(skipKey);
+      return plaintext;
     }
 
+    // Everything below is staged. `this` is not touched until the tag verifies, so an
+    // authentication failure - or a forged header that trips _maxSkip - leaves the session
+    // exactly as it was.
+    final staged = _ReceiveStaging.fromRatchet(this);
+    final newlySkipped = <String, _MessageKey>{};
+
     // Check if we need to perform DH ratchet
-    if (_dhRemote != null) {
-      if (!_bytesEqual(message.header.dhPublicKey, _dhRemote!)) {
-        await _dhRatchetReceive(message.header);
-      }
-    } else {
-      // First message from remote
-      await _dhRatchetReceive(message.header);
+    final remote = staged.dhRemote;
+    if (remote == null || !_bytesEqual(message.header.dhPublicKey, remote)) {
+      // Either the remote rotated its key, or this is the first message from it.
+      await staged.dhRatchetReceive(message.header);
     }
 
     // Skip messages if needed
-    await _skipMessageKeys(message.header.messageNumber);
+    await staged.skipMessageKeys(
+      message.header.messageNumber,
+      _skippedMessageKeys.length,
+      newlySkipped,
+    );
 
     // Decrypt the message
-    final chainKey = _receivingChainKey;
+    final chainKey = staged.receivingChainKey;
     if (chainKey == null) {
       throw ProtocolException('No receiving chain key');
     }
 
     final messageKey = await chainKey.messageKey();
+
+    // The gate. Nothing above this line has been committed.
     final plaintext = await messageKey.decrypt(message.ciphertext, aad);
 
-    // Advance receiving chain
-    _receivingChainKey = await chainKey.next();
-    _receivingMessageNumber++;
+    // Advance receiving chain, then commit.
+    staged.receivingChainKey = await chainKey.next();
+    staged.receivingMessageNumber++;
+    staged.commitInto(this);
+    _skippedMessageKeys.addAll(newlySkipped);
 
     return plaintext;
   }
 
-  /// Perform DH ratchet when receiving new public key
-  Future<void> _dhRatchetReceive(MessageHeader header) async {
-    // Store previous chain length
-    _previousChainLength = _sendingMessageNumber;
-    _sendingMessageNumber = 0;
-    _receivingMessageNumber = 0;
-
-    // Update remote DH key
-    _dhRemote = header.dhPublicKey;
-
-    // Perform DH and derive new receiving chain
-    final dhOutput = await _dhSelf.diffieHellman(header.dhPublicKey);
-    final (newRootKey, receivingChainKey) = await _rootKey.dhRatchet(dhOutput);
-    _rootKey = newRootKey;
-    _receivingChainKey = receivingChainKey;
-
-    // Generate new DH key pair and derive new sending chain
-    _dhSelf = await X25519KeyPair.generate();
-    final dhOutput2 = await _dhSelf.diffieHellman(header.dhPublicKey);
-    final (finalRootKey, sendingChainKey) = await _rootKey.dhRatchet(dhOutput2);
-    _rootKey = finalRootKey;
-    _sendingChainKey = sendingChainKey;
-  }
-
-  /// Derive and store message keys for messages that arrived out of order.
+  /// Number of skipped message keys currently held.
   ///
-  /// Mirrors `skip_message_keys` in `backend/crates/crypto/src/double_ratchet.rs`.
-  ///
-  /// The bound counts the **size of the stored map**, not the size of the gap, and is checked
-  /// inside the loop. Bounding the gap lets many small-gap messages grow
-  /// [_skippedMessageKeys] without limit, which is the memory exhaustion the bound exists to
-  /// prevent.
-  ///
-  /// On return `_receivingMessageNumber` is `until`, so the caller's own increment leaves it
-  /// at `until + 1`.
-  Future<void> _skipMessageKeys(int until) async {
-    final chainKey = _receivingChainKey;
-    if (chainKey == null) return;
-
-    var currentKey = chainKey;
-    while (_receivingMessageNumber < until) {
-      if (_skippedMessageKeys.length >= _maxSkip) {
-        throw ProtocolException('Too many skipped messages (max: $_maxSkip)');
-      }
-
-      final messageKey = await currentKey.messageKey();
-      final skipKey = _makeSkipKey(_dhRemote!, _receivingMessageNumber);
-      _skippedMessageKeys[skipKey] = messageKey;
-      currentKey = await currentKey.next();
-      _receivingMessageNumber++;
-    }
-    _receivingChainKey = currentKey;
-  }
-
-  String _makeSkipKey(Uint8List dhKey, int messageNumber) {
-    return '${base64Encode(dhKey)}:$messageNumber';
-  }
-
-  bool _bytesEqual(Uint8List a, Uint8List b) {
-    if (a.length != b.length) return false;
-    for (int i = 0; i < a.length; i++) {
-      if (a[i] != b[i]) return false;
-    }
-    return true;
-  }
+  /// Mirrors `skipped_messages_count` in the Rust implementation. Useful for asserting that
+  /// a rejected message left no partial state behind.
+  int get skippedMessagesCount => _skippedMessageKeys.length;
 
   /// Serialize ratchet state for storage
   Map<String, dynamic> serialize() {

--- a/client-mobile/test/core/crypto/double_ratchet_atomicity_test.dart
+++ b/client-mobile/test/core/crypto/double_ratchet_atomicity_test.dart
@@ -1,0 +1,118 @@
+/// Atomicity tests for Double Ratchet decryption.
+///
+/// The Dart mirror of #106, fixed in Rust by `0be3de17` and never carried across. Before
+/// that fix, `decrypt` mutated the session before the AEAD tag was checked:
+///
+///   * `_dhRatchetReceive` rotated `_dhRemote`, `_rootKey` and both chain keys as soon as it
+///     saw an unfamiliar DH public key - so a single forged header destroyed the session,
+///     even when the skip loop never ran.
+///   * a skipped message key was removed from the map and *then* used, so one corrupted copy
+///     of a message burned the key needed by the genuine one.
+///
+/// Binding the header into the AAD (#213) narrows the first case but does not close it: the
+/// mutation still happened before the tag was verified.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guardyn_client/core/crypto/double_ratchet.dart';
+
+import 'crypto_test_helper.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeCryptoForTests();
+  });
+
+  final ad = Uint8List.fromList(utf8.encode('alice|bob'));
+
+  Future<(DoubleRatchet alice, DoubleRatchet bob)> pair() async {
+    final secret = Uint8List.fromList(List.generate(32, (i) => i));
+    final bob = await DoubleRatchet.initBob(secret);
+    final alice = await DoubleRatchet.initAlice(secret, bob.publicKey);
+    return (alice, bob);
+  }
+
+  cryptoGroup('decryption is atomic', () {
+    test('a forged header does not poison the session', () async {
+      final (alice, bob) = await pair();
+
+      final genuine = await alice.encrypt(
+        Uint8List.fromList(utf8.encode('genuine')),
+        ad,
+      );
+
+      // A header claiming a DH public key Bob has never seen. Before the fix this drove
+      // _dhRatchetReceive on the live session, rotating the root key and both chain keys,
+      // after which no genuine message could ever be decrypted again.
+      final forgedKey = (await X25519KeyPair.generate()).publicKey;
+      final forged = EncryptedMessage(
+        header: MessageHeader(
+          dhPublicKey: forgedKey,
+          previousChainLength: 0,
+          messageNumber: 0,
+        ),
+        ciphertext: genuine.ciphertext,
+      );
+
+      await expectLater(bob.decrypt(forged, ad), throwsA(isA<Exception>()));
+
+      // The session must be exactly as it was.
+      expect(utf8.decode(await bob.decrypt(genuine, ad)), equals('genuine'));
+    });
+
+    test('a forged header that would trip the skip bound changes nothing', () async {
+      final (alice, bob) = await pair();
+
+      final genuine = await alice.encrypt(
+        Uint8List.fromList(utf8.encode('still here')),
+        ad,
+      );
+
+      // An absurd message number on the real DH key: the skip loop tries to stage far more
+      // keys than _maxSkip allows and throws. That must leave no partial state behind.
+      final forged = EncryptedMessage(
+        header: MessageHeader(
+          dhPublicKey: genuine.header.dhPublicKey,
+          previousChainLength: 0,
+          messageNumber: 500000,
+        ),
+        ciphertext: genuine.ciphertext,
+      );
+
+      await expectLater(bob.decrypt(forged, ad), throwsA(isA<Exception>()));
+      expect(bob.skippedMessagesCount, equals(0));
+
+      expect(utf8.decode(await bob.decrypt(genuine, ad)), equals('still here'));
+    });
+
+    test('a failed skipped-key decrypt keeps the key', () async {
+      final (alice, bob) = await pair();
+
+      final m0 = await alice.encrypt(Uint8List.fromList(utf8.encode('zero')), ad);
+      final m1 = await alice.encrypt(Uint8List.fromList(utf8.encode('one')), ad);
+
+      // Receiving m1 first stages a skipped key for m0.
+      expect(utf8.decode(await bob.decrypt(m1, ad)), equals('one'));
+      expect(bob.skippedMessagesCount, equals(1));
+
+      // A corrupted copy of m0: same header, mangled ciphertext. Before the fix the key was
+      // removed before the decrypt was attempted, so this destroyed the ability to read the
+      // genuine m0 that follows.
+      final corrupted = EncryptedMessage(
+        header: m0.header,
+        ciphertext: Uint8List.fromList(
+          m0.ciphertext.map((b) => b ^ 0xff).toList(),
+        ),
+      );
+      await expectLater(bob.decrypt(corrupted, ad), throwsA(isA<Exception>()));
+      expect(bob.skippedMessagesCount, equals(1));
+
+      // The genuine message still decrypts.
+      expect(utf8.decode(await bob.decrypt(m0, ad)), equals('zero'));
+      expect(bob.skippedMessagesCount, equals(0));
+    });
+  });
+}

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -123,7 +123,7 @@ steps:
   - {id: PR-68, issue: 203, phase: 3, type: chore, status: todo, title: "Add the mobile CI workflow (split out of PR-44)"}
   - {id: PR-69, issue: 204, phase: 3, type: chore, status: todo, title: "Un-gate the Dart crypto suite so it runs under flutter test"}
   - {id: PR-70, issue: 213, phase: 3, type: security, status: todo, title: "Dart - adopt ratchet wire format v1 and bind the header into the AEAD"}
-  - {id: PR-71, issue: null, phase: 3, type: security, status: todo, title: "Dart - make ratchet decryption atomic"}
+  - {id: PR-71, issue: 216, phase: 3, type: security, status: todo, title: "Dart - make ratchet decryption atomic"}
   - {id: PR-72, issue: null, phase: 3, type: security, status: todo, title: "Unify the client AAD convention and fix UTF-8 handling"}
   - {id: PR-73, issue: null, phase: 3, type: security, status: todo, title: "Apply PADME padding on the mobile message path"}
   - {id: PR-74, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - make the ratchet AAD symmetric"}


### PR DESCRIPTION
Closes #216

The Dart mirror of **#106**, fixed in Rust by `0be3de17` and never carried across. `decrypt`
mutated the session **before** the AEAD tag was verified, in two independent ways.

## 1. `_dhRatchetReceive` ran on the live session

The moment an unfamiliar `dhPublicKey` arrived it rotated `_dhRemote`, `_rootKey` and **both**
chain keys, and generated a fresh `_dhSelf`. A single forged header walked the chain past every
genuine message and left the session unrecoverable without a new handshake.

As the Rust commit noted, this was the worse half: #106 blamed only `skip_message_keys`, but the
DH step destroyed the session **even when the skip loop never ran**.

## 2. Skipped keys were removed before use

```dart
final messageKey = _skippedMessageKeys.remove(skipKey)!;
return messageKey.decrypt(message.ciphertext, associatedData);
```

One corrupted copy of a message burned the stored key needed by the genuine one it names. Rust
decrypts first and removes only on success.

## Binding the header did not fix this

#213 bound the header into the AAD, so a forged header now fails the tag — but the mutation still
*preceded* that check. ADR-0011 says exactly this of the Rust side: *"It does not close #106."*
This PR is what closes it on mobile.

## The fix

`_ReceiveStaging` mirrors `ReceiveStaging` (`double_ratchet.rs:656`): stage the receive-side
transition, verify the tag, **then** commit. Skipped keys accumulate into a map the caller
discards on failure, and the bound counts `alreadyStored + out.length` so a rejected message
cannot stage a fresh budget each time.

References are copied rather than the whole ratchet. The key types are immutable value objects and
every staged field is fixed-size, whereas `_skippedMessageKeys` can hold up to `_maxSkip` (1000)
entries — allocating that on every message to guard against a rare failure is the wrong trade.
That is the same reasoning the Rust implementation records, and it is why the staging type
enumerates 8 fields instead of cloning.

`_makeSkipKey` and `_bytesEqual` move to top level so the staging type can use them. Adds
`skippedMessagesCount`, mirroring `skipped_messages_count`, so a test can assert that a rejected
message left **no** partial state.

## Verified red before green

Nothing tested forged headers or failed skipped-key decrypts on this client. All three new cases
fail against the previous implementation:

```
$ git checkout origin/main -- lib/core/crypto/double_ratchet.dart
$ flutter test test/core/crypto/double_ratchet_atomicity_test.dart
+0 -3: Some tests failed.
```

## Verification

```
flutter test                      594 pass, 4 skip, 0 fail   (was 591/4/0)
flutter analyze --no-fatal-infos  exit 0
rules-verify                      all checks passed
docs-verify                       all checks passed
budget                            3 files, 359 lines
```

## Deliberately out of scope

- The AAD **content** — mobile sends `sender|recipient`, desktop sends an asymmetric bare peer id —
  and its `codeUnits` encoding, which corrupts any non-ASCII message.
- PADMÉ, which mobile never applies at all, so ciphertext length still leaks plaintext length.
- The plaintext fallbacks in `message_repository_impl.dart`.

With this, the Dart ratchet matches the Rust one on wire format, header binding, skip semantics
and atomicity. What remains between the two clients is the *caller-side* contract, which is the
next group of steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)