### PR TITLE
security(mobile): apply PADMÉ on the message path

### DIFF
--- a/client-mobile/lib/core/crypto/crypto_service.dart
+++ b/client-mobile/lib/core/crypto/crypto_service.dart
@@ -13,6 +13,7 @@ import 'crypto_exceptions.dart';
 import 'crypto_isolate.dart';
 import 'crypto_primitives.dart';
 import 'double_ratchet.dart';
+import 'padme.dart' as padme;
 import 'x3dh.dart';
 
 /// Configuration for one-time pre-key management
@@ -538,7 +539,12 @@ class CryptoService {
       );
     }
 
-    final encrypted = await session.encrypt(plaintext, associatedData);
+    // PADME first, then the ratchet: the padding must be inside the AEAD, or an observer
+    // reads the true plaintext length straight off the ciphertext. This mirrors the desktop
+    // pipeline (client-desktop/src-tauri/src/commands/crypto.rs), which pads before
+    // encrypting and unpads after decrypting.
+    final padded = padme.padMessage(plaintext);
+    final encrypted = await session.encrypt(padded, associatedData);
     final sessionId = _makeSessionId(recipientUserId, recipientDeviceId);
     await _saveSession(sessionId, session);
 
@@ -564,11 +570,11 @@ class CryptoService {
     }
 
     final encrypted = EncryptedMessage.fromBytes(ciphertext);
-    final decrypted = await session.decrypt(encrypted, associatedData);
+    final padded = await session.decrypt(encrypted, associatedData);
     final sessionId = _makeSessionId(senderUserId, senderDeviceId);
     await _saveSession(sessionId, session);
 
-    return decrypted;
+    return padme.unpadMessage(padded);
   }
 
   /// Delete a session

--- a/client-mobile/test/core/crypto/crypto_service_padding_test.dart
+++ b/client-mobile/test/core/crypto/crypto_service_padding_test.dart
@@ -1,0 +1,150 @@
+/// Proves that CryptoService applies PADMÉ, rather than merely owning a correct
+/// implementation of it.
+///
+/// Padding was a no-op on this client for its whole history: `padMessage` had no production
+/// caller anywhere in `lib/`, so ciphertext length tracked plaintext length exactly and the
+/// `enablePadme` flag was inert. A unit test of `padme.dart` alone cannot catch a regression
+/// that simply stops calling it, which is what these assert against.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guardyn_client/core/crypto/crypto_service.dart';
+import 'package:guardyn_client/core/crypto/message_aad.dart';
+import 'package:guardyn_client/core/crypto/padme.dart' as padme;
+import 'package:mocktail/mocktail.dart';
+
+import 'crypto_test_helper.dart';
+
+/// An in-memory stand-in for the platform keystore.
+class _FakeSecureStorage extends Mock implements FlutterSecureStorage {
+  final Map<String, String> store = {};
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async =>
+      store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      store.remove(key);
+    } else {
+      store[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    store.remove(key);
+  }
+}
+
+void main() {
+  setUpAll(() async {
+    await initializeCryptoForTests();
+  });
+
+  cryptoGroup('CryptoService applies PADMÉ', () {
+    late CryptoService alice;
+
+    setUp(() async {
+      alice = CryptoService(storage: _FakeSecureStorage());
+      await alice.initialize();
+      await alice.initializeX3DH(oneTimePreKeyCount: 2);
+    });
+
+    Future<void> openSessionToBob() async {
+      final bobService = CryptoService(storage: _FakeSecureStorage());
+      await bobService.initialize();
+      await bobService.initializeX3DH(oneTimePreKeyCount: 2);
+      final bobBundle = bobService.exportKeyBundles().first;
+
+      await alice.createSessionAsInitiator(
+        recipientUserId: 'bob',
+        recipientDeviceId: 'device-1',
+        remoteKeyBundle: bobBundle,
+      );
+    }
+
+    Future<int> ciphertextLengthFor(String text) async {
+      final bytes = await alice.encrypt(
+        recipientUserId: 'bob',
+        recipientDeviceId: 'device-1',
+        plaintext: Uint8List.fromList(utf8.encode(text)),
+        associatedData: messageAssociatedData(
+          senderUserId: 'alice',
+          recipientUserId: 'bob',
+        ),
+      );
+      return bytes.length;
+    }
+
+    test('short messages of different lengths share a ciphertext length', () async {
+      await openSessionToBob();
+
+      // 'a' and a 20-character message both fall in the 32-byte PADMÉ bucket, so an observer
+      // cannot tell them apart by size. Without padding these differ by 19 bytes.
+      final short = await ciphertextLengthFor('a');
+      final longer = await ciphertextLengthFor('12345678901234567890');
+
+      expect(short, equals(longer));
+    });
+
+    test('ciphertext length follows the PADMÉ schedule, not the plaintext', () async {
+      await openSessionToBob();
+
+      // Ciphertext is version(1) + len(4) + header(40) + nonce(12) + padded + tag(16).
+      const overhead = 1 + 4 + 40 + 12 + 16;
+
+      for (final text in ['a', 'hello there', 'x' * 100, 'y' * 300]) {
+        final len = await ciphertextLengthFor(text);
+        final expectedPadded = padme.nextPadmeLength(utf8.encode(text).length);
+        expect(
+          len,
+          equals(overhead + expectedPadded),
+          reason: 'ciphertext for ${text.length} chars should carry '
+              '$expectedPadded padded bytes',
+        );
+      }
+    });
+
+    test('a 300-byte message is not the same size as a 100-byte one', () async {
+      await openSessionToBob();
+
+      // Padding hides length within a bucket, not across buckets - the property is
+      // indistinguishability among neighbours, not uniformity.
+      expect(
+        await ciphertextLengthFor('x' * 100),
+        isNot(equals(await ciphertextLengthFor('y' * 300))),
+      );
+    });
+  });
+}

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -126,7 +126,7 @@ steps:
   - {id: PR-71, issue: 216, phase: 3, type: security, status: todo, title: "Dart - make ratchet decryption atomic"}
   - {id: PR-72, issue: 218, phase: 3, type: security, status: todo, title: "Unify the client AAD convention and fix UTF-8 handling"}
   - {id: PR-73a, issue: 220, phase: 3, type: security, status: todo, title: "Implement PADME correctly in Dart"}
-  - {id: PR-73b, issue: null, phase: 3, type: security, status: todo, title: "Apply PADME padding on the mobile message path"}
+  - {id: PR-73b, issue: 222, phase: 3, type: security, status: todo, title: "Apply PADME padding on the mobile message path"}
   - {id: PR-74, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - make the ratchet AAD symmetric"}
   - {id: PR-75, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed instead of sending plaintext"}
   - {id: PR-76, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed on group messaging"}


### PR DESCRIPTION
Closes #222 · depends on #220 (merged)

## Padding was a no-op for this client's entire history

`padMessage` / `unpadMessage` had **no production caller anywhere in `lib/`**. The only
invocations were in tests. `NativeCryptoConfig.enablePadme` defaulted to `true` and did nothing.

So **ciphertext length tracked plaintext length exactly** — every message advertised its own size
to the relay and to anyone observing the connection, while the interface claimed *"PADMÉ padding
for traffic analysis protection"* (`native_crypto_bridge.dart:22`). That is a metadata leak that
survives the encryption entirely.

## It was also an interop break

`client-desktop` already pads (`commands/crypto.rs:621` before `ratchet.encrypt`, `:692` after
`ratchet.decrypt`). Desktop decrypting a mobile message would fail to `unpad_message`; mobile
receiving a desktop message would hand padded bytes straight to the UI.

## The fix

Pad in `CryptoService.encrypt` before the ratchet, unpad in `CryptoService.decrypt` after it —
**inside the AEAD**, matching the desktop pipeline. That seam is where every message path already
converges, so no caller has to remember.

## Why the test asserts on `CryptoService`, not on `padme.dart`

This is the part worth reading. **The padding implementation was never wrong — it was never
called.** A unit test of `padme.dart` passes just as happily before and after this change, so it
cannot catch this class of defect at all.

The regression test therefore asserts on `CryptoService` output:

- two different-length plaintexts in the **same** PADMÉ bucket produce ciphertexts of **identical**
  length (`'a'` vs a 20-char message — 19 bytes apart without padding);
- ciphertext length equals `overhead + nextPadmeLength(len)`, following the schedule rather than
  the message;
- and messages in **different** buckets still differ — padding provides indistinguishability among
  neighbours, not uniformity, and a test asserting otherwise would be asserting the wrong property.

The test drives a real `CryptoService` end-to-end through X3DH against a second instance, with an
in-memory stand-in for the platform keystore.

**Verified red before green:** 2 of the 3 fail against the previous implementation.

## Verification

```
flutter test                      636 pass, 4 skip, 0 fail   (was 633/4/0)
flutter analyze --no-fatal-infos  exit 0
rules-verify                      all checks passed
docs-verify                       all checks passed
budget                            3 files, 164 lines
```

## Deliberately out of scope

- **`enablePadme` as a disable path.** A config key that switches off a privacy control is the
  shape I-2 forbids. Removing it belongs with the fail-closed work, where the other
  encryption-optional branches are being removed together.
- The plaintext fallbacks and the group path.

With this, mobile and desktop now agree on the full pipeline —
`plaintext → PADMÉ → AES-256-GCM(AAD = utf8("{sender}|{recipient}") ‖ header) → v1 frame → base64`
— **except** for the desktop's asymmetric AAD, which is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)