### PR TITLE
security(mobile): fail closed instead of sending plaintext

### DIFF
--- a/client-mobile/lib/core/crypto/crypto_exceptions.dart
+++ b/client-mobile/lib/core/crypto/crypto_exceptions.dart
@@ -44,3 +44,12 @@ class InvalidKeyException extends CryptoException {
 class PaddingException extends CryptoException {
   const PaddingException(super.message);
 }
+
+/// Thrown when a message cannot be encrypted or decrypted and there is no safe alternative.
+///
+/// This exists so the message path has something to *fail with*. It previously fell back to
+/// sending the plaintext, which is the I-2 breach this type replaces: encryption that can be
+/// skipped when it is inconvenient is not always-on encryption.
+class EncryptionUnavailableException extends CryptoException {
+  const EncryptionUnavailableException(super.message);
+}

--- a/client-mobile/lib/features/messaging/data/repositories/message_repository_impl.dart
+++ b/client-mobile/lib/features/messaging/data/repositories/message_repository_impl.dart
@@ -6,6 +6,7 @@ import 'package:grpc/grpc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:logger/logger.dart';
 
+import '../../../../core/crypto/crypto_exceptions.dart';
 import '../../../../core/crypto/message_aad.dart';
 import '../../../../core/crypto/crypto_service.dart';
 import '../../../../core/crypto/x3dh.dart';
@@ -123,6 +124,10 @@ class MessageRepositoryImpl implements MessageRepository {
       );
 
       return Right(completeMessage);
+    } on EncryptionUnavailableException catch (e) {
+      // Nothing was sent. The caller must surface this: a message that cannot be encrypted is
+      // not sent at all.
+      return Left(CryptoFailure(e.message));
     } on GrpcError catch (e) {
       return Left(_handleGrpcError(e));
     } catch (e) {
@@ -453,12 +458,14 @@ class MessageRepositoryImpl implements MessageRepository {
         _logger.i(
           'E2EE session created successfully, prekey: ${x3dhPrekey != null}',
         );
-      } catch (e) {
-        // ignore: avoid_print
-        print('🔐 Failed to create E2EE session: $e');
-        _logger.w('Failed to create E2EE session: $e. Sending plaintext.');
-        // Fall back to plaintext if session creation fails
-        return (plaintext, null);
+      } on Object catch (e) {
+        // Fail closed. This used to return the plaintext, which handed the server the
+        // message in the clear precisely when encryption was least healthy - and returned
+        // Right(), so the UI showed an ordinary sent bubble and nobody could tell.
+        _logger.e('Failed to create E2EE session for $recipientUserId');
+        throw EncryptionUnavailableException(
+          'Could not establish an encrypted session with the recipient: $e',
+        );
       }
     } else {
       // ignore: avoid_print
@@ -485,10 +492,10 @@ class MessageRepositoryImpl implements MessageRepository {
       // Return as base64 for safe transmission
       final encryptedBase64 = base64.encode(encrypted);
       return (encryptedBase64, x3dhPrekey);
-    } catch (e) {
-      _logger.e('Encryption failed: $e. Sending plaintext.');
-      // Encryption failed, fall back to plaintext
-      return (plaintext, null);
+    } on Object catch (e) {
+      // Fail closed - see the session-creation branch above.
+      _logger.e('Encryption failed for $recipientUserId');
+      throw EncryptionUnavailableException('Could not encrypt the message: $e');
     }
   }
 

--- a/client-mobile/test/features/messaging/data/repositories/message_repository_impl_test.dart
+++ b/client-mobile/test/features/messaging/data/repositories/message_repository_impl_test.dart
@@ -1,7 +1,11 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:guardyn_client/core/crypto/crypto_service.dart';
+import 'package:guardyn_client/core/crypto/double_ratchet.dart';
 import 'package:guardyn_client/core/error/failures.dart';
 import 'package:guardyn_client/core/storage/secure_storage.dart';
 import 'package:guardyn_client/features/messaging/data/datasources/key_exchange_datasource.dart';
