### PR TITLE
security(desktop): fail closed instead of sending plaintext

### DIFF
--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -626,40 +626,55 @@ fn message_associated_data(sender_user_id: &str, recipient_user_id: &str) -> Vec
     format!("{}|{}", sender_user_id, recipient_user_id).into_bytes()
 }
 
-/// Encrypt a message for a peer using Double Ratchet
-#[tauri::command]
-pub async fn encrypt_message(
-    plaintext: String,
-    recipient_id: String,
-    self_user_id: String,
-) -> Result<EncryptedMessage, String> {
-    tracing::debug!("Encrypting message for {} ({} bytes)", recipient_id, plaintext.len());
+/// Returned when a message cannot be encrypted, so callers can fail closed on it.
+///
+/// The desktop client must never fall back to transmitting plaintext: the server is a pure
+/// relay (see `docs/adr/ADR-0010-pure-relay-server.md`) and stores whatever it is handed
+/// byte-for-byte, so an unencrypted send is plaintext at rest, not merely plaintext in flight.
+pub const ENCRYPTION_UNAVAILABLE: &str = "encryption unavailable";
 
-    // Apply PADMÉ padding for traffic analysis protection
+/// Encrypt one message for a peer and return the serialized ciphertext.
+///
+/// This is the single encryption entry point for the send path. `encrypt_message` exposes it
+/// to the frontend and `commands::messaging::send_message` uses it directly, so neither can
+/// acquire a way to emit an unencrypted payload without the other noticing.
+///
+/// Returns an error beginning with [`ENCRYPTION_UNAVAILABLE`] when no Double Ratchet session
+/// exists for `recipient_id`. **That error must abort the send.** Today it is the only outcome,
+/// because nothing on the desktop establishes a session yet; the callers are nevertheless
+/// written against the real contract so that landing session establishment needs no change
+/// here.
+pub(crate) fn encrypt_for_peer(
+    plaintext: &str,
+    recipient_id: &str,
+    self_user_id: &str,
+) -> Result<Vec<u8>, String> {
+    // Apply PADMÉ padding for traffic analysis protection.
     let padded = guardyn_crypto::pad_message(plaintext.as_bytes())
         .map_err(|e| format!("Padding failed: {}", e))?;
 
-    // Get Double Ratchet for this peer
+    // Get Double Ratchet for this peer.
     let mut ratchet_store = RATCHET_STORE.lock().map_err(|e| e.to_string())?;
-    let ratchet = ratchet_store.get_mut(&recipient_id)
-        .ok_or_else(|| format!("No Double Ratchet session with peer: {}", recipient_id))?;
+    let ratchet = ratchet_store.get_mut(recipient_id).ok_or_else(|| {
+        format!("{}: no Double Ratchet session with peer {}", ENCRYPTION_UNAVAILABLE, recipient_id)
+    })?;
 
     // Encrypt with Double Ratchet. The local user is the sender.
-    let associated_data = message_associated_data(&self_user_id, &recipient_id);
-    let encrypted = ratchet.encrypt(&padded, &associated_data)
+    let associated_data = message_associated_data(self_user_id, recipient_id);
+    let encrypted = ratchet
+        .encrypt(&padded, &associated_data)
         .map_err(|e| format!("Double Ratchet encryption failed: {}", e))?;
 
-    // Serialize encrypted message
     let encrypted_bytes = encrypted.to_bytes();
     drop(ratchet_store);
 
-    // Update session metadata
+    // Update session metadata.
     let mut store = SESSION_STORE.lock().map_err(|e| e.to_string())?;
-    if let Some(session) = store.sessions.get_mut(&recipient_id) {
+    if let Some(session) = store.sessions.get_mut(recipient_id) {
         session.messages_sent += 1;
         // Update serialized ratchet state
         if let Ok(ratchet_store) = RATCHET_STORE.lock() {
-            if let Some(ratchet) = ratchet_store.get(&recipient_id) {
+            if let Some(ratchet) = ratchet_store.get(recipient_id) {
                 session.state = ratchet.serialize();
             }
         }
@@ -670,9 +685,26 @@ pub async fn encrypt_message(
     drop(store);
     persist_sessions(&sessions_clone)?;
 
+    Ok(encrypted_bytes)
+}
+
+/// Encrypt a message for a peer using Double Ratchet
+#[tauri::command]
+pub async fn encrypt_message(
+    plaintext: String,
+    recipient_id: String,
+    self_user_id: String,
+) -> Result<EncryptedMessage, String> {
+    tracing::debug!("Encrypting message for {} ({} bytes)", recipient_id, plaintext.len());
+
+    let encrypted_bytes = encrypt_for_peer(&plaintext, &recipient_id, &self_user_id)?;
+
     Ok(EncryptedMessage {
-        ciphertext: base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &encrypted_bytes),
-        nonce: String::new(), // Nonce is included in encrypted message
+        ciphertext: base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            &encrypted_bytes,
+        ),
+        nonce: String::new(),  // Nonce is included in encrypted message
         header: String::new(), // Header is included in encrypted message
     })
 }
@@ -1068,6 +1100,30 @@ mod tests {
         let encrypted = alice.encrypt(&padded, &alice_sends).unwrap();
         let out = bob.decrypt(&encrypted, &bob_receives).unwrap();
         assert_eq!(guardyn_crypto::unpad_message(&out).unwrap(), b"hello bob");
+    }
+
+    #[test]
+    fn encrypt_for_peer_refuses_when_there_is_no_session() {
+        // The #163 regression test. Before the fix the send path did not consult the ratchet at
+        // all - it assigned `content.as_bytes().to_vec()` and sent it - so a peer with no
+        // session produced a perfectly successful "encrypted" send carrying plaintext.
+        //
+        // A peer id that cannot collide with anything another test established, because
+        // RATCHET_STORE is process-global.
+        let peer = "no-session-peer-e6f1a4c2";
+
+        let result = encrypt_for_peer("attack at dawn", peer, "self-user");
+
+        let err = result.expect_err("a send with no session must fail, never fall back to plaintext");
+        assert!(
+            err.starts_with(ENCRYPTION_UNAVAILABLE),
+            "callers fail closed by matching on this prefix, so it is part of the contract; got: {}",
+            err
+        );
+        assert!(
+            !err.contains("attack at dawn"),
+            "the error must not carry the plaintext it refused to send"
+        );
     }
 
     #[test]

--- a/client-desktop/src-tauri/src/commands/messaging.rs
+++ b/client-desktop/src-tauri/src/commands/messaging.rs
@@ -78,12 +78,26 @@ pub async fn send_message(
         request.recipient_id
     );
 
-    // Encrypt message content using Double Ratchet
-    // In a real implementation, we would:
-    // 1. Get or create a Double Ratchet session for this conversation
-    // 2. Apply PADMÉ padding to the message
-    // 3. Encrypt with the session
-    let encrypted_content = request.content.as_bytes().to_vec();
+    // Encrypt, or refuse to send.
+    //
+    // This previously assigned `request.content.as_bytes().to_vec()` - the plaintext, into a
+    // field named `encrypted_content` (#163). That was survivable only while the server
+    // encrypted on the client's behalf, and it stopped doing so when the E2EE handler fork was
+    // removed: `messaging-service` now stores what it is handed byte-for-byte, so the plaintext
+    // was reaching ScyllaDB in the clear.
+    //
+    // There is no fallback branch here on purpose. Invariant I-2 is that encryption cannot be
+    // turned off, which means the only correct behaviour when it is unavailable is to refuse,
+    // exactly as `client-mobile` now does (#226).
+    let self_user_id = state
+        .user_id()
+        .ok_or_else(|| "Not authenticated: no local user id".to_string())?;
+    let encrypted_content =
+        crate::commands::crypto::encrypt_for_peer(&request.content, &request.recipient_id, &self_user_id)
+            .map_err(|e| {
+                tracing::warn!("Refusing to send: {}", e);
+                format!("Failed to send message: {}", e)
+            })?;
 
     // Create outgoing message - use recipient_id (user ID), not conversation_id
     let outgoing = OutgoingMessage {
@@ -101,7 +115,7 @@ pub async fn send_message(
             let message = Message {
                 id: result.message_id,
                 conversation_id: request.conversation_id,
-                sender_id: state.user_id().unwrap_or_default(),
+                sender_id: self_user_id,
                 content: request.content,
                 timestamp: result.server_timestamp,
                 status: match result.delivery_status {

--- a/client-desktop/src/pages/Chat.test.tsx
+++ b/client-desktop/src/pages/Chat.test.tsx
@@ -4,9 +4,31 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Conversation, Message } from '../types';
 
 // Create hoisted mock that can be used by vi.mock
-const { mockInvoke } = vi.hoisted(() => ({
-  mockInvoke: vi.fn(),
-}));
+const { mockInvoke, mockWs, mockEncryptMessage } = vi.hoisted(() => {
+  const ws = {
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    send: vi.fn(),
+    sendMessage: vi.fn(),
+    sendTyping: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    // Chat.tsx registers these in onMount; capture the state callback so a test can bring
+    // the socket up and actually exercise the send path.
+    onStateChange: vi.fn((cb: (state: string) => void) => {
+      ws._stateCb = cb;
+    }),
+    onMessage: vi.fn(),
+    onTyping: vi.fn(),
+    isConnected: false,
+    _stateCb: undefined as ((state: string) => void) | undefined,
+  };
+  return {
+    mockInvoke: vi.fn(),
+    mockWs: ws,
+    mockEncryptMessage: vi.fn(),
+  };
+});
 
 // Mock Tauri API using hoisted mock
 vi.mock('@tauri-apps/api/core', () => ({
@@ -21,16 +43,16 @@ vi.mock('../api/websocket', () => ({
     TYPING_STOP: 'TYPING_STOP',
     PRESENCE_UPDATE: 'PRESENCE_UPDATE',
   },
-  initWebSocket: vi.fn(),
-  getWebSocket: vi.fn(() => ({
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-    send: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn(),
-    isConnected: false,
-  })),
+  initWebSocket: vi.fn(() => mockWs),
+  getWebSocket: vi.fn(() => mockWs),
   destroyWebSocket: vi.fn(),
+}));
+
+// The send path now runs through the encryption manager, and must refuse when it throws.
+vi.mock('../services/encryption', () => ({
+  encryptionManager: {
+    encryptMessage: (...args: unknown[]) => mockEncryptMessage(...args),
+  },
 }));
 
 vi.mock('../api/websocket.mock', () => ({
@@ -108,7 +130,10 @@ describe('Chat Page', () => {
   };
 
   beforeEach(() => {
-    mockInvoke.mockClear();
+    mockInvoke.mockReset();
+    mockWs.sendMessage.mockClear();
+    mockWs._stateCb = undefined;
+    mockEncryptMessage.mockReset();
     resetMessageStore();
   });
 
@@ -220,49 +245,73 @@ describe('Chat Page', () => {
     });
   });
 
-  it('sends a new message', async () => {
-    setupMockInvoke(
-      mockConversations,  // get_conversations
-      mockMessages,       // get_messages
-      undefined,          // send_message
-      [...mockMessages, { // get_messages after send
-        id: 'msg-3',
-        conversation_id: 'conv-1',
-        sender_id: 'user-1',
-        content: 'New message',
-        timestamp: Date.now(),
-        status: 'Sending',
-        reactions: [],
-      }],
-    );
+  // These two replace a test named "sends a new message", which asserted
+  //
+  //     expect(mockInvoke).toHaveBeenCalledWith('send_message', {
+  //       conversationId: 'conv-1', recipientId: 'user-1', content: 'New message', ...
+  //     })
+  //
+  // - that is, it pinned #163: it required the plaintext to be handed to the transport, and
+  // would have failed had the client started encrypting. A test that enforces the defect has
+  // to be corrected rather than kept, the same way #227 corrected the mobile equivalent.
 
+  const openAliceAndType = async (text: string) => {
     renderWithRouter(() => <Chat />);
 
     await waitFor(() => {
       expect(screen.getByText('Alice')).toBeInTheDocument();
     });
 
-    const aliceConv = screen.getByText('Alice').closest('button');
-    await fireEvent.click(aliceConv!);
+    await fireEvent.click(screen.getByText('Alice').closest('button')!);
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
     });
 
-    const messageInput = screen.getByPlaceholderText('Type a message...') as HTMLInputElement;
-    const sendButton = screen.getByRole('button', { name: /send message/i });
+    // Bring the socket up, as onStateChange would at runtime.
+    mockWs._stateCb?.('connected');
 
-    await fireEvent.input(messageInput, { target: { value: 'New message' } });
-    await fireEvent.click(sendButton);
+    const messageInput = screen.getByPlaceholderText('Type a message...') as HTMLInputElement;
+    await fireEvent.input(messageInput, { target: { value: text } });
+    await fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+  };
+
+  it('sends ciphertext, never the plaintext', async () => {
+    setupMockInvoke(mockConversations, mockMessages, undefined, mockMessages);
+    mockEncryptMessage.mockResolvedValue({ ciphertext: 'AQIDBA==', nonce: '', header: '' });
+
+    await openAliceAndType('New message');
 
     await waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith('send_message', {
-        conversationId: 'conv-1',
-        recipientId: 'user-1',
-        content: 'New message',
-        mediaId: undefined,
-      });
+      expect(mockWs.sendMessage).toHaveBeenCalled();
     });
+
+    const [recipientId, payload, options] = mockWs.sendMessage.mock.calls[0];
+    expect(recipientId).toBe('user-1');
+    expect(payload).toBe('AQIDBA==');
+    expect(payload).not.toBe('New message');
+    expect(options.encrypted).toBe(true);
+
+    // The plaintext must not reach the transport by any route, including the gRPC command
+    // that used to be invoked alongside the socket.
+    expect(mockInvoke).not.toHaveBeenCalledWith('send_message', expect.anything());
+    expect(JSON.stringify(mockWs.sendMessage.mock.calls)).not.toContain('New message');
+  });
+
+  it('refuses to send when encryption is unavailable', async () => {
+    setupMockInvoke(mockConversations, mockMessages, undefined, mockMessages);
+    mockEncryptMessage.mockRejectedValue(
+      new Error('No established session with peer: user-1')
+    );
+
+    await openAliceAndType('New message');
+
+    // Fail closed: nothing leaves the client at all.
+    await waitFor(() => {
+      expect(mockEncryptMessage).toHaveBeenCalled();
+    });
+    expect(mockWs.sendMessage).not.toHaveBeenCalled();
+    expect(mockInvoke).not.toHaveBeenCalledWith('send_message', expect.anything());
   });
 
   // TODO: Fix these tests after WebSocket integration stabilizes

--- a/client-desktop/src/pages/Chat.tsx
+++ b/client-desktop/src/pages/Chat.tsx
@@ -7,6 +7,7 @@ import { stopMockGenerator } from '../api/websocket.mock';
 import { ForwardModal, MessageInput, MessageStatusIndicator, QuotedMessage, ReactionMenu } from '../components/chat';
 import { TypingIndicator } from '../components/shared';
 import { CallAudioService } from '../services/callAudioService';
+import { encryptionManager } from '../services/encryption';
 import {
   addMessage,
   addTypingUser,
@@ -21,6 +22,7 @@ import {
   setActiveConversation,
   setReplyingTo,
   toggleReaction,
+  updateMessageStatus,
   type Message as StoreMessage
 } from '../stores/messageStore';
 import type { Conversation } from '../types';
@@ -33,6 +35,8 @@ const Chat: Component<ChatPageProps> = () => {
   const [selectedConversation, setSelectedConversation] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(true);
   const [isConnected, setIsConnected] = createSignal(false);
+  // The local user id, needed to build the message AAD: utf8("{sender}|{recipient}").
+  const [selfUserId, setSelfUserId] = createSignal<string | null>(null);
 
   // Reaction menu state
   const [reactionMenu, setReactionMenu] = createSignal<{
@@ -79,6 +83,8 @@ const Chat: Component<ChatPageProps> = () => {
         device_id: string | null;
         user_id: string | null;
       }>('get_ws_config');
+
+      setSelfUserId(wsConfig.user_id);
 
       console.log('[Chat] WebSocket config:', {
         url: wsConfig.url,
@@ -262,26 +268,49 @@ const Chat: Component<ChatPageProps> = () => {
       clearReplyingTo();
     }
 
+    // Encrypt, or do not send. The server is a pure relay (ADR-0010): it stores whatever it
+    // receives byte-for-byte, so sending unencrypted here writes plaintext to ScyllaDB. This
+    // path used to pass `content` straight to the socket with `encrypted: false` (#163).
+    //
+    // No session can be established on the desktop yet, so today this always refuses. That is
+    // the intended behaviour: invariant I-2 says encryption cannot be turned off, so an
+    // unavailable session must stop the send rather than downgrade it.
+    let ciphertext: string;
     try {
-      // Send via WebSocket - use recipientId, not convId
-      const ws = getWebSocket();
-      if (ws && isConnected()) {
-        ws.sendMessage(recipientId, content, {
-          clientMessageId: messageId,
-          mediaId,
-          recipientUsername,
-        });
+      const self = selfUserId();
+      if (!self) {
+        throw new Error('no local user id; cannot build the message associated data');
       }
+      const encrypted = await encryptionManager.encryptMessage(recipientId, content, self);
+      ciphertext = encrypted.ciphertext;
+    } catch (err) {
+      console.error('[Chat] Refusing to send: encryption unavailable:', err);
+      updateMessageStatus(convId, messageId, 'failed');
+      return;
+    }
 
-      // Also send via Tauri backend
-      await invoke('send_message', {
-        conversationId: convId,
-        recipientId: recipientId,
-        content,
+    try {
+      // Send via WebSocket - use recipientId, not convId.
+      //
+      // This is the only send transport. There was a second one directly below - an
+      // `invoke('send_message')` on the gRPC command - which would have stored the same
+      // message twice: the WebSocket handler persists to ScyllaDB itself
+      // (`messaging-service/src/websocket/handlers.rs`, store_message_in_db) before fanning
+      // out over NATS. It never actually double-stored only because the invoke passed
+      // arguments the Rust signature could not deserialize, so it threw every time.
+      const ws = getWebSocket();
+      if (!ws || !isConnected()) {
+        throw new Error('WebSocket is not connected');
+      }
+      ws.sendMessage(recipientId, ciphertext, {
+        encrypted: true,
+        clientMessageId: messageId,
         mediaId,
+        recipientUsername,
       });
     } catch (err) {
       console.error('Failed to send message:', err);
+      updateMessageStatus(convId, messageId, 'failed');
     }
   };
 

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -29,7 +29,7 @@ project_sync_enabled: true
 
 invariants:
   - {id: I-1, name: Zero-Knowledge,   met: partial, note: "rate_limit.rs logs a raw IP; span fields are not redacted"}
-  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78], note: "server side is done and no longer reads the flags, so PR-32c is unblocked; client-desktop still sends plaintext (PR-78) and client-mobile still sends groups in the clear (PR-76)"}
+  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78], note: "server side is done and no longer reads the flags, so PR-32c is unblocked; both clients now refuse rather than send plaintext one-to-one, but client-mobile still sends groups in the clear (PR-76) and desktop cannot yet establish a session (PR-79..PR-81)"}
   - {id: I-3, name: Post-Quantum,     met: false,   closed_by: [PR-36, PR-37, PR-38, PR-39, PR-40]}
   - {id: I-4, name: Data Sovereignty, met: partial, note: "envoy/ingress.yaml hardcodes a domain"}
 
@@ -138,7 +138,7 @@ steps:
   - {id: PR-75, issue: 226, phase: 3, type: security, status: done, title: "client-mobile - fail closed instead of sending plaintext"}
   - {id: PR-76, issue: 229, phase: 3, type: security, status: todo, title: "client-mobile - fail closed on group messaging"}
   - {id: PR-77, issue: 230, phase: 3, type: security, status: todo, title: "client-mobile - refuse the native to Dart crypto downgrade"}
-  - {id: PR-78, issue: 163, phase: 3, type: security, status: todo, title: "client-desktop - encrypt on the send path"}
+  - {id: PR-78, issue: 163, phase: 3, type: security, status: done, title: "client-desktop - encrypt on the send path"}
   - {id: PR-79, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - retain private prekey material"}
   - {id: PR-80, issue: null, phase: 3, type: feat, status: todo, title: "client-desktop - implement the X3DH responder path"}
   - {id: PR-81, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - restore the ratchet store from persisted state"}


### PR DESCRIPTION
Closes #163

## The premise in #163 has expired, and that makes this urgent

#163 argued the breach was survivable because *"production sets `GUARDYN_E2EE_ENABLED=true`, so
the server encrypts what it receives... its content is encrypted at rest — with a key the server
holds."*

**The server stopped doing that.** PR-32a/32b removed the E2EE handler fork:

```
$ grep -rn "e2ee_enabled\|E2eeConfig\|MlsConfig" backend/crates/messaging-service/src backend/crates/common/src
(no output)
```

`send_message.rs:76` stores `request.encrypted_content` verbatim, and the WebSocket handler
persists too (`websocket/handlers.rs`, `store_message_in_db`) before fanning out over NATS. So
desktop plaintext has been landing in ScyllaDB **in the clear**, on `main`, not encrypted under a
server-held key.

## What was sending plaintext

Two paths, both of them:

```rust
// commands/messaging.rs:86
let encrypted_content = request.content.as_bytes().to_vec();
```

```ts
// Chat.tsx:268 -> websocket.types.ts:425
ws.sendMessage(recipientId, content, { ... });   // encrypted: false
```

## The fix

Encryption is now the only way out of this client. There is **no fallback branch** — I-2 says
encryption cannot be turned off, so an unavailable session must stop the send, exactly as
`client-mobile` adopted in #226.

The logic moves into `encrypt_for_peer`, a single entry point shared by the `encrypt_message`
Tauri command and the gRPC send path, so neither can regain a way to emit an unencrypted payload
without the other seeing it. PADMÉ is applied there and not duplicated.

### The regression this causes, deliberately

Nothing on the desktop establishes a session yet — `establishSession` has zero callers,
`respond_x3dh` is not registered, prekey privates are discarded, and `RATCHET_STORE` is never
rehydrated. **So this currently refuses every one-to-one send.** That was signed off: a client
that cannot send is recoverable; a conversation stored in the clear is not. PR-79…PR-81 are the
fast-follow.

The user is not left guessing — the optimistic message is marked `failed` rather than left
spinning at `sending`.

## The second send transport is removed

`Chat.tsx` invoked `send_message` over gRPC *alongside* the socket. Since the WebSocket handler
persists the message itself, that would have stored every message twice. It never actually did,
only because the invoke passed `{conversationId, recipientId, content, mediaId}` while the Rust
signature takes a single `request` — so it threw on every send and the error was swallowed by the
surrounding `catch`. The socket is now the single transport.

## A test that pinned the defect

```ts
expect(mockInvoke).toHaveBeenCalledWith('send_message', {
  conversationId: 'conv-1', recipientId: 'user-1', content: 'New message', ...
});
```

This **required** the plaintext to reach the transport and would have failed the moment the client
started encrypting. Per AGENTS.md §8 I am flagging it explicitly rather than quietly deleting it:
the test enforced the bug, so it is corrected, the same way #227 corrected the mobile equivalent.

Two replace it:

- `sends ciphertext, never the plaintext` — asserts the payload is the ciphertext, `encrypted:
  true` is set, and `'New message'` appears nowhere in the call arguments.
- `refuses to send when encryption is unavailable` — asserts neither transport is invoked at all.

Plus a Rust regression test, `encrypt_for_peer_refuses_when_there_is_no_session`, which also
asserts the error does not carry the plaintext it refused to send.

## Verification

```
cargo test --all-features   50 passed / 51 passed, 0 failed
npx vitest run              28 files, 411 passed, 17 skipped
npx tsc --noEmit            clean
npm run lint                0 errors
just rules-verify           all checks passed
```

## docs-impact:none — reason

`docs/.manifest.yaml` maps no document to `client-desktop/`. The architecture this implements is
already recorded in `ADR-0010` (pure relay) and `ADR-0011` (wire format); this PR makes the client
conform to them and changes neither.

## Deliberately out of scope

- **The receive path.** `messaging.rs:187` still does `String::from_utf8_lossy` and `Chat.tsx`
  still stores `data.content` undecrypted. That is #232, kept separate so a receive-path UI
  decision does not ride along with a send-path security fix.
- **Session establishment** — PR-79 (retain prekey privates), PR-80 (X3DH responder), PR-81
  (ratchet rehydration).
- `client-desktop/src-tauri/src/proto/guardyn.media.rs`, which the build rewrites on every run.
  That is #188 and is reverted out of this diff rather than smuggled in.

## Budget

5 files, 312 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
