### PR TITLE
security(mobile): pin the AAD convention and fix UTF-8 handling

### DIFF
--- a/client-mobile/lib/core/crypto/message_aad.dart
+++ b/client-mobile/lib/core/crypto/message_aad.dart
@@ -1,0 +1,37 @@
+/// The caller-side associated data for a one-to-one message.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Builds the caller-supplied associated data bound into a message's AEAD.
+///
+/// The full AAD is `messageAssociatedData(...) || header(40)`; the ratchet appends the header
+/// itself (see `_aadWithHeader` in `double_ratchet.dart`). This function supplies only the
+/// caller's half.
+///
+/// The convention is **`utf8("{senderUserId}|{recipientUserId}")`**, and it is canonical
+/// across both clients — `client-desktop` builds the same bytes in
+/// `src-tauri/src/commands/crypto.rs`. It is recorded in
+/// `docs/adr/ADR-0011-ratchet-header-authentication.md`.
+///
+/// Two properties matter, and both were violated somewhere before this existed:
+///
+/// **It is directional, and therefore symmetric.** Both ends name the *originator* first and
+/// the *destination* second, so a sender encrypting to Bob and Bob decrypting from that
+/// sender compute identical bytes. Deriving the value from "me" and "the other party" instead
+/// produces two different strings for the same message and the tag never verifies — which is
+/// what the desktop client did, passing `recipient_id` on encrypt and `sender_id` on decrypt.
+///
+/// **It is UTF-8, not `String.codeUnits`.** `codeUnits` yields UTF-16 units, and
+/// `Uint8List.fromList` then truncates anything above 0xFF, so any non-ASCII identifier would
+/// silently produce different bytes on the two sides.
+///
+/// Binding both participants is what stops a ciphertext being replayed into a different
+/// conversation that shares a session.
+Uint8List messageAssociatedData({
+  required String senderUserId,
+  required String recipientUserId,
+}) {
+  return Uint8List.fromList(utf8.encode('$senderUserId|$recipientUserId'));
+}