@@ -22,12 +26,19 @@ class MockSecureStorage extends Mock implements SecureStorage {}
 
 class MockCryptoService extends Mock implements CryptoService {}
 
+class MockDoubleRatchet extends Mock implements DoubleRatchet {}
+
 void main() {
   late MessageRepositoryImpl repository;
   late MockMessageRemoteDatasource mockDatasource;
   late MockKeyExchangeDatasource mockKeyExchangeDatasource;
   late MockSecureStorage mockSecureStorage;
   late MockCryptoService mockCryptoService;
+
+  setUpAll(() {
+    // `any(named: 'plaintext')` / `any(named: 'associatedData')` are Uint8List parameters.
+    registerFallbackValue(Uint8List(0));
+  });
 
   setUp(() {
     mockDatasource = MockMessageRemoteDatasource();
@@ -49,6 +60,7 @@ void main() {
   const tRecipientDeviceId = 'device-456';
   const tRecipientUsername = 'bob';
   const tTextContent = 'Hello, World!';
+  final tCiphertext = Uint8List.fromList(List.generate(64, (i) => i));
 
   final tMessageModel = MessageModel(
     messageId: 'msg-789',
@@ -101,13 +113,22 @@ void main() {
           .thenAnswer((_) async => tCurrentUserId);
       when(() => mockSecureStorage.getDeviceId())
           .thenAnswer((_) async => tCurrentDeviceId);
-      // E2EE: Return null session to trigger plaintext fallback (test simplicity)
+      // An established E2EE session. This used to stub `getSession` to null and let the
+      // plaintext fallback carry the test - which meant the suite asserted that an
+      // unencryptable message is sent in the clear.
+      final session = MockDoubleRatchet();
+      when(() => session.hasSendingChainKey).thenReturn(true);
       when(() => mockCryptoService.getSession(
             remoteUserId: any(named: 'remoteUserId'),
             remoteDeviceId: any(named: 'remoteDeviceId'),
-          )).thenAnswer((_) async => null);
-      // E2EE: Skip session creation for tests (would need KeyBundle mock)
-      when(() => mockCryptoService.isInitialized).thenReturn(false);
+          )).thenAnswer((_) async => session);
+      when(() => mockCryptoService.encrypt(
+            recipientUserId: any(named: 'recipientUserId'),
+            recipientDeviceId: any(named: 'recipientDeviceId'),
+            plaintext: any(named: 'plaintext'),
+            associatedData: any(named: 'associatedData'),
+          )).thenAnswer((_) async => tCiphertext);
+      when(() => mockCryptoService.isInitialized).thenReturn(true);
     }
 
     test('should return message when send is successful', () async {
@@ -133,17 +154,122 @@ void main() {
 
       // assert
       expect(result.isRight(), true);
-      // Called twice: once for sendMessage, once for E2EE session creation attempt
-      verify(() => mockSecureStorage.getAccessToken()).called(2);
+      verify(() => mockSecureStorage.getAccessToken()).called(1);
+      // What goes on the wire is the base64 ciphertext, never the plaintext. The previous
+      // version of this test asserted `textContent: tTextContent` - the plaintext - which is
+      // the behaviour the fallback produced.
       verify(() => mockDatasource.sendMessage(
             accessToken: tAccessToken,
             recipientUserId: tRecipientUserId,
             recipientDeviceId: tRecipientDeviceId,
             recipientUsername: tRecipientUsername,
-            textContent: tTextContent,
+            textContent: base64.encode(tCiphertext),
             metadata: any(named: 'metadata'),
             x3dhPrekey: any(named: 'x3dhPrekey'),
           )).called(1);
+    });
+
+    group('fails closed', () {
+      // I-2: encryption that can be skipped when inconvenient is not always-on encryption.
+      // These used to be the "plaintext fallback": the repository returned the unencrypted
+      // message, the datasource sent it, and sendMessage still returned Right() - so the UI
+      // showed an ordinary sent bubble and nothing anywhere said the message had left the
+      // device in the clear.
+
+      void expectNothingSent() {
+        verifyNever(() => mockDatasource.sendMessage(
+              accessToken: any(named: 'accessToken'),
+              recipientUserId: any(named: 'recipientUserId'),
+              recipientDeviceId: any(named: 'recipientDeviceId'),
+              recipientUsername: any(named: 'recipientUsername'),
+              textContent: any(named: 'textContent'),
+              metadata: any(named: 'metadata'),
+              x3dhPrekey: any(named: 'x3dhPrekey'),
+            ));
+      }
+
+      test('does not send when the ratchet fails to encrypt', () async {
+        setUpSuccessfulAuth();
+        when(() => mockCryptoService.encrypt(
+              recipientUserId: any(named: 'recipientUserId'),
+              recipientDeviceId: any(named: 'recipientDeviceId'),
+              plaintext: any(named: 'plaintext'),
+              associatedData: any(named: 'associatedData'),
+            )).thenThrow(Exception('ratchet unavailable'));
+
+        final result = await repository.sendMessage(
+          recipientUserId: tRecipientUserId,
+          recipientDeviceId: tRecipientDeviceId,
+          recipientUsername: tRecipientUsername,
+          textContent: tTextContent,
+        );
+
+        expect(result.isLeft(), isTrue);
+        result.fold(
+          (failure) => expect(failure, isA<CryptoFailure>()),
+          (_) => fail('a message that cannot be encrypted must not be sent'),
+        );
+        expectNothingSent();
+      });
+
+      test('does not send when no session can be established', () async {
+        setUpSuccessfulAuth();
+        // No existing session, and X3DH cannot complete.
+        when(() => mockCryptoService.getSession(
+              remoteUserId: any(named: 'remoteUserId'),
+              remoteDeviceId: any(named: 'remoteDeviceId'),
+            )).thenAnswer((_) async => null);
+        when(() => mockSecureStorage.getAccessToken())
+            .thenAnswer((_) async => tAccessToken);
+        when(() => mockKeyExchangeDatasource.getKeyBundle(
+              accessToken: any(named: 'accessToken'),
+              userId: any(named: 'userId'),
+              deviceId: any(named: 'deviceId'),
+            )).thenThrow(Exception('peer has no key bundle'));
+
+        final result = await repository.sendMessage(
+          recipientUserId: tRecipientUserId,
+          recipientDeviceId: tRecipientDeviceId,
+          recipientUsername: tRecipientUsername,
+          textContent: tTextContent,
+        );
+
+        expect(result.isLeft(), isTrue);
+        result.fold(
+          (failure) => expect(failure, isA<CryptoFailure>()),
+          (_) => fail('a message with no session must not be sent'),
+        );
+        expectNothingSent();
+      });
+
+      test('the plaintext never reaches the datasource', () async {
+        setUpSuccessfulAuth();
+        when(() => mockCryptoService.encrypt(
+              recipientUserId: any(named: 'recipientUserId'),
+              recipientDeviceId: any(named: 'recipientDeviceId'),
+              plaintext: any(named: 'plaintext'),
+              associatedData: any(named: 'associatedData'),
+            )).thenThrow(Exception('boom'));
+
+        await repository.sendMessage(
+          recipientUserId: tRecipientUserId,
+          recipientDeviceId: tRecipientDeviceId,
+          recipientUsername: tRecipientUsername,
+          textContent: tTextContent,
+        );
+
+        // Stated separately from expectNothingSent(): the property that matters is not merely
+        // "no call happened", it is "this string did not leave the device".
+        verifyNever(() => mockDatasource.sendMessage(
+              accessToken: any(named: 'accessToken'),
+              recipientUserId: any(named: 'recipientUserId'),
+              recipientDeviceId: any(named: 'recipientDeviceId'),
+              recipientUsername: any(named: 'recipientUsername'),
+              textContent: tTextContent,
+              metadata: any(named: 'metadata'),
+              x3dhPrekey: any(named: 'x3dhPrekey'),
+            ));
+      });
     });
 
     test('should return AuthFailure when no access token', () async {

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -128,7 +128,7 @@ steps:
   - {id: PR-73a, issue: 220, phase: 3, type: security, status: todo, title: "Implement PADME correctly in Dart"}
   - {id: PR-73b, issue: 222, phase: 3, type: security, status: todo, title: "Apply PADME padding on the mobile message path"}
   - {id: PR-74, issue: 224, phase: 3, type: fix, status: todo, title: "client-desktop - make the ratchet AAD symmetric"}
-  - {id: PR-75, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed instead of sending plaintext"}
+  - {id: PR-75, issue: 226, phase: 3, type: security, status: todo, title: "client-mobile - fail closed instead of sending plaintext"}
   - {id: PR-76, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - fail closed on group messaging"}
   - {id: PR-77, issue: null, phase: 3, type: security, status: todo, title: "client-mobile - refuse the native to Dart crypto downgrade"}
   - {id: PR-78, issue: 163, phase: 3, type: security, status: todo, title: "client-desktop - encrypt on the send path"}


### PR DESCRIPTION
Closes #226

## The breach

`message_repository_impl.dart` transmitted the message **in the clear** whenever encryption did
not work — twice:

```dart
// :458  X3DH session creation failed
_logger.w('Failed to create E2EE session: $e. Sending plaintext.');
return (plaintext, null);

// :487  the ratchet failed to encrypt
_logger.e('Encryption failed: $e. Sending plaintext.');
return (plaintext, null);
```

The plaintext then went to `remoteDatasource.sendMessage` exactly as ciphertext would have.

**And it was silent.** `sendMessage` returned `Right(completeMessage)` on both paths, so the UI
rendered an ordinary sent bubble. Nothing told the user — or the developer — that the message had
left the device unencrypted. The only trace was a log line.

A fallback that fires precisely when encryption is least healthy is a kill-switch nobody has to
remember to set. That is what I-2 forbids.

## The test suite had pinned the breach, not missed it

This is the part worth reading before reviewing the diff.

`message_repository_impl_test.dart` stubbed `getSession → null` with the comment:

```dart
// E2EE: Return null session to trigger plaintext fallback (test simplicity)
```

…and the "should return message when send is successful" case then asserted:

```dart
textContent: tTextContent,   // the PLAINTEXT
```

So the suite asserted that an unencryptable message **is sent in the clear**. Three tests
depended on that and failed the moment the fallback was removed.

They are **corrected, not deleted or skipped** (AGENTS.md §8): they now stub an established
session and assert that what reaches the datasource is the base64 ciphertext — which is what they
always claimed to be testing.

## The new tests assert the property that matters

Not "a failure was returned" — that is weaker than it looks. They assert **the plaintext never
reaches the datasource**:

```dart
verifyNever(() => mockDatasource.sendMessage(
      textContent: tTextContent,   // this string must not leave the device
      ...
    ));
```

Three cases: the ratchet fails to encrypt, no session can be established, and the explicit
"plaintext never leaves" check stated separately from "no call happened", because those are
different properties.

## Verification

```
flutter test                      639 pass, 4 skip, 0 fail   (was 636/4/0)
flutter analyze --no-fatal-infos  exit 0
rules-verify                      all checks passed
docs-verify                       all checks passed
budget                            4 files, 178 lines
```

## Deliberately out of scope

- **Receive-side masking** (`:577-580`, `:620-624`, `:368-372`): when decryption fails the
  repository returns the raw ciphertext *as message text*. That is a display problem rather than a
  leak, and it needs a decision about what an undecryptable message should look like — including
  l10n. Filed separately rather than guessed at here.
- **Group messages**, which are not encrypted at all (`group_remote_datasource.dart:226`). That is
  the larger half of the I-2 story on mobile and is its own step.
- The `enablePadme` config key.

**Behaviour change:** sending now *fails* where it previously succeeded-by-leaking. That is the
intent, and the UI surfaces `CryptoFailure` through the existing failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)