### PR TITLE
fix(desktop): make the ratchet associated data symmetric

### DIFF
--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -609,11 +609,29 @@ pub async fn delete_session(peer_id: String) -> Result<bool, String> {
 // MESSAGE ENCRYPTION/DECRYPTION
 // =============================================================================
 
+/// The caller-supplied half of the AEAD associated data for a one-to-one message.
+///
+/// The full AAD is this value followed by the 40-byte ratchet header, which
+/// `guardyn_crypto` appends itself (see `aad_with_header`). The convention is
+/// `utf8("{sender_user_id}|{recipient_user_id}")` and it is canonical across both clients -
+/// `client-mobile/lib/core/crypto/message_aad.dart` builds the same bytes. It is recorded in
+/// `docs/adr/ADR-0011-ratchet-header-authentication.md`.
+///
+/// Ordering is by **role**, not by point of view: originator first, destination second. That
+/// is what makes the two ends agree. This function exists because they previously did not -
+/// `encrypt_message` passed `recipient_id` while `decrypt_message` passed `sender_id`, so for
+/// a session A-B, A encrypted under `bytes(B)` and B decrypted under `bytes(A)`, and the tag
+/// could never verify.
+fn message_associated_data(sender_user_id: &str, recipient_user_id: &str) -> Vec<u8> {
+    format!("{}|{}", sender_user_id, recipient_user_id).into_bytes()
+}
+
 /// Encrypt a message for a peer using Double Ratchet
 #[tauri::command]
 pub async fn encrypt_message(
     plaintext: String,
     recipient_id: String,
+    self_user_id: String,
 ) -> Result<EncryptedMessage, String> {
     tracing::debug!("Encrypting message for {} ({} bytes)", recipient_id, plaintext.len());
 
@@ -626,9 +644,9 @@ pub async fn encrypt_message(
     let ratchet = ratchet_store.get_mut(&recipient_id)
         .ok_or_else(|| format!("No Double Ratchet session with peer: {}", recipient_id))?;
 
-    // Encrypt with Double Ratchet
-    let associated_data = recipient_id.as_bytes();
-    let encrypted = ratchet.encrypt(&padded, associated_data)
+    // Encrypt with Double Ratchet. The local user is the sender.
+    let associated_data = message_associated_data(&self_user_id, &recipient_id);
+    let encrypted = ratchet.encrypt(&padded, &associated_data)
         .map_err(|e| format!("Double Ratchet encryption failed: {}", e))?;
 
     // Serialize encrypted message
@@ -665,6 +683,7 @@ pub async fn decrypt_message(
     ciphertext: String,
     _nonce: String, // Nonce is now embedded in ciphertext
     sender_id: String,
+    self_user_id: String,
 ) -> Result<String, String> {
     tracing::debug!("Decrypting message from {}", sender_id);
 
@@ -681,9 +700,9 @@ pub async fn decrypt_message(
     let ratchet = ratchet_store.get_mut(&sender_id)
         .ok_or_else(|| format!("No Double Ratchet session with peer: {}", sender_id))?;
 
-    // Decrypt with Double Ratchet
-    let associated_data = sender_id.as_bytes();
-    let padded = ratchet.decrypt(&encrypted_msg, associated_data)
+    // Decrypt with Double Ratchet. The local user is the recipient.
+    let associated_data = message_associated_data(&sender_id, &self_user_id);
+    let padded = ratchet.decrypt(&encrypted_msg, &associated_data)
         .map_err(|e| format!("Double Ratchet decryption failed: {}", e))?;
 
     drop(ratchet_store);
@@ -1009,6 +1028,65 @@ mod tests {
         // Bob decrypts the message
         let decrypted = bob.decrypt(&encrypted, b"alice->bob").unwrap();
         assert_eq!(&decrypted[..], plaintext);
+    }
+
+    #[test]
+    fn associated_data_is_role_ordered_not_point_of_view() {
+        // The bug this replaced: encrypt_message passed recipient_id and decrypt_message
+        // passed sender_id, so each end built the string from its own point of view.
+        let sender = "alice";
+        let recipient = "bob";
+
+        // Both ends name originator first, destination second, so both get the same bytes.
+        let sending = message_associated_data(sender, recipient);
+        let receiving = message_associated_data(sender, recipient);
+        assert_eq!(sending, receiving);
+
+        assert_eq!(sending, b"alice|bob".to_vec());
+
+        // And it is directional: the reply is a different context.
+        assert_ne!(sending, message_associated_data(recipient, sender));
+    }
+
+    #[test]
+    fn cross_party_exchange_verifies_with_the_canonical_aad() {
+        // The existing ratchet tests pass a symmetric literal (b"ad", b"alice->bob") to both
+        // ends, so they cannot catch an asymmetric AAD by construction. This one builds each
+        // side's associated data the way the commands do.
+        let shared_secret = [11u8; 32];
+        let bob_dh = guardyn_crypto::StaticSecret::from([3u8; 32]);
+        let bob_public = guardyn_crypto::X25519PublicKey::from(&bob_dh);
+        let mut bob = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
+        let mut alice =
+            guardyn_crypto::DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
+
+        // Alice is the local user when sending; Bob is the local user when receiving.
+        let alice_sends = message_associated_data("alice", "bob");
+        let bob_receives = message_associated_data("alice", "bob");
+
+        let padded = guardyn_crypto::pad_message(b"hello bob").unwrap();
+        let encrypted = alice.encrypt(&padded, &alice_sends).unwrap();
+        let out = bob.decrypt(&encrypted, &bob_receives).unwrap();
+        assert_eq!(guardyn_crypto::unpad_message(&out).unwrap(), b"hello bob");
+    }
+
+    #[test]
+    fn the_old_asymmetric_associated_data_would_have_failed() {
+        // Pins the defect so it cannot come back: encrypting under the recipient id and
+        // decrypting under the sender id must not verify.
+        let shared_secret = [12u8; 32];
+        let bob_dh = guardyn_crypto::StaticSecret::from([5u8; 32]);
+        let bob_public = guardyn_crypto::X25519PublicKey::from(&bob_dh);
+        let mut bob = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret, bob_dh).unwrap();
+        let mut alice =
+            guardyn_crypto::DoubleRatchet::init_alice(&shared_secret, bob_public).unwrap();
+
+        let encrypted = alice.encrypt(b"hello bob", b"bob").unwrap();
+        assert!(
+            bob.decrypt(&encrypted, b"alice").is_err(),
+            "encrypting under the recipient id and decrypting under the sender id must not \
+             verify - if this ever passes, the AAD has stopped binding the participants"
+        );
     }
 
     #[test]

--- a/client-desktop/src/api/crypto.ts
+++ b/client-desktop/src/api/crypto.ts
@@ -282,29 +282,42 @@ export async function deleteSession(peerId: string): Promise<boolean> {
 // =============================================================================
 
 /**
- * Encrypt a message for a peer using Double Ratchet
+ * Encrypt a message for a peer using Double Ratchet.
+ *
+ * `selfUserId` is required because the AEAD associated data is
+ * `utf8("{senderUserId}|{recipientUserId}")` - ordered by role, not by point of view - and
+ * both ends must compute identical bytes or the tag never verifies.
  */
 export async function encryptMessage(
   plaintext: string,
-  recipientId: string
+  recipientId: string,
+  selfUserId: string
 ): Promise<EncryptedMessage> {
   const result = await invoke<{
     ciphertext: string;
     nonce: string;
     header: string;
-  }>('encrypt_message', { plaintext, recipientId });
+  }>('encrypt_message', { plaintext, recipientId, selfUserId });
   return result;
 }
 
 /**
- * Decrypt a message from a peer using Double Ratchet
+ * Decrypt a message from a peer using Double Ratchet.
+ *
+ * `selfUserId` is the recipient half of the associated data; see {@link encryptMessage}.
  */
 export async function decryptMessage(
   ciphertext: string,
   nonce: string,
-  senderId: string
+  senderId: string,
+  selfUserId: string
 ): Promise<string> {
-  return invoke<string>('decrypt_message', { ciphertext, nonce, senderId });
+  return invoke<string>('decrypt_message', {
+    ciphertext,
+    nonce,
+    senderId,
+    selfUserId,
+  });
 }
 
 // =============================================================================
@@ -394,13 +407,17 @@ export class EncryptionService {
   /**
    * Send an encrypted message
    */
-  async sendMessage(peerId: string, plaintext: string): Promise<EncryptedMessage> {
+  async sendMessage(
+    peerId: string,
+    plaintext: string,
+    selfUserId: string
+  ): Promise<EncryptedMessage> {
     const session = await getSession(peerId);
     if (!session) {
       throw new Error(`No session with peer: ${peerId}`);
     }
 
-    return encryptMessage(plaintext, peerId);
+    return encryptMessage(plaintext, peerId, selfUserId);
   }
 
   /**
@@ -408,14 +425,20 @@ export class EncryptionService {
    */
   async receiveMessage(
     senderId: string,
-    encrypted: EncryptedMessage
+    encrypted: EncryptedMessage,
+    selfUserId: string
   ): Promise<string> {
     const session = await getSession(senderId);
     if (!session) {
       throw new Error(`No session with peer: ${senderId}`);
     }
 
-    return decryptMessage(encrypted.ciphertext, encrypted.nonce, senderId);
+    return decryptMessage(
+      encrypted.ciphertext,
+      encrypted.nonce,
+      senderId,
+      selfUserId
+    );
   }
 
   /**

--- a/client-desktop/src/services/encryption.ts
+++ b/client-desktop/src/services/encryption.ts
@@ -215,13 +215,21 @@ class EncryptionManager {
   /**
    * Encrypt a message for a peer
    */
-  async encryptMessage(peerId: string, plaintext: string): Promise<EncryptedMessage> {
+  async encryptMessage(
+    peerId: string,
+    plaintext: string,
+    selfUserId: string
+  ): Promise<EncryptedMessage> {
     const state = this.peerStates.get(peerId);
     if (state?.status !== 'established') {
       throw new Error(`No established session with peer: ${peerId}`);
     }
 
-    const encrypted = await encryptionService.sendMessage(peerId, plaintext);
+    const encrypted = await encryptionService.sendMessage(
+      peerId,
+      plaintext,
+      selfUserId
+    );
 
     this.emit({
       type: 'message_encrypted',
@@ -236,13 +244,21 @@ class EncryptionManager {
   /**
    * Decrypt a message from a peer
    */
-  async decryptMessage(senderId: string, encrypted: EncryptedMessage): Promise<string> {
+  async decryptMessage(
+    senderId: string,
+    encrypted: EncryptedMessage,
+    selfUserId: string
+  ): Promise<string> {
     const state = this.peerStates.get(senderId);
     if (state?.status !== 'established') {
       throw new Error(`No established session with peer: ${senderId}`);
     }
 
-    const plaintext = await encryptionService.receiveMessage(senderId, encrypted);
+    const plaintext = await encryptionService.receiveMessage(
+      senderId,
+      encrypted,
+      selfUserId
+    );
 
     this.emit({
       type: 'message_decrypted',

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -127,7 +127,7 @@ steps:
   - {id: PR-72, issue: 218, phase: 3, type: security, status: todo, title: "Unify the client AAD convention and fix UTF-8 handling"}
   - {id: PR-73a, issue: 220, phase: 3, type: security, status: todo, title: "Implement PADME correctly in Dart"}
   - {id: PR-73b, issue: 222, phase: 3, type: security, status: todo, title: "Apply PADME padding on the mobile message path"}
-  - {id: PR-74, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - make the ratchet AAD symmetric"}
+  - {id: PR-74, issue: 224, phase: 3, type: fix, status: todo, title: "client-desktop - make the ratchet AAD symmetric"}
   - {id: PR-75, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed instead of sending plaintext"}
   - {id: PR-76, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed on group messaging"}
   - {id: PR-77, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - refuse the native to Dart crypto downgrade"}


### PR DESCRIPTION
Closes #224

## The defect

```rust
// encrypt_message, crypto.rs:630
let associated_data = recipient_id.as_bytes();

// decrypt_message, crypto.rs:685
let associated_data = sender_id.as_bytes();
```

For a session A↔B: **A encrypts under `bytes(B)`, B decrypts under `bytes(A)`.** Those differ, so
the AEAD tag can never verify. Each end built the associated data from *its own point of view*
rather than from the participants' roles.

## Why nothing caught it

Two reasons, and the second is the one worth fixing:

1. **No message reaches this path** — `commands::messaging` never calls `encrypt_message` (#163).
2. **The existing tests cannot detect it by construction.** `test_double_ratchet_basic_encryption`
   and `test_double_ratchet_bidirectional` pass a *symmetric literal* (`b"alice->bob"`, `b"ad"`) to
   both ends. Any asymmetry in how the real call sites build that value is invisible to them. A
   test that hands the same bytes to both parties can never catch two parties computing different
   bytes.

## The fix, and why the signature had to change

Adopts the canonical convention from ADR-0011 —
`utf8("{sender_user_id}|{recipient_user_id}")`, ordered by role — matching
`client-mobile/lib/core/crypto/message_aad.dart`.

That requires knowing **both** parties, and the commands knew only one. So `self_user_id` is
threaded through `encrypt_message` / `decrypt_message` and their TypeScript wrappers.

**The absence of that parameter is the direct cause of the bug**: with a single identifier in
scope, "the peer" is the only thing either side can name, and "the peer" is a different person
depending on which end you are standing at. Adding the second identifier is what makes the correct
value expressible at all.

## Tests

- `associated_data_is_role_ordered_not_point_of_view` — both ends agree; the form is directional.
- `cross_party_exchange_verifies_with_the_canonical_aad` — a real exchange where each side builds
  its associated data the way the commands do, through the full pad → encrypt → decrypt → unpad
  pipeline.
- `the_old_asymmetric_associated_data_would_have_failed` — pins the defect: encrypting under the
  recipient id and decrypting under the sender id **must not** verify. If that test ever passes,
  the AAD has stopped binding the participants.

## Verification

```
cargo test (src-tauri)   50 passed, 0 failed
npx tsc --noEmit         exit 0
npx vitest run           410 passed, 17 skipped, 0 failed
rules-verify             all checks passed
docs-verify              all checks passed
budget                   4 files, 159 lines
```

Note: building `src-tauri` rewrites `src/proto/guardyn.media.rs`. That is **#188**, not a change
belonging to this PR, so it was reverted out — including it would also trip `PROTO-EDIT`.

## Deliberately out of scope

- **`commands::messaging` still sends plaintext** (#163). This PR makes the encryption path
  *correct*; it does not make it *reachable*. Those are separate, and #163 is the larger job — it
  also has to remove the second plaintext copy `Chat.tsx` sends over WebSocket.
- The X3DH responder path, retained prekey material, and ratchet-store persistence.
- The 132 desktop clippy errors (#191) and the stale committed protobuf (#188).

With this, both clients now agree on the complete pipeline:
`plaintext → PADMÉ → AES-256-GCM(AAD = utf8("{sender}|{recipient}") ‖ header) → v1 frame → base64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)