### PR TITLE
security(mobile): refuse the native to Dart crypto downgrade

### DIFF
--- a/client-mobile/lib/core/crypto/native/native_bridge_io.dart
+++ b/client-mobile/lib/core/crypto/native/native_bridge_io.dart
@@ -10,22 +10,36 @@ import '../native_crypto_bridge.dart';
 import 'dart_crypto_bridge.dart';
 import 'rust_crypto_bridge.dart';
 
-/// Create crypto bridge for IO platforms
+/// Create the crypto bridge for IO platforms.
 ///
-/// Tries native Rust implementation first, falls back to Dart if not available.
-CryptoBridge? createNativeCryptoBridge() {
-  // Try native Rust implementation first
+/// Returns the native Rust implementation, or throws [UnsupportedError].
+///
+/// This used to fall back to [DartCryptoBridge] whenever the FFI failed to load, announcing it
+/// with a `debugPrint` - which is compiled out of release builds. So any failure to load the
+/// library, from a missing `.so` to an ABI mismatch, silently demoted the entire application to
+/// an implementation that describes itself as *"for development purposes only"*, with nothing
+/// in a release build to say so. There is no `kReleaseMode` check anywhere in the app to catch
+/// it either.
+///
+/// A downgrade the user cannot observe is worse than a crash: a crash is reported, a quiet
+/// downgrade ships. So the fallback now requires
+/// [CryptoBridgeFactory.allowInsecureDartFallback] to be set explicitly, which only the test
+/// suite does.
+CryptoBridge createNativeCryptoBridge() {
   if (NativeRustCryptoBridge.checkNativeAvailable()) {
-    debugPrint('🔐 Using native Rust crypto implementation');
     return NativeRustCryptoBridge();
   }
 
-  // Fall back to pure Dart implementation
-  debugPrint(
-    '🔐 Native Rust crypto not available, using Dart fallback. '
-    'Build native libraries for production use.',
+  if (CryptoBridgeFactory.insecureDartFallbackAllowed) {
+    debugPrint('🔐 Native crypto unavailable; using DartCryptoBridge by explicit opt-in.');
+    return DartCryptoBridge();
+  }
+
+  throw UnsupportedError(
+    'Native Rust crypto is required but not available. Ensure libguardyn_crypto_ffi is built '
+    'and bundled with the app. Refusing to fall back to the development-only Dart '
+    'implementation.',
   );
-  return DartCryptoBridge();
 }
 
 /// Check if native crypto is available

--- a/client-mobile/lib/core/crypto/native/rust_crypto_bridge.dart
+++ b/client-mobile/lib/core/crypto/native/rust_crypto_bridge.dart
@@ -427,38 +427,12 @@ class NativeRustCryptoBridge implements CryptoBridge {
   }
 }
 
-/// Extended CryptoBridgeFactory that includes native support
-///
-/// IMPORTANT: Web is NOT supported. Use only on native platforms:
-/// - Android, iOS (mobile)
-/// - Linux, macOS, Windows (desktop)
-class ExtendedCryptoBridgeFactory {
-  static CryptoBridge? _instance;
-
-  /// Get the singleton crypto bridge instance
-  static CryptoBridge get instance {
-    _instance ??= _createBridge();
-    return _instance!;
-  }
-
-  static CryptoBridge _createBridge() {
-    // Native Rust implementation is required on all supported platforms
-    if (NativeRustCryptoBridge.checkNativeAvailable()) {
-      debugPrint('🔐 Native Rust crypto available');
-      return NativeRustCryptoBridge();
-    }
-
-    // Native bridge not available - this is a critical error
-    throw UnsupportedError(
-      'Native Rust crypto is required but not available. '
-      'Ensure libguardyn_crypto_ffi is built and included in the app bundle. '
-      'Web platform is not supported.',
-    );
-  }
-
-  /// Reset instance (for testing)
-  @visibleForTesting
-  static void reset() {
-    _instance = null;
-  }
-}
+// ExtendedCryptoBridgeFactory was removed here.
+//
+// It was the fail-closed factory - it threw UnsupportedError when the native library was
+// missing, which is the correct behaviour - and it had zero call sites anywhere in lib/, test/
+// or integration_test/. Production went through CryptoBridgeFactory, which fell back silently
+// instead. The right code was written and never wired up.
+//
+// CryptoBridgeFactory now refuses too, so keeping a second copy of that logic would be exactly
+// the arrangement that let the two drift apart in the first place.

--- a/client-mobile/lib/core/crypto/native_crypto_bridge.dart
+++ b/client-mobile/lib/core/crypto/native_crypto_bridge.dart
@@ -250,6 +250,31 @@ class EncryptedData {
 class CryptoBridgeFactory {
   static CryptoBridge? _instance;
 
+  /// Permits [DartCryptoBridge] to stand in for the native library. **Tests only.**
+  ///
+  /// The production path must never set this. `DartCryptoBridge` documents itself as
+  /// development-only, and silently substituting it for the audited Rust implementation is a
+  /// downgrade a release build cannot report: the fallback announced itself with a
+  /// `debugPrint`, which is compiled out of release, so the app would ship on it with nothing
+  /// to show for it.
+  ///
+  /// It exists because the crypto suite deliberately runs on the Dart bridge - CI has no FFI,
+  /// and pinning protocol behaviour there is worth far more than skipping the suite entirely
+  /// (see `test/core/crypto/crypto_test_helper.dart`). An FFI-backed job is #211. Making the
+  /// fallback an explicit, named opt-in keeps that arrangement while removing the implicit one.
+  static bool _allowInsecureDartFallback = false;
+
+  /// Whether the fallback is currently permitted. Read by the bridge factory.
+  static bool get insecureDartFallbackAllowed => _allowInsecureDartFallback;
+
+  /// Setting this is marked test-only deliberately: the getter above is public so the factory
+  /// can consult it, but anything in `lib/` that tries to *enable* the fallback trips
+  /// `invalid_use_of_visible_for_testing_member` in the analyzer, which the mobile CI job
+  /// fails on. The permission is readable everywhere and grantable only from a test.
+  @visibleForTesting
+  static set allowInsecureDartFallback(bool value) =>
+      _allowInsecureDartFallback = value;
+
   /// Get the singleton crypto bridge instance
   static CryptoBridge get instance {
     _instance ??= _createBridge();
@@ -257,17 +282,8 @@ class CryptoBridgeFactory {
   }
 
   static CryptoBridge _createBridge() {
-    // Create crypto bridge (native Rust or Dart fallback)
-    final bridge = native_bridge.createNativeCryptoBridge();
-    if (bridge != null) {
-      return bridge;
-    }
-
-    // This should not happen - createNativeCryptoBridge now always returns a bridge
-    throw UnsupportedError(
-      'Failed to create crypto bridge. '
-      'This is an internal error - please report it.',
-    );
+    // Throws rather than downgrading when the native library is missing.
+    return native_bridge.createNativeCryptoBridge();
   }
 
   /// Force native implementation (for testing)

--- a/client-mobile/test/core/crypto/crypto_bridge_factory_test.dart
+++ b/client-mobile/test/core/crypto/crypto_bridge_factory_test.dart
@@ -7,15 +7,50 @@
 library;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:guardyn_client/core/crypto/native/dart_crypto_bridge.dart';
 import 'package:guardyn_client/core/crypto/native_crypto_bridge.dart';
 
 void main() {
   group('CryptoBridgeFactory', () {
+    setUp(() {
+      CryptoBridgeFactory.reset();
+      CryptoBridgeFactory.allowInsecureDartFallback = false;
+    });
+
     tearDown(() {
       CryptoBridgeFactory.reset();
+      CryptoBridgeFactory.allowInsecureDartFallback = false;
+    });
+
+    test('refuses to build a bridge when the native library is missing', () {
+      // The #230 regression test, and the reason the three tests that used to live here were
+      // rewritten: they asserted `expect(bridge, isNotNull)` under the title "factory returns
+      // native bridge on supported platforms". That passed on DartCryptoBridge just as happily
+      // as on the real one, so it certified precisely the downgrade it was named after.
+      //
+      // There is no FFI in a headless test VM, so this exercises the missing-library path.
+      expect(
+        () => CryptoBridgeFactory.instance,
+        throwsA(
+          isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            contains('Refusing to fall back'),
+          ),
+        ),
+        reason: 'a missing native library must fail loudly, never downgrade silently',
+      );
+    });
+
+    test('uses the Dart bridge only when the fallback is granted explicitly', () {
+      CryptoBridgeFactory.allowInsecureDartFallback = true;
+
+      expect(CryptoBridgeFactory.instance, isA<DartCryptoBridge>());
     });
 
     test('instance returns singleton', () {
+      CryptoBridgeFactory.allowInsecureDartFallback = true;
+
       final bridge1 = CryptoBridgeFactory.instance;
       final bridge2 = CryptoBridgeFactory.instance;
 
@@ -27,6 +62,8 @@ void main() {
     });
 
     test('reset clears singleton', () {
+      CryptoBridgeFactory.allowInsecureDartFallback = true;
+
       final bridge1 = CryptoBridgeFactory.instance;
       CryptoBridgeFactory.reset();
       final bridge2 = CryptoBridgeFactory.instance;
@@ -38,13 +75,16 @@ void main() {
       );
     });
 
-    test('factory returns native bridge on supported platforms', () {
-      // On desktop/mobile, should return NativeRustCryptoBridge
-      // On web (removed), would throw UnsupportedError
-      final bridge = CryptoBridgeFactory.instance;
+    test('revoking the grant makes the next build refuse again', () {
+      // The permission is not sticky: it gates each construction, so a test that granted it
+      // cannot leave the application permanently downgraded.
+      CryptoBridgeFactory.allowInsecureDartFallback = true;
+      expect(CryptoBridgeFactory.instance, isA<DartCryptoBridge>());
 
-      // The bridge should be a NativeCryptoBridge on all supported platforms
-      expect(bridge, isNotNull);
+      CryptoBridgeFactory.reset();
+      CryptoBridgeFactory.allowInsecureDartFallback = false;
+
+      expect(() => CryptoBridgeFactory.instance, throwsUnsupportedError);
     });
   });
 
@@ -75,14 +115,4 @@ void main() {
     });
   });
 
-  group('Platform support', () {
-    test('web platform is not supported', () {
-      // This test documents that web platform is intentionally not supported
-      // for security reasons - all crypto must use native Rust FFI
-      //
-      // If someone tries to run on web, CryptoBridgeFactory.instance
-      // will throw UnsupportedError
-      expect(true, isTrue); // Placeholder - actual test would need web context
-    });
-  });
 }

--- a/client-mobile/test/core/crypto/crypto_primitives_test.dart
+++ b/client-mobile/test/core/crypto/crypto_primitives_test.dart
@@ -11,15 +11,17 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:guardyn_client/core/crypto/crypto_primitives.dart';
-import 'package:guardyn_client/core/crypto/native_crypto_bridge.dart';
+
+import 'crypto_test_helper.dart';
 
 void main() {
   late bool nativeAvailable;
 
   setUpAll(() async {
-    await CryptoPrimitives.initialize(
-      const NativeCryptoConfig(preferNative: true, enablePadme: true),
-    );
+    // Goes through the shared helper rather than calling CryptoPrimitives.initialize directly,
+    // because the application now refuses to substitute DartCryptoBridge for the native library
+    // (#230) and the helper is the single place that grants the test-only exception.
+    await initializeCryptoForTests();
     nativeAvailable = CryptoPrimitives.isNativeAvailable;
 
     if (!nativeAvailable) {

--- a/client-mobile/test/core/crypto/crypto_test_helper.dart
+++ b/client-mobile/test/core/crypto/crypto_test_helper.dart
@@ -17,6 +17,7 @@ library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:guardyn_client/core/crypto/crypto_primitives.dart';
+import 'package:guardyn_client/core/crypto/native_crypto_bridge.dart';
 import 'package:meta/meta.dart';
 
 /// Whether native crypto is available in the current test environment.
@@ -34,6 +35,12 @@ const String skipNativeCryptoMessage =
 /// Call this in setUpAll() of crypto test files.
 /// After calling, check [nativeCryptoAvailable] to skip tests if needed.
 Future<void> initializeCryptoForTests() async {
+  // Grant the fallback explicitly. The application refuses to substitute DartCryptoBridge for
+  // the native library (#230) - a silent downgrade is invisible in a release build - so the
+  // suite has to ask for it by name. This line is the whole reason the permission exists, and
+  // it is the only place in the repository that sets it.
+  CryptoBridgeFactory.allowInsecureDartFallback = true;
+
   await CryptoPrimitives.initialize();
   nativeCryptoAvailable = CryptoPrimitives.isNativeAvailable;
 

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -137,7 +137,7 @@ steps:
   - {id: PR-74, issue: 224, phase: 3, type: fix, status: done, title: "client-desktop - make the ratchet AAD symmetric"}
   - {id: PR-75, issue: 226, phase: 3, type: security, status: done, title: "client-mobile - fail closed instead of sending plaintext"}
   - {id: PR-76, issue: 229, phase: 3, type: security, status: todo, title: "client-mobile - fail closed on group messaging"}
-  - {id: PR-77, issue: 230, phase: 3, type: security, status: todo, title: "client-mobile - refuse the native to Dart crypto downgrade"}
+  - {id: PR-77, issue: 230, phase: 3, type: security, status: done, title: "client-mobile - refuse the native to Dart crypto downgrade"}
   - {id: PR-78, issue: 163, phase: 3, type: security, status: todo, title: "client-desktop - encrypt on the send path"}
   - {id: PR-79, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - retain private prekey material"}
   - {id: PR-80, issue: null, phase: 3, type: feat, status: todo, title: "client-desktop - implement the X3DH responder path"}


### PR DESCRIPTION
Closes #230

## The downgrade

```dart
// native_bridge_io.dart:23-28
debugPrint(
  '🔐 Native Rust crypto not available, using Dart fallback. '
  'Build native libraries for production use.',
);
return DartCryptoBridge();
```

`debugPrint` is compiled out of release builds. So the entire signal that the app had dropped to
a development-grade crypto implementation did not exist where it mattered. Any throw from
`checkNativeAvailable()` — a missing `.so`, an ABI mismatch, a stripped symbol — demoted the
whole process, and the verdict was cached in a static.

What it demoted to says so itself (`dart_crypto_bridge.dart:6-10`):

> SECURITY WARNING: This implementation is for development purposes only! Production builds MUST
> use the native Rust implementation

And `grep -rn "kReleaseMode|kDebugMode|kProfileMode" lib/` returns **zero hits**, so nothing else
in the app would have caught it.

A downgrade nobody can observe is worse than a crash: a crash gets reported, a quiet downgrade
ships.

## The permission, and why it is split

The fallback now requires `CryptoBridgeFactory.allowInsecureDartFallback`:

```dart
static bool _allowInsecureDartFallback = false;

/// Whether the fallback is currently permitted. Read by the bridge factory.
static bool get insecureDartFallbackAllowed => _allowInsecureDartFallback;

@visibleForTesting
static set allowInsecureDartFallback(bool value) => _allowInsecureDartFallback = value;
```

The getter is public so the factory can consult it; the **setter** is `@visibleForTesting`, so
anything in `lib/` that tries to *enable* the fallback trips
`invalid_use_of_visible_for_testing_member` — which `flutter analyze` reports as a warning and
the mobile job fails on. Readable everywhere, grantable only from a test.

A single annotation on the field would not work: `native_bridge_io.dart` has to read it, and
`@visibleForTesting` blocks that too.

## The test arrangement is preserved

The crypto suite deliberately runs on `DartCryptoBridge` — that is the arrangement adopted in
#204, because CI has no FFI and pinning protocol behaviour on the Dart bridge is worth far more
than skipping the suite outright. #211 remains the FFI-backed job.

`crypto_test_helper.initializeCryptoForTests` is now the **single place in the repository** that
grants the exception. `crypto_primitives_test.dart` called `CryptoPrimitives.initialize`
directly, so it is routed through the helper to keep that true rather than sprinkling a second
grant.

## Dead code removed

`ExtendedCryptoBridgeFactory` (`rust_crypto_bridge.dart:435-464`) was the fail-closed factory —
correct behaviour, written and then never wired up. `grep` finds **zero call sites** in `lib/`,
`test/` or `integration_test/`; production went through the silently-downgrading
`CryptoBridgeFactory` instead. Now that the real factory refuses, keeping a second copy is the
arrangement that let the two drift apart in the first place.

`CryptoBridgeFactory._createBridge`'s own `UnsupportedError` was unreachable by construction —
its comment admitted `createNativeCryptoBridge` "now always returns a bridge" — so the return
type tightens from `CryptoBridge?` to `CryptoBridge`.

## Tests that certified the defect

```dart
test('factory returns native bridge on supported platforms', () {
  final bridge = CryptoBridgeFactory.instance;
  expect(bridge, isNotNull);
});
```

`isNotNull` passes on `DartCryptoBridge` exactly as happily as on the real one — the test was
named after the guarantee and asserted something that could not distinguish it from the
downgrade. Flagging rather than silently deleting, per AGENTS.md §8. Replaced with tests for the
refusal, the explicit grant, and that the grant is **not sticky** (revoking it makes the next
build refuse again).

A fourth, `'web platform is not supported'`, had a body of `expect(true, isTrue)` with a comment
calling itself a placeholder. Removed rather than left looking like coverage.

## Not changed, and why

`NativeCryptoConfig.preferNative: false` (`rust_crypto_bridge.dart:87-92`) sets
`_nativeAvailable = false`, and every operation then throws through `_ensureNativeAvailable`
(`:129-134`). It already refuses rather than downgrading, so there was nothing to fix — the issue
listed it as suspect and it turned out to be sound.

## Verification

```
flutter analyze --no-fatal-infos   no errors, no warnings
flutter test                       640 passed, 4 skipped
just rules-verify                  all checks passed
```

## docs-impact:none — reason

`docs/.manifest.yaml` maps no document to `client-mobile/`. No architectural decision changes;
this makes the client enforce one already recorded (I-2, encryption cannot be turned off).

## Budget

7 files, 197 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