--- a/client-mobile/lib/core/crypto/sealed_sender.dart
+++ b/client-mobile/lib/core/crypto/sealed_sender.dart
@@ -9,6 +9,7 @@
 // NOTE: This implementation uses CryptoPrimitives which can use either
 // pure Dart or native Rust FFI depending on platform availability.
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'crypto_primitives.dart';
@@ -102,9 +103,9 @@ class SenderCertificate {
     int expiresAt,
   ) {
     final buffer = BytesBuilder();
-    buffer.add(userId.codeUnits);
+    buffer.add(utf8.encode(userId));
     buffer.addByte(0); // Null separator
-    buffer.add(deviceId.codeUnits);
+    buffer.add(utf8.encode(deviceId));
     buffer.addByte(0);
     buffer.add(identityKey);
 
@@ -120,7 +121,7 @@ class SenderCertificate {
     final buffer = BytesBuilder();
 
     // sender_user_id (length-prefixed)
-    final userIdBytes = Uint8List.fromList(senderUserId.codeUnits);
+    final userIdBytes = Uint8List.fromList(utf8.encode(senderUserId));
     buffer.add(
       (ByteData(
         2,
@@ -129,7 +130,7 @@ class SenderCertificate {
     buffer.add(userIdBytes);
 
     // sender_device_id (length-prefixed)
-    final deviceIdBytes = Uint8List.fromList(senderDeviceId.codeUnits);
+    final deviceIdBytes = Uint8List.fromList(utf8.encode(senderDeviceId));
     buffer.add(
       (ByteData(
         2,
@@ -169,7 +170,7 @@ class SenderCertificate {
     if (bytes.length < offset + userIdLen) {
       throw FormatException('Invalid user_id length');
     }
-    final senderUserId = String.fromCharCodes(
+    final senderUserId = utf8.decode(
       bytes.sublist(offset, offset + userIdLen),
     );
     offset += userIdLen;
@@ -187,7 +188,7 @@ class SenderCertificate {
     if (bytes.length < offset + deviceIdLen) {
       throw FormatException('Invalid device_id length');
     }
-    final senderDeviceId = String.fromCharCodes(
+    final senderDeviceId = utf8.decode(
       bytes.sublist(offset, offset + deviceIdLen),
     );
     offset += deviceIdLen;
@@ -322,7 +323,7 @@ class SealedSender {
     // 3. Derive encryption key using HKDF
     final derivedKey = await CryptoPrimitives.hkdf(
       inputKeyMaterial: sharedSecret,
-      info: Uint8List.fromList(_hkdfLabel.codeUnits),
+      info: Uint8List.fromList(utf8.encode(_hkdfLabel)),
       outputLength: 32,
     );
 
@@ -376,7 +377,7 @@ class SealedSender {
     // 2. Derive decryption key
     final derivedKey = await CryptoPrimitives.hkdf(
       inputKeyMaterial: sharedSecret,
-      info: Uint8List.fromList(_hkdfLabel.codeUnits),
+      info: Uint8List.fromList(utf8.encode(_hkdfLabel)),
       outputLength: 32,
     );
 

--- a/client-mobile/lib/features/messaging/data/datasources/message_remote_datasource.dart
+++ b/client-mobile/lib/features/messaging/data/datasources/message_remote_datasource.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 import 'package:injectable/injectable.dart';
@@ -34,7 +36,7 @@ class MessageRemoteDatasource {
       recipientUserId: recipientUserId,
       recipientDeviceId: recipientDeviceId,
       recipientUsername: recipientUsername,
-      encryptedContent: textContent.codeUnits,
+      encryptedContent: utf8.encode(textContent),
       messageType: proto.MessageType.TEXT,
       clientMessageId: _generateMessageId(),
       clientTimestamp: _createTimestamp(DateTime.now()),

--- a/client-mobile/lib/features/messaging/data/models/message_model.dart
+++ b/client-mobile/lib/features/messaging/data/models/message_model.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:fixnum/fixnum.dart';
 
 import '../../../../generated/common.pb.dart' as common_proto;
@@ -49,7 +51,7 @@ class MessageModel extends Message {
       accessToken: accessToken,
       recipientUserId: recipientUserId,
       recipientDeviceId: recipientDeviceId,
-      encryptedContent: textContent.codeUnits,
+      encryptedContent: utf8.encode(textContent),
       messageType: _messageTypeToProto(messageType),
       clientMessageId: clientMessageId,
       clientTimestamp: _timestampToProto(timestamp),

--- a/client-mobile/lib/features/messaging/data/repositories/message_repository_impl.dart
+++ b/client-mobile/lib/features/messaging/data/repositories/message_repository_impl.dart
@@ -6,6 +6,7 @@ import 'package:grpc/grpc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:logger/logger.dart';
 
+import '../../../../core/crypto/message_aad.dart';
 import '../../../../core/crypto/crypto_service.dart';
 import '../../../../core/crypto/x3dh.dart';
 import '../../../../core/error/failures.dart';
@@ -467,9 +468,10 @@ class MessageRepositoryImpl implements MessageRepository {
     }
 
     // Encrypt with Double Ratchet
-    final plaintextBytes = Uint8List.fromList(plaintext.codeUnits);
-    final associatedData = Uint8List.fromList(
-      '$currentUserId|$recipientUserId'.codeUnits,
+    final plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
+    final associatedData = messageAssociatedData(
+      senderUserId: currentUserId,
+      recipientUserId: recipientUserId,
     );
 
     try {
@@ -600,8 +602,9 @@ class MessageRepositoryImpl implements MessageRepository {
       _logger.d('Base64 decode failed, using codeUnits: $e');
     }
 
-    final associatedData = Uint8List.fromList(
-      '$senderUserId|$currentUserId'.codeUnits,
+    final associatedData = messageAssociatedData(
+      senderUserId: senderUserId,
+      recipientUserId: currentUserId,
     );
 
     try {
@@ -611,7 +614,7 @@ class MessageRepositoryImpl implements MessageRepository {
         ciphertext: ciphertextBytes,
         associatedData: associatedData,
       );
-      final result = String.fromCharCodes(decrypted);
+      final result = utf8.decode(decrypted);
       _logger.d('Decryption successful: ${result.length} chars');
       return result;
     } catch (e) {

--- a/client-mobile/test/core/crypto/message_aad_test.dart
+++ b/client-mobile/test/core/crypto/message_aad_test.dart
@@ -1,0 +1,113 @@
+/// Tests for the canonical caller-side associated data, and for UTF-8 correctness.
+///
+/// Both clients must compute identical AAD bytes or no message crosses between them. Two
+/// things used to break that:
+///
+///   * `client-desktop` passed `recipient_id` when encrypting and `sender_id` when decrypting,
+///     so the two ends never agreed;
+///   * `client-mobile` built the string with `String.codeUnits`, which yields UTF-16 units and
+///     is then truncated by `Uint8List.fromList`, so any non-ASCII identifier silently
+///     produced different bytes.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guardyn_client/core/crypto/double_ratchet.dart';
+import 'package:guardyn_client/core/crypto/message_aad.dart';
+
+import 'crypto_test_helper.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeCryptoForTests();
+  });
+
+  group('messageAssociatedData', () {
+    test('is utf8("{sender}|{recipient}")', () {
+      expect(
+        messageAssociatedData(senderUserId: 'alice', recipientUserId: 'bob'),
+        equals(Uint8List.fromList(utf8.encode('alice|bob'))),
+      );
+    });
+
+    test('both ends of one message compute identical bytes', () {
+      // The sender knows itself as "me" and the peer as the recipient; the receiver knows the
+      // peer as the sender and itself as "me". Naming originator-then-destination is what
+      // makes those two views agree.
+      final sending = messageAssociatedData(
+        senderUserId: 'alice',
+        recipientUserId: 'bob',
+      );
+      final receiving = messageAssociatedData(
+        senderUserId: 'alice',
+        recipientUserId: 'bob',
+      );
+      expect(sending, equals(receiving));
+    });
+
+    test('is directional', () {
+      expect(
+        messageAssociatedData(senderUserId: 'alice', recipientUserId: 'bob'),
+        isNot(
+          equals(
+            messageAssociatedData(
+              senderUserId: 'bob',
+              recipientUserId: 'alice',
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('encodes non-ASCII identifiers as UTF-8, not truncated UTF-16', () {
+      const sender = 'Пётр';
+      final aad = messageAssociatedData(
+        senderUserId: sender,
+        recipientUserId: 'bob',
+      );
+
+      expect(aad, equals(Uint8List.fromList(utf8.encode('$sender|bob'))));
+
+      // The old construction. Every Cyrillic code unit exceeds 0xFF, so Uint8List.fromList
+      // truncates it - a different byte string entirely.
+      final broken = Uint8List.fromList('$sender|bob'.codeUnits);
+      expect(aad, isNot(equals(broken)));
+    });
+  });
+
+  cryptoGroup('non-ASCII message round trip', () {
+    test('Cyrillic and emoji survive encrypt/decrypt', () async {
+      final secret = Uint8List.fromList(List.generate(32, (i) => i));
+      final bob = await DoubleRatchet.initBob(secret);
+      final alice = await DoubleRatchet.initAlice(secret, bob.publicKey);
+
+      final ad = messageAssociatedData(
+        senderUserId: 'Пётр',
+        recipientUserId: 'bob',
+      );
+
+      // A messaging product has to prove non-Latin text round-trips; the repository keeps
+      // Cyrillic fixtures for exactly this reason.
+      const messages = ['Привет, мир!', 'ऄआइ', '🔐 end-to-end 🎉', 'plain ascii'];
+
+      for (final text in messages) {
+        final encrypted = await alice.encrypt(
+          Uint8List.fromList(utf8.encode(text)),
+          ad,
+        );
+        final decrypted = await bob.decrypt(encrypted, ad);
+        expect(utf8.decode(decrypted), equals(text));
+
+        // And the old encoding would not have survived: codeUnits truncates above 0xFF.
+        if (text.codeUnits.any((u) => u > 0xff)) {
+          expect(
+            Uint8List.fromList(text.codeUnits),
+            isNot(equals(Uint8List.fromList(utf8.encode(text)))),
+          );
+        }
+      }
+    });
+  });
+}

--- a/docs/adr/ADR-0011-ratchet-header-authentication.md
+++ b/docs/adr/ADR-0011-ratchet-header-authentication.md
@@ -66,6 +66,20 @@ besides this one: `client-mobile/lib/core/crypto/double_ratchet.dart`, and the d
 consumes this crate through `client-desktop/src-tauri/src/commands/crypto.rs`. Both must bind
 the header and emit the version byte, or messages will not cross platforms.
 
+**The caller-supplied half of the AAD is `utf8("{senderUserId}|{recipientUserId}")`.** This
+document defines `AD = AD_caller || header`, and left `AD_caller` to the caller — which produced
+two conventions and one outright bug. `client-desktop` passed `recipient_id` when encrypting and
+`sender_id` when decrypting (`commands/crypto.rs:630`, `:685`), so the two ends of a conversation
+never computed the same bytes; `client-mobile` built `"{sender}|{recipient}"` but with
+`String.codeUnits`, which yields UTF-16 units that `Uint8List.fromList` then truncates above
+0xFF.
+
+The convention is now pinned: **originator first, destination second**, UTF-8, `|`-separated.
+Naming the parties by role rather than by "me" and "them" is what makes both ends agree, and
+binding both is what stops a ciphertext being replayed into another conversation that shares a
+session. Mobile builds it in `client-mobile/lib/core/crypto/message_aad.dart`; the desktop must
+build the same bytes.
+
 **Client conformance.** The desktop inherited both changes for free, because it links this crate
 rather than reimplementing it. The Dart client did not, and was left on the pre-v1 format with an
 unauthenticated header until #213 — the header binding is the #105 vulnerability itself, so it was

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -124,7 +124,7 @@ steps:
   - {id: PR-69, issue: 204, phase: 3, type: chore, status: todo, title: "Un-gate the Dart crypto suite so it runs under flutter test"}
   - {id: PR-70, issue: 213, phase: 3, type: security, status: todo, title: "Dart - adopt ratchet wire format v1 and bind the header into the AEAD"}
   - {id: PR-71, issue: 216, phase: 3, type: security, status: todo, title: "Dart - make ratchet decryption atomic"}
-  - {id: PR-72, issue: null, phase: 3, type: security, status: todo, title: "Unify the client AAD convention and fix UTF-8 handling"}
+  - {id: PR-72, issue: 218, phase: 3, type: security, status: todo, title: "Unify the client AAD convention and fix UTF-8 handling"}
   - {id: PR-73, issue: null, phase: 3, type: security, status: todo, title: "Apply PADME padding on the mobile message path"}
   - {id: PR-74, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - make the ratchet AAD symmetric"}
   - {id: PR-75, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed instead of sending plaintext"}


### PR DESCRIPTION
Closes #218

ADR-0011 defines `AD = AD_caller || header` but left `AD_caller` to the caller. The two clients
chose differently — and one chose something that cannot work at all.

## The convergence target

**`utf8("{senderUserId}|{recipientUserId}")`** — originator first, destination second.

Naming the parties by *role* rather than by "me" and "them" is what makes both ends agree: the
sender knows itself as `me` and the peer as recipient, the receiver knows the peer as sender and
itself as `me`, and only the role-ordered form collapses those two views to the same bytes.
Binding both participants is what stops a ciphertext being replayed into another conversation that
shares a session.

`client-desktop` is **asymmetric**: `crypto.rs:630` encrypts with `recipient_id`, `:685` decrypts
with `sender_id`. For a session A↔B, A encrypts under `bytes(B)` while B decrypts under
`bytes(A)`. The tag can never verify. It is invisible today only because no message reaches that
path (#163) and its unit tests use a symmetric literal (`b"alice->bob"`). **The desktop half is a
separate step** — this PR fixes mobile and pins the convention so there is something to converge
*on*.

## `codeUnits` was corrupting more than the AAD

`client-mobile` had the right *shape* built the wrong way: `String.codeUnits` yields UTF-16 code
units, and `Uint8List.fromList` truncates anything above 0xFF.

The same defect ran through the message path itself — plaintext went in as `codeUnits`
(`:470`) and came back through `String.fromCharCodes` (`:614`). **Any message containing Cyrillic,
CJK or an emoji was mangled**, in a repository that deliberately keeps Cyrillic fixtures to prove
exactly that round-trip (`.claude/rules/20-code-style.md`). `sealed_sender.dart` had it too, on the
user and device identifiers it *signs over*.

## Changes

- **`lib/core/crypto/message_aad.dart`** — one definition both call sites use, so they cannot
  drift again. The doc comment records why the ordering is role-based and why UTF-8 matters.
- `message_repository_impl.dart` — both AAD sites, the plaintext encode and the decrypt decode.
- `sealed_sender.dart` — identifiers and the HKDF label.
- `message_remote_datasource.dart`, `message_model.dart` — the gRPC boundary.
- **ADR-0011** — records the convention, rather than leaving the gap that allowed two of them.

## Verification

```
flutter test                      599 pass, 4 skip, 0 fail   (was 594/4/0)
flutter analyze --no-fatal-infos  exit 0
rules-verify                      all checks passed
docs-verify                       all checks passed (language check green — Cyrillic in a
                                  Dart fixture is explicitly permitted; LANG-MD scopes to Markdown)
budget                            7 files, 204 lines
```

New coverage asserts the bytes directly, that both ends agree, that the form is directional, and
that `Пётр`, `ऄआइ` and `🔐 end-to-end 🎉` survive a real encrypt/decrypt — each also asserting that
the old `codeUnits` construction would have produced different bytes.

## Deliberately out of scope

- **The desktop AAD** (`crypto.rs:630`/`:685`). Next step; it needs a cross-party test, since the
  existing ones use a symmetric literal and structurally cannot catch the asymmetry.
- **The `codeUnits` fallbacks that treat ciphertext as a string**
  (`message_repository_impl.dart:594-599`, `message_model.dart:35`). Those are part of the
  fail-open behaviour — they exist to render a failed decrypt as if it were text — and removing
  them belongs with the step that makes the client fail closed.
- PADMÉ, which mobile still never applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)