### PR TITLE
security(mobile): fail closed on group messaging

### DIFF
--- a/client-mobile/lib/features/groups/data/datasources/group_remote_datasource.dart
+++ b/client-mobile/lib/features/groups/data/datasources/group_remote_datasource.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 import 'package:injectable/injectable.dart';
-import 'package:uuid/uuid.dart';
 
 import '../../../../core/network/grpc_clients.dart';
 import '../../../../generated/common.pb.dart' as proto_common;
@@ -16,7 +15,6 @@ import '../models/group_model.dart';
 @injectable
 class GroupRemoteDatasource {
   final GrpcClients _grpcClients;
-  final _uuid = const Uuid();
 
   GroupRemoteDatasource(this._grpcClients);
 
@@ -203,51 +201,13 @@ class GroupRemoteDatasource {
     );
   }
 
-  /// Send a message to a group via gRPC
-  Future<GroupMessageModel> sendGroupMessage({
-    required String accessToken,
-    required String groupId,
-    required String textContent,
-    required String currentUserId,
-    Map<String, String>? metadata,
-    proto.MessageType messageType = proto.MessageType.TEXT,
-  }) async {
-    final clientMessageId = _uuid.v4();
-    final clientTimestamp = DateTime.now();
-
-    // Determine message type based on metadata
-    final actualMessageType = metadata != null && metadata['media_id'] != null
-        ? proto.MessageType.IMAGE  // Use IMAGE for media messages
-        : messageType;
-
-    final request = proto.SendGroupMessageRequest(
-      accessToken: accessToken,
-      groupId: groupId,
-      encryptedContent: utf8.encode(textContent),
-      messageType: actualMessageType,
-      clientMessageId: clientMessageId,
-      clientTimestamp: _createTimestamp(clientTimestamp),
-    );
-
-    final response = await _messagingClient.sendGroupMessage(request);
-
-    if (response.hasError()) {
-      throw GrpcError.custom(response.error.code.value, response.error.message);
-    }
-
-    return GroupMessageModel(
-      messageId: response.success.messageId,
-      groupId: groupId,
-      senderUserId: currentUserId,
-      senderDeviceId: '', // Will be filled by repository
-      senderUsername: '', // Will be filled by repository
-      messageType: _messageTypeFromProto(messageType),
-      textContent: textContent,
-      clientTimestamp: clientTimestamp,
-      serverTimestamp: _timestampFromProto(response.success.serverTimestamp),
-      currentUserId: currentUserId,
-    );
-  }
+  // GroupRemoteDatasource.sendGroupMessage was removed here.
+  //
+  // It built `encryptedContent: utf8.encode(textContent)` - the plaintext, in the field
+  // named for ciphertext - and since the server became a pure relay it stored exactly those
+  // bytes. With GroupRepositoryImpl.sendGroupMessage now refusing, this had no caller left,
+  // and a method that assembles a plaintext group send is a defect one call site away from
+  // returning. Whichever step implements MLS reintroduces it emitting real ciphertext.
 
   /// Get group messages via gRPC
   Future<List<GroupMessageModel>> getGroupMessages({

--- a/client-mobile/lib/features/groups/data/repositories/group_repository_impl.dart
+++ b/client-mobile/lib/features/groups/data/repositories/group_repository_impl.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:dartz/dartz.dart';
 import 'package:grpc/grpc.dart';
 import 'package:injectable/injectable.dart';
@@ -150,6 +148,22 @@ class GroupRepositoryImpl implements GroupRepository {
     }
   }
 
+  /// Refuses to send. This client cannot encrypt a group message.
+  ///
+  /// There is no MLS implementation on mobile: `GroupRemoteDatasource.sendGroupMessage` put
+  /// `utf8.encode(textContent)` straight into the field named `encryptedContent`, and this
+  /// repository has no [CryptoService] injected at all - unlike the one-to-one
+  /// `MessageRepositoryImpl`, which does.
+  ///
+  /// While the server encrypted on the client's behalf that was merely dishonest. It is now a
+  /// pure relay (`docs/adr/ADR-0010-pure-relay-server.md`) and stores what it is handed
+  /// byte-for-byte, so every group message was plaintext at rest - beneath a chat header that
+  /// displayed an "MLS" badge claiming the opposite.
+  ///
+  /// Invariant I-2 is that encryption cannot be turned off, so the only correct behaviour is to
+  /// refuse, exactly as the one-to-one path now does (#226). Restoring the send is the job of
+  /// whichever step implements MLS; until then this failure is the honest answer, and the
+  /// group UI reports `E2EEStatus.notEncrypted` to match.
   @override
   Future<Either<Failure, GroupMessage>> sendGroupMessage({
     required String groupId,
@@ -157,58 +171,12 @@ class GroupRepositoryImpl implements GroupRepository {
     GroupMessageType messageType = GroupMessageType.text,
     Map<String, String>? metadata,
   }) async {
-    try {
-      final accessToken = await _getAccessToken();
-      if (accessToken == null) {
-        return const Left(AuthFailure('Not authenticated'));
-      }
-
-      final currentUserId = await _getCurrentUserId();
-      if (currentUserId == null) {
-        return const Left(AuthFailure('User ID not found'));
-      }
-
-      final currentDeviceId = await _getCurrentDeviceId();
-      final username = await _secureStorage.getUsername();
-
-      // For media messages with empty textContent, create JSON with media metadata
-      String contentToSend = textContent;
-      if (textContent.isEmpty && metadata != null && metadata['media_id'] != null) {
-        contentToSend = json.encode({
-          'type': 'media',
-          'media_id': metadata['media_id'],
-          'media_type': metadata['media_type'] ?? 'image',
-          'filename': metadata['filename'] ?? '',
-          'mime_type': metadata['mime_type'] ?? '',
-        });
-      }
-
-      final message = await _remoteDatasource.sendGroupMessage(
-        accessToken: accessToken,
-        groupId: groupId,
-        textContent: contentToSend,
-        currentUserId: currentUserId,
-        metadata: metadata,
-      );
-
-      // Return message with complete user info
-      return Right(GroupMessageModel(
-        messageId: message.messageId,
-        groupId: message.groupId,
-        senderUserId: currentUserId,
-        senderDeviceId: currentDeviceId ?? '',
-        senderUsername: username ?? currentUserId,
-        messageType: message.messageType,
-        textContent: textContent,
-        clientTimestamp: message.clientTimestamp,
-        serverTimestamp: message.serverTimestamp,
-        currentUserId: currentUserId,
-      ));
-    } on GrpcError catch (e) {
-      return Left(ServerFailure(e.message ?? 'Failed to send group message'));
-    } catch (e) {
-      return Left(UnknownFailure(e.toString()));
-    }
+    return const Left(
+      CryptoFailure(
+        'Group encryption is unavailable: this client has no MLS implementation, '
+        'so sending would transmit the message unencrypted.',
+      ),
+    );
   }
 
   @override

--- a/client-mobile/lib/features/groups/presentation/pages/group_chat_page.dart
+++ b/client-mobile/lib/features/groups/presentation/pages/group_chat_page.dart
@@ -235,11 +235,16 @@ class _GroupChatPageState extends State<GroupChatPage> {
                 ],
               ),
               actions: [
-                // E2EE indicator showing MLS encryption
+                // Group messages are NOT encrypted: this client has no MLS implementation,
+                // and GroupRepositoryImpl.sendGroupMessage now refuses rather than transmit
+                // them in the clear. This badge claimed mlsEncrypted, which was the opposite
+                // of the truth and is the more dangerous half of the defect - an unprotected
+                // channel a user knows about is survivable, one they are told is protected is
+                // not. It goes back to mlsEncrypted when MLS actually lands.
                 const Padding(
                   padding: EdgeInsets.only(right: 8),
                   child: E2EEIndicator(
-                    status: E2EEStatus.mlsEncrypted,
+                    status: E2EEStatus.notEncrypted,
                     showLabel: false,
                     size: 20,
                   ),

--- a/client-mobile/lib/features/groups/presentation/pages/group_info_page.dart
+++ b/client-mobile/lib/features/groups/presentation/pages/group_info_page.dart
@@ -319,15 +319,17 @@ class _GroupInfoPageState extends State<GroupInfoPage> {
           ),
           const SizedBox(height: AppSpacing.space2),
 
-          // MLS Encryption Badge
+          // Encryption badge. Reports the real state, which is that group messages are not
+          // encrypted on this client - see GroupRepositoryImpl.sendGroupMessage. The success
+          // colouring goes with it: a warning surface must not be tinted as reassurance.
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             decoration: BoxDecoration(
-              color: SemanticColors.success.withValues(alpha: 0.1),
+              color: SemanticColors.warning.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(16),
             ),
             child: const E2EEIndicator(
-              status: E2EEStatus.mlsEncrypted,
+              status: E2EEStatus.notEncrypted,
               showLabel: true,
               size: 14,
             ),

--- a/client-mobile/test/features/groups/data/repositories/group_repository_impl_test.dart
+++ b/client-mobile/test/features/groups/data/repositories/group_repository_impl_test.dart
@@ -243,96 +243,62 @@ void main() {
   });
 
   group('sendGroupMessage', () {
-    test('returns GroupMessage when datasource call is successful', () async {
-      // Arrange
-      setUpAuthenticatedUser();
-      when(() => mockDatasource.sendGroupMessage(
-            accessToken: tAccessToken,
-            groupId: tGroupId,
-            textContent: 'Hello group!',
-            currentUserId: tUserId,
-          )).thenAnswer((_) async => tMessageModel);
+    // These replace four tests that assumed the send worked. The first of them asserted
+    //
+    //     expect(message.textContent, 'Hello group!');
+    //
+    // after stubbing the datasource to echo it back - so it pinned the plaintext round-trip
+    // rather than catching it, exactly as the one-to-one test did before #226. A test that
+    // requires the defective behaviour has to be corrected, not kept.
+    //
+    // The authentication cases went with them: the repository now refuses before it looks at
+    // credentials, because whether the user is signed in has no bearing on the fact that this
+    // client cannot encrypt a group message.
 
-      // Act
+    test('refuses with CryptoFailure and sends nothing', () async {
+      setUpAuthenticatedUser();
+
       final result = await repository.sendGroupMessage(
         groupId: tGroupId,
         textContent: 'Hello group!',
       );
 
-      // Assert
-      expect(result.isRight(), true);
+      expect(result.isLeft(), true);
       result.fold(
-        (failure) => fail('Expected Right but got Left'),
-        (message) {
-          expect(message.textContent, 'Hello group!');
-          expect(message.groupId, tGroupId);
+        (failure) {
+          expect(failure, isA<CryptoFailure>());
+          expect(failure.message, contains('unavailable'));
         },
+        (_) => fail('a group message must not be sent while it cannot be encrypted'),
       );
     });
 
-    test('returns AuthFailure when not authenticated', () async {
-      // Arrange
+    test('refuses even when authenticated and the transport is healthy', () async {
+      // The point of fail-closed: nothing about the environment being fine makes an
+      // unencrypted send acceptable.
+      setUpAuthenticatedUser();
+
+      final result = await repository.sendGroupMessage(
+        groupId: tGroupId,
+        textContent: 'Hello group!',
+      );
+
+      expect(result.isLeft(), true);
+      verifyZeroInteractions(mockDatasource);
+    });
+
+    test('refuses when unauthenticated too', () async {
       setUpUnauthenticatedUser();
 
-      // Act
       final result = await repository.sendGroupMessage(
         groupId: tGroupId,
         textContent: 'Hello!',
       );
 
-      // Assert
       expect(result.isLeft(), true);
-      result.fold(
-        (failure) => expect(failure, isA<AuthFailure>()),
-        (_) => fail('Expected Left but got Right'),
-      );
-    });
-
-    test('returns AuthFailure when user ID is null', () async {
-      // Arrange
-      when(() => mockSecureStorage.getAccessToken())
-          .thenAnswer((_) async => tAccessToken);
-      when(() => mockSecureStorage.getUserId()).thenAnswer((_) async => null);
-
-      // Act
-      final result = await repository.sendGroupMessage(
-        groupId: tGroupId,
-        textContent: 'Hello!',
-      );
-
-      // Assert
-      expect(result.isLeft(), true);
-      result.fold(
-        (failure) => expect(failure, isA<AuthFailure>()),
-        (_) => fail('Expected Left but got Right'),
-      );
-    });
-
-    test('returns ServerFailure when GrpcError occurs', () async {
-      // Arrange
-      setUpAuthenticatedUser();
-      when(() => mockDatasource.sendGroupMessage(
-            accessToken: tAccessToken,
-            groupId: tGroupId,
-            textContent: 'Hello!',
-            currentUserId: tUserId,
-          )).thenThrow(GrpcError.unavailable('Server unavailable'));
-
-      // Act
-      final result = await repository.sendGroupMessage(
-        groupId: tGroupId,
-        textContent: 'Hello!',
-      );
-
-      // Assert
-      expect(result.isLeft(), true);
-      result.fold(
-        (failure) => expect(failure, isA<ServerFailure>()),
-        (_) => fail('Expected Left but got Right'),
-      );
+      verifyZeroInteractions(mockDatasource);
     });
   });
-
   group('getGroupMessages', () {
     test('returns list of messages when datasource call is successful',
         () async {

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -136,7 +136,7 @@ steps:
   - {id: PR-73b, issue: 222, phase: 3, type: security, status: done, title: "Apply PADME padding on the mobile message path"}
   - {id: PR-74, issue: 224, phase: 3, type: fix, status: done, title: "client-desktop - make the ratchet AAD symmetric"}
   - {id: PR-75, issue: 226, phase: 3, type: security, status: done, title: "client-mobile - fail closed instead of sending plaintext"}
-  - {id: PR-76, issue: 229, phase: 3, type: security, status: todo, title: "client-mobile - fail closed on group messaging"}
+  - {id: PR-76, issue: 229, phase: 3, type: security, status: done, title: "client-mobile - fail closed on group messaging"}
   - {id: PR-77, issue: 230, phase: 3, type: security, status: todo, title: "client-mobile - refuse the native to Dart crypto downgrade"}
   - {id: PR-78, issue: 163, phase: 3, type: security, status: todo, title: "client-desktop - encrypt on the send path"}
   - {id: PR-79, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - retain private prekey material"}
@@ -153,3 +153,4 @@ steps:
   - {id: PR-86, issue: 228, phase: 3, type: chore, status: done, title: "Reconcile roadmap status so roadmap-sync stops reopening issues"}
   - {id: PR-87, issue: 231, phase: 3, type: fix, status: todo, title: "client-mobile - show an explicit cannot-decrypt placeholder"}
   - {id: PR-88, issue: 232, phase: 3, type: fix, status: todo, title: "client-desktop - show an explicit cannot-decrypt placeholder"}
+  - {id: PR-89, issue: 235, phase: 3, type: fix, status: todo, title: "group_chat_page_test renders a replica of the page, not the page"}


### PR DESCRIPTION
Closes #229

## The breach

```dart
// group_remote_datasource.dart:226
encryptedContent: utf8.encode(textContent),
```

A field named for ciphertext, receiving the plaintext. There is no MLS on this client —
`grep -rni "mls|sender_key"` over `lib/` returns no implementation — and `GroupRepositoryImpl`
has no `CryptoService` injected at all, unlike the one-to-one `MessageRepositoryImpl`.

While the server encrypted on the client's behalf this was merely dishonest. Since
[ADR-0010](docs/adr/ADR-0010-pure-relay-server.md) made it a pure relay it stores those bytes
verbatim, so **every group message was plaintext at rest**.

## The worse half

The chat header hardcoded `E2EEStatus.mlsEncrypted`, tooltip: *"Group messages are end-to-end
encrypted using MLS (RFC 9420)"*. `group_info_page.dart` repeated it, tinted
`SemanticColors.success`.

An unprotected channel a user knows about is survivable. One they are told is protected is not —
they will say things they would not otherwise say. Both badges now report `notEncrypted`, and the
info badge loses the success-green for a warning tint: a warning surface must not be coloured as
reassurance.

## The fix

`GroupRepositoryImpl.sendGroupMessage` returns `Left(CryptoFailure(...))`. It refuses **before**
checking credentials, because whether the user is signed in has no bearing on the fact that this
client cannot encrypt a group message.

`GroupRemoteDatasource.sendGroupMessage` is **deleted**, not left unreachable. It had no caller
once the repository refused, and a method that assembles a plaintext group send is a defect one
call site away from returning. Whichever step implements MLS reintroduces it emitting real
ciphertext. The now-unused `dart:convert` and `uuid` imports go with it.

## The tests pinned the defect

```dart
when(() => mockDatasource.sendGroupMessage(..., textContent: 'Hello group!', ...))
    .thenAnswer((_) async => tMessageModel);
...
expect(message.textContent, 'Hello group!');
```

That stubs the datasource to echo the plaintext back and then asserts it round-tripped — it
enforced the plaintext path rather than catching it, the same shape #226 had to correct
one-to-one. Per AGENTS.md §8 I am flagging this rather than quietly deleting it. Three tests
replace the four: the refusal returns `CryptoFailure`, the datasource gets
`verifyZeroInteractions`, and it refuses unauthenticated too.

## A regression test I could not add, and why

The badge flip has no test. `group_chat_page_test.dart` does not render `GroupChatPage` — its
`buildTestableWidget()` hand-builds a **replica** `Scaffold`/`AppBar`, and never imports the page.
Asserting on the real badge finds zero `E2EEIndicator` widgets while all thirteen existing tests
pass, because they are asserting about a tree the test itself constructed.

Rather than delete my test quietly or fake it against the replica, it is filed as **#235**.
Fixing the harness needs DI overrides and a `Navigator` observer, which does not belong in a
security fix.

## Verification

```
flutter analyze --no-fatal-infos   no errors, no warnings
flutter test                       638 passed, 4 skipped
just rules-verify                  all checks passed
```

## docs-impact:none — reason

`docs/.manifest.yaml` maps no document to `client-mobile/`. The architecture is already recorded
in ADR-0010; this makes the client stop contradicting it.

## Deliberately out of scope

- **Implementing MLS.** This step makes its absence explicit instead of hiding it behind a badge.
- **The group receive path**, which still does `utf8.decode(..., allowMalformed: true)`. That is
  display rather than transmission and belongs with the cannot-decrypt placeholder step (#231).
- **#235**, the replica test harness.

## Budget

6 files, 238 changed lines — a net removal of 98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
