### PR TITLE
fix(mobile): show an explicit cannot-decrypt placeholder

### DIFF
--- a/client-mobile/lib/core/crypto/undecryptable_message.dart
+++ b/client-mobile/lib/core/crypto/undecryptable_message.dart
@@ -1,0 +1,34 @@
+/// What a received message becomes when it cannot be decrypted.
+///
+/// The receive path used to return the bytes it failed to decrypt, so ciphertext - or anything
+/// else that happened to arrive - was rendered to the user as if it were the message. That is
+/// fail-open: a message that could not be authenticated was presented as though it had been.
+///
+/// Decryption fails for ordinary reasons as well as hostile ones: a message from a device whose
+/// session was never established, one that arrives after a reinstall, or one written in a wire
+/// format this build predates ([ADR-0011] versions the ratchet format precisely so this case is
+/// distinguishable). The user is told, rather than shown noise that looks like content.
+///
+/// [ADR-0011]: docs/adr/ADR-0011-ratchet-header-authentication.md
+library;
+
+/// Metadata key set on a message whose content could not be decrypted.
+///
+/// Namespaced so it cannot collide with a server-supplied key such as `x3dh_prekey`.
+const String undecryptableMetadataKey = 'guardyn.undecryptable';
+
+/// Placeholder shown in place of content that could not be decrypted.
+///
+/// The UI keys off [undecryptableMetadataKey] rather than matching this string, so a user who
+/// types these exact words is not rendered as an undecryptable message.
+const String undecryptableMessagePlaceholder = 'Message cannot be decrypted';
+
+/// Whether [metadata] marks its message as undecryptable.
+bool isUndecryptable(Map<String, String> metadata) =>
+    metadata[undecryptableMetadataKey] == 'true';
+
+/// Returns [metadata] with the undecryptable marker set.
+Map<String, String> markUndecryptable(Map<String, String> metadata) => {
+      ...metadata,
+      undecryptableMetadataKey: 'true',
+    };

--- a/client-mobile/lib/features/messaging/data/repositories/message_repository_impl.dart
+++ b/client-mobile/lib/features/messaging/data/repositories/message_repository_impl.dart
@@ -8,6 +8,7 @@ import 'package:logger/logger.dart';
 
 import '../../../../core/crypto/crypto_exceptions.dart';
 import '../../../../core/crypto/message_aad.dart';
+import '../../../../core/crypto/undecryptable_message.dart';
 import '../../../../core/crypto/crypto_service.dart';
 import '../../../../core/crypto/x3dh.dart';
 import '../../../../core/error/failures.dart';
@@ -177,7 +178,7 @@ class MessageRepositoryImpl implements MessageRepository {
           // Extract X3DH prekey from message metadata (for first message in session)
           final x3dhPrekey = message.metadata['x3dh_prekey'];
 
-          final decryptedContent = await _decryptMessage(
+          final decrypted = await _decryptMessage(
             encryptedContent: message.textContent,
             senderUserId: message.senderUserId,
             senderDeviceId: message.senderDeviceId,
@@ -193,8 +194,8 @@ class MessageRepositoryImpl implements MessageRepository {
               recipientUserId: message.recipientUserId,
               recipientDeviceId: message.recipientDeviceId,
               messageType: message.messageType,
-              textContent: decryptedContent,
-              metadata: message.metadata,
+              textContent: decrypted.text,
+              metadata: decrypted.metadataFrom(message.metadata),
               timestamp: message.timestamp,
               deliveryStatus: message.deliveryStatus,
               currentUserId: currentUserId,
@@ -237,7 +238,7 @@ class MessageRepositoryImpl implements MessageRepository {
           // Extract X3DH prekey from message metadata (for first message in session)
           final x3dhPrekey = message.metadata['x3dh_prekey'];
 
-          final decryptedContent = await _decryptMessage(
+          final decrypted = await _decryptMessage(
             encryptedContent: message.textContent,
             senderUserId: message.senderUserId,
             senderDeviceId: message.senderDeviceId,
@@ -253,8 +254,8 @@ class MessageRepositoryImpl implements MessageRepository {
               recipientUserId: message.recipientUserId,
               recipientDeviceId: message.recipientDeviceId,
               messageType: message.messageType,
-              textContent: decryptedContent,
-              metadata: message.metadata,
+              textContent: decrypted.text,
+              metadata: decrypted.metadataFrom(message.metadata),
               timestamp: message.timestamp,
               deliveryStatus: message.deliveryStatus,
               currentUserId: currentUserId,
@@ -362,7 +363,7 @@ class MessageRepositoryImpl implements MessageRepository {
         return const Left(AuthFailure('User not authenticated'));
       }
 
-      final decryptedContent = await _decryptMessage(
+      final decrypted = await _decryptMessage(
         encryptedContent: encryptedContent,
         senderUserId: senderUserId,
         senderDeviceId: senderDeviceId,
@@ -370,11 +371,14 @@ class MessageRepositoryImpl implements MessageRepository {
         x3dhPrekey: x3dhPrekey,
       );
 
-      return Right(decryptedContent);
+      // Returns the placeholder rather than the content it could not decrypt. _decryptMessage
+      // already handles the expected failures, so reaching this as a Right with the original
+      // content - which is what used to happen - meant handing the caller ciphertext labelled
+      // as plaintext.
+      return Right(decrypted.text);
     } catch (e) {
       _logger.e('Failed to decrypt message: $e');
-      // Return original content on failure
-      return Right(encryptedContent);
+      return const Right(undecryptableMessagePlaceholder);
     }
   }
 
@@ -416,29 +420,17 @@ class MessageRepositoryImpl implements MessageRepository {
   }) async {
     String? x3dhPrekey;
 
-    // ignore: avoid_print
-    print(
-      '🔐 _encryptMessageWithPrekey: checking session for $recipientUserId:$recipientDeviceId',
-    );
-    // ignore: avoid_print
-    print('🔐 CryptoService initialized: ${cryptoService.isInitialized}');
-
     // Check if E2EE session exists
     var session = await cryptoService.getSession(
       remoteUserId: recipientUserId,
       remoteDeviceId: recipientDeviceId,
     );
 
-    // ignore: avoid_print
-    print('🔐 Existing session: ${session != null}');
-
     // No session? Create one via X3DH key exchange
     if (session == null) {
       _logger.i(
         'No E2EE session for $recipientUserId:$recipientDeviceId, initiating X3DH',
       );
-      // ignore: avoid_print
-      print('🔐 No session found, creating new X3DH session...');
       try {
         final prekeyMessage = await _createE2ESessionWithPrekey(
           recipientUserId: recipientUserId,
@@ -451,10 +443,6 @@ class MessageRepositoryImpl implements MessageRepository {
         );
         // Get X3DH prekey data for first message
         x3dhPrekey = prekeyMessage?.toBase64();
-        // ignore: avoid_print
-        print(
-          '🔐 Session created, prekey: ${x3dhPrekey != null ? 'present (${x3dhPrekey.length} chars)' : 'null'}',
-        );
         _logger.i(
           'E2EE session created successfully, prekey: ${x3dhPrekey != null}',
         );
@@ -467,11 +455,6 @@ class MessageRepositoryImpl implements MessageRepository {
           'Could not establish an encrypted session with the recipient: $e',
         );
       }
-    } else {
-      // ignore: avoid_print
-      print(
-        '🔐 Session already exists: hasSendingChainKey=${session.hasSendingChainKey}',
-      );
     }
 
     // Encrypt with Double Ratchet
@@ -533,20 +516,17 @@ class MessageRepositoryImpl implements MessageRepository {
   /// Returns plaintext if decryption successful, or original content if not encrypted.
   /// Handles both base64-encoded content (from WebSocket) and raw bytes (from gRPC).
   /// If X3DH prekey data is provided, creates responder session first.
-  Future<String> _decryptMessage({
+  Future<_DecryptedContent> _decryptMessage({
     required String encryptedContent,
     required String senderUserId,
     required String senderDeviceId,
     required String currentUserId,
     String? x3dhPrekey,
   }) async {
-    // ignore: avoid_print
-    print(
-      '🔐 _decryptMessage: from $senderUserId, x3dhPrekey: ${x3dhPrekey != null ? 'present (${x3dhPrekey.length} chars)' : 'null'}',
-    );
-
+    // An empty payload is a media-only message, not a failure - there is nothing to decrypt
+    // and nothing to warn about.
     if (encryptedContent.isEmpty) {
-      return encryptedContent;
+      return const _DecryptedContent.plaintext('');
     }
 
     // Check if E2EE session exists
@@ -557,8 +537,6 @@ class MessageRepositoryImpl implements MessageRepository {
 
     // If no session but we have X3DH prekey data, create responder session
     if (session == null && x3dhPrekey != null && x3dhPrekey.isNotEmpty) {
-      // ignore: avoid_print
-      print('🔐 No session found, creating responder session with X3DH prekey');
       _logger.i('Creating responder session with X3DH prekey data');
       try {
         await _createResponderSession(
@@ -571,42 +549,33 @@ class MessageRepositoryImpl implements MessageRepository {
           remoteUserId: senderUserId,
           remoteDeviceId: senderDeviceId,
         );
-        // ignore: avoid_print
-        print(
-          '🔐 Responder session created: hasSendingChainKey=${session?.hasSendingChainKey}, hasReceivingChainKey=${session?.hasReceivingChainKey}',
-        );
         _logger.i('Responder session created successfully');
       } catch (e) {
+        // Leaves `session` null, so the check below returns the placeholder. Previously that
+        // path returned the raw content instead.
         _logger.e('Failed to create responder session: $e');
       }
     }
 
     if (session == null) {
-      // No E2EE session - return content as-is (not encrypted or legacy message)
-      _logger.d('No E2EE session for $senderUserId - returning content as-is');
-      return encryptedContent;
+      // No session, so there is nothing to decrypt with. Returning the content as-is here is
+      // what let ciphertext render as message text.
+      _logger.d('No E2EE session for $senderUserId');
+      return const _DecryptedContent.undecryptable();
     }
 
-    // Try to detect if content is base64 encoded (from WebSocket)
-    // Base64 uses only A-Za-z0-9+/= characters
-    Uint8List ciphertextBytes;
+    // Ciphertext arrives base64-encoded. This used to sniff for base64 with a regex and fall
+    // back to `encryptedContent.codeUnits`, which is wrong twice over: codeUnits yields UTF-16
+    // units that Uint8List.fromList truncates above 0xFF - the same defect #218 fixed in the
+    // AAD - and the regex was a guess about which transport produced the string. A payload that
+    // does not decode is one this client cannot read, which is the undecryptable case, not a
+    // reason to invent bytes.
+    final Uint8List ciphertextBytes;
     try {
-      // Check if it looks like base64 (common pattern for encrypted messages)
-      final base64Regex = RegExp(r'^[A-Za-z0-9+/]+=*$');
-      if (base64Regex.hasMatch(encryptedContent) &&
-          encryptedContent.length > 20) {
-        // Looks like base64 - try to decode
-        ciphertextBytes = base64.decode(encryptedContent);
-        _logger.d('Decoded base64 content: ${ciphertextBytes.length} bytes');
-      } else {
-        // Not base64 - use codeUnits (raw bytes encoded as string)
-        ciphertextBytes = Uint8List.fromList(encryptedContent.codeUnits);
-        _logger.d('Using raw codeUnits: ${ciphertextBytes.length} bytes');
-      }
-    } catch (e) {
-      // Base64 decode failed - use codeUnits
-      ciphertextBytes = Uint8List.fromList(encryptedContent.codeUnits);
-      _logger.d('Base64 decode failed, using codeUnits: $e');
+      ciphertextBytes = base64.decode(encryptedContent);
+    } on FormatException catch (e) {
+      _logger.w('Content is not valid base64: $e');
+      return const _DecryptedContent.undecryptable();
     }
 
     final associatedData = messageAssociatedData(
@@ -623,11 +592,12 @@ class MessageRepositoryImpl implements MessageRepository {
       );
       final result = utf8.decode(decrypted);
       _logger.d('Decryption successful: ${result.length} chars');
-      return result;
+      return _DecryptedContent.plaintext(result);
     } catch (e) {
-      // Decryption failed - message might not be encrypted
-      _logger.w('Decryption failed: $e - returning original content');
-      return encryptedContent;
+      // A failed tag is indistinguishable from tampering, a desynchronised ratchet and an
+      // unsupported wire version. None of them makes the payload safe to display.
+      _logger.w('Decryption failed: $e');
+      return const _DecryptedContent.undecryptable();
     }
   }
 
@@ -663,4 +633,26 @@ class MessageRepositoryImpl implements MessageRepository {
       rethrow;
     }
   }
+}
+
+/// The outcome of trying to decrypt one received message.
+///
+/// A plain `String` return could not distinguish "this is the message" from "this is what I
+/// could not decrypt", which is why the receive path used to render the latter as the former.
+class _DecryptedContent {
+  const _DecryptedContent.plaintext(this.text) : undecryptable = false;
+
+  const _DecryptedContent.undecryptable()
+      : text = undecryptableMessagePlaceholder,
+        undecryptable = true;
+
+  /// What to display. For the undecryptable case this is the placeholder, never the bytes.
+  final String text;
+
+  /// Whether [text] is the placeholder rather than the sender's content.
+  final bool undecryptable;
+
+  /// Metadata for the resulting message, carrying the marker when it applies.
+  Map<String, String> metadataFrom(Map<String, String> original) =>
+      undecryptable ? markUndecryptable(original) : original;
 }

--- a/client-mobile/lib/features/messaging/presentation/widgets/message_bubble.dart
+++ b/client-mobile/lib/features/messaging/presentation/widgets/message_bubble.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../../../../core/crypto/undecryptable_message.dart';
 import '../../../../shared/theme/app_colors.dart';
 import '../../../../shared/theme/app_shadows.dart';
 import '../../../../shared/theme/app_spacing.dart';
@@ -95,16 +96,47 @@ class MessageBubble extends StatelessWidget {
                                 right: AppSpacing.space1,
                               )
                             : EdgeInsets.zero,
-                        child: Text(
-                          message.textContent,
-                          style: TextStyle(
-                            color: isSentByMe
-                                ? Colors.white
-                                : (isDark ? Colors.white : GrayColors.gray900),
-                            fontSize: 15,
-                            height: 1.4,
-                          ),
-                        ),
+                        child: isUndecryptable(message.metadata)
+                            // Styled apart from real content on purpose: the placeholder must
+                            // not be mistakable for something the sender wrote.
+                            ? Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(
+                                    Icons.lock_open,
+                                    size: 15,
+                                    color: isSentByMe
+                                        ? Colors.white70
+                                        : GrayColors.gray500,
+                                  ),
+                                  const SizedBox(width: AppSpacing.space1),
+                                  Flexible(
+                                    child: Text(
+                                      message.textContent,
+                                      style: TextStyle(
+                                        color: isSentByMe
+                                            ? Colors.white70
+                                            : GrayColors.gray500,
+                                        fontSize: 15,
+                                        height: 1.4,
+                                        fontStyle: FontStyle.italic,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              )
+                            : Text(
+                                message.textContent,
+                                style: TextStyle(
+                                  color: isSentByMe
+                                      ? Colors.white
+                                      : (isDark
+                                            ? Colors.white
+                                            : GrayColors.gray900),
+                                  fontSize: 15,
+                                  height: 1.4,
+                                ),
+                              ),
                       ),
                     SizedBox(height: hasMedia && message.textContent.isEmpty 
                         ? AppSpacing.space0_5 

--- a/client-mobile/test/features/messaging/data/repositories/message_repository_impl_test.dart
+++ b/client-mobile/test/features/messaging/data/repositories/message_repository_impl_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:guardyn_client/core/crypto/crypto_service.dart';
 import 'package:guardyn_client/core/crypto/double_ratchet.dart';
+import 'package:guardyn_client/core/crypto/undecryptable_message.dart';
 import 'package:guardyn_client/core/error/failures.dart';
 import 'package:guardyn_client/core/storage/secure_storage.dart';
 import 'package:guardyn_client/features/messaging/data/datasources/key_exchange_datasource.dart';
@@ -374,9 +375,95 @@ void main() {
     });
   });
 
+  group('undecryptable messages', () {
+    // The receive path used to return whatever it could not decrypt, so ciphertext - or any
+    // other bytes that arrived - was rendered to the user as the message. A payload that could
+    // not be authenticated was presented as though it had been.
+
+    void noSession() {
+      when(() => mockCryptoService.getSession(
+            remoteUserId: any(named: 'remoteUserId'),
+            remoteDeviceId: any(named: 'remoteDeviceId'),
+          )).thenAnswer((_) async => null);
+    }
+
+    test('decryptMessageContent returns the placeholder, not the ciphertext', () async {
+      noSession();
+      when(() => mockSecureStorage.getUserId())
+          .thenAnswer((_) async => tCurrentUserId);
+      const ciphertext = 'AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRo=';
+
+      final result = await repository.decryptMessageContent(
+        encryptedContent: ciphertext,
+        senderUserId: tRecipientUserId,
+        senderDeviceId: tRecipientDeviceId,
+      );
+
+      result.fold(
+        (failure) => fail('Expected Right but got Left'),
+        (content) {
+          expect(content, undecryptableMessagePlaceholder);
+          expect(content, isNot(ciphertext));
+        },
+      );
+    });
+
+    test('content that is not valid base64 is undecryptable, not reinterpreted', () async {
+      // This used to fall through to `encryptedContent.codeUnits`, which truncates every unit
+      // above 0xFF - the same defect #218 fixed in the AAD - and then attempted decryption on
+      // bytes it had invented.
+      noSession();
+      when(() => mockSecureStorage.getUserId())
+          .thenAnswer((_) async => tCurrentUserId);
+
+      final result = await repository.decryptMessageContent(
+        encryptedContent: 'привет — not base64 at all',
+        senderUserId: tRecipientUserId,
+        senderDeviceId: tRecipientDeviceId,
+      );
+
+      result.fold(
+        (failure) => fail('Expected Right but got Left'),
+        (content) => expect(content, undecryptableMessagePlaceholder),
+      );
+    });
+
+    test('getMessages marks undecryptable messages in metadata', () async {
+      noSession();
+      when(() => mockSecureStorage.getAccessToken())
+          .thenAnswer((_) async => tAccessToken);
+      when(() => mockSecureStorage.getUserId())
+          .thenAnswer((_) async => tCurrentUserId);
+      when(() => mockDatasource.getMessages(
+            accessToken: any(named: 'accessToken'),
+            conversationUserId: any(named: 'conversationUserId'),
+            conversationId: any(named: 'conversationId'),
+            limit: any(named: 'limit'),
+            beforeMessageId: any(named: 'beforeMessageId'),
+            currentUserId: any(named: 'currentUserId'),
+          )).thenAnswer((_) async => tMessagesList);
+
+      final result = await repository.getMessages(
+        conversationUserId: tRecipientUserId,
+      );
+
+      result.fold(
+        (failure) => fail('Expected Right but got Left'),
+        (messages) {
+          for (final message in messages) {
+            expect(isUndecryptable(message.metadata), isTrue,
+                reason: 'the UI keys off this marker to render the placeholder');
+            expect(message.textContent, undecryptableMessagePlaceholder);
+          }
+        },
+      );
+    });
+  });
+
   group('getMessages', () {
     void setUpCryptoMocks() {
-      // E2EE: Return null session to skip decryption (messages returned as-is)
+      // No session, so nothing can be decrypted. Content therefore comes back as the
+      // undecryptable placeholder rather than as the stored bytes.
       when(() => mockCryptoService.getSession(
             remoteUserId: any(named: 'remoteUserId'),
             remoteDeviceId: any(named: 'remoteDeviceId'),

--- a/client-mobile/test/features/messaging/presentation/widgets/message_bubble_test.dart
+++ b/client-mobile/test/features/messaging/presentation/widgets/message_bubble_test.dart
@@ -1,0 +1,88 @@
+/// Widget tests for [MessageBubble], covering how a message that could not be decrypted is
+/// presented.
+///
+/// The receive path used to hand the bubble whatever it failed to decrypt, so the bubble
+/// rendered those bytes as ordinary message text. The repository now substitutes a placeholder
+/// and marks the message in metadata; these tests pin the half the user actually sees.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guardyn_client/core/crypto/undecryptable_message.dart';
+import 'package:guardyn_client/features/messaging/domain/entities/message.dart';
+import 'package:guardyn_client/features/messaging/presentation/widgets/message_bubble.dart';
+
+void main() {
+  const tCurrentUserId = 'user-123';
+  const tSenderUserId = 'user-456';
+  final tTimestamp = DateTime(2026, 1, 1, 10, 30);
+
+  Message buildMessage({
+    required String textContent,
+    Map<String, String> metadata = const {},
+  }) {
+    return Message(
+      messageId: 'msg-001',
+      conversationId: 'conv-001',
+      senderUserId: tSenderUserId,
+      senderDeviceId: 'device-456',
+      senderUsername: 'alice',
+      recipientUserId: tCurrentUserId,
+      recipientDeviceId: 'device-123',
+      messageType: MessageType.text,
+      textContent: textContent,
+      metadata: metadata,
+      timestamp: tTimestamp,
+      deliveryStatus: DeliveryStatus.delivered,
+      currentUserId: tCurrentUserId,
+    );
+  }
+
+  Widget wrap(Message message) => MaterialApp(
+        home: Scaffold(
+          body: MessageBubble(message: message),
+        ),
+      );
+
+  testWidgets('an ordinary message renders as plain text', (tester) async {
+    await tester.pumpWidget(wrap(buildMessage(textContent: 'Hello there')));
+
+    expect(find.text('Hello there'), findsOneWidget);
+    expect(find.byIcon(Icons.lock_open), findsNothing);
+
+    final text = tester.widget<Text>(find.text('Hello there'));
+    expect(text.style?.fontStyle, isNot(FontStyle.italic));
+  });
+
+  testWidgets('an undecryptable message is marked apart from real content',
+      (tester) async {
+    await tester.pumpWidget(wrap(buildMessage(
+      textContent: undecryptableMessagePlaceholder,
+      metadata: markUndecryptable(const {}),
+    )));
+
+    expect(find.text(undecryptableMessagePlaceholder), findsOneWidget);
+    expect(find.byIcon(Icons.lock_open), findsOneWidget);
+
+    final text = tester.widget<Text>(find.text(undecryptableMessagePlaceholder));
+    expect(
+      text.style?.fontStyle,
+      FontStyle.italic,
+      reason: 'the placeholder must not be mistakable for something the sender wrote',
+    );
+  });
+
+  testWidgets('a user typing the placeholder text is not styled as undecryptable',
+      (tester) async {
+    // The marker lives in metadata rather than in the text, precisely so that content which
+    // happens to match the placeholder is still rendered as what the sender wrote.
+    await tester.pumpWidget(wrap(buildMessage(
+      textContent: undecryptableMessagePlaceholder,
+    )));
+
+    expect(find.byIcon(Icons.lock_open), findsNothing);
+
+    final text = tester.widget<Text>(find.text(undecryptableMessagePlaceholder));
+    expect(text.style?.fontStyle, isNot(FontStyle.italic));
+  });
+}

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -151,6 +151,6 @@ steps:
   # unverified bytes than refuse. PR-86 comes first: until the statuses above are correct,
   # roadmap-sync reopens each of these seconds after it merges.
   - {id: PR-86, issue: 228, phase: 3, type: chore, status: done, title: "Reconcile roadmap status so roadmap-sync stops reopening issues"}
-  - {id: PR-87, issue: 231, phase: 3, type: fix, status: todo, title: "client-mobile - show an explicit cannot-decrypt placeholder"}
+  - {id: PR-87, issue: 231, phase: 3, type: fix, status: done, title: "client-mobile - show an explicit cannot-decrypt placeholder"}
   - {id: PR-88, issue: 232, phase: 3, type: fix, status: todo, title: "client-desktop - show an explicit cannot-decrypt placeholder"}
   - {id: PR-89, issue: 235, phase: 3, type: fix, status: todo, title: "group_chat_page_test renders a replica of the page, not the page"}


### PR DESCRIPTION
Closes #231

## The decision #226 deferred

#226 sealed the send path and left the receive path alone, on the grounds that it *"is a display
problem rather than a leak and needs a decision about what an undecryptable message should look
like."* This is that decision.

## Four paths that rendered raw bytes as the message

| Line | Behaviour |
|---|---|
| `:585` | no session → `return encryptedContent` |
| `:627` | decrypt threw → returns the ciphertext as message text |
| `:374` | `decryptMessageContent` swallows failure into `Right(encryptedContent)` |
| `:579` | responder-session failure swallowed, falls into `:585` |

That is fail-open: a message that could not be authenticated was presented as though it had been.
A failed AEAD tag is indistinguishable from tampering, a desynchronised ratchet, and a wire
version this build predates — [ADR-0011](docs/adr/ADR-0011-ratchet-header-authentication.md)
added the version byte precisely because those should be distinguishable — and none of them makes
the payload safe to display.

## Why a new return type

`_decryptMessage` returned a bare `String`, which cannot express the difference between *"this is
the message"* and *"this is what I could not decrypt"*. That is the whole bug: the two were the
same value. It now returns `_DecryptedContent`, and the undecryptable case carries the placeholder
plus a metadata marker.

## The marker is in metadata, not in the text

`undecryptableMetadataKey` is `guardyn.undecryptable`, namespaced so it cannot collide with a
server-supplied key such as `x3dh_prekey`. The UI keys off it rather than string-matching the
placeholder — otherwise a user who types *"Message cannot be decrypted"* would be rendered as an
undecryptable message. There is a test for exactly that.

Rendering: italic, muted, preceded by a `lock_open` icon, so it cannot be mistaken for content the
sender wrote.

## The base64 sniffing is gone

```dart
final base64Regex = RegExp(r'^[A-Za-z0-9+/]+=*$');
if (base64Regex.hasMatch(encryptedContent) && encryptedContent.length > 20) {
  ciphertextBytes = base64.decode(encryptedContent);
} else {
  ciphertextBytes = Uint8List.fromList(encryptedContent.codeUnits);
}
```

`codeUnits` yields UTF-16 units that `Uint8List.fromList` truncates above `0xFF` — the same defect
#218 fixed in the AAD — and the regex was a guess about which transport produced the string. So
the client invented bytes and then tried to decrypt them. A payload that does not decode is one
this client cannot read, which is the undecryptable case.

The surviving `codeUnits` uses are ASCII test fixtures and the two deliberate negative controls in
`message_aad_test.dart`; those stay.

## Under I-1

Eight `// ignore: avoid_print` statements logged session state and prekey presence to stdout
(`:419-421`, `:432`, `:441`, `:456-459`, `:473-475`). Removed.

## Tests

- `decryptMessageContent returns the placeholder, not the ciphertext`
- `content that is not valid base64 is undecryptable, not reinterpreted`
- `getMessages marks undecryptable messages in metadata`
- New `message_bubble_test.dart`: plain text renders plainly; a marked message gets the icon and
  italics; **a user typing the placeholder text is not styled as undecryptable**.

One existing comment in `getMessages` read *"Return null session to skip decryption (messages
returned as-is)"* — it described the defect. Corrected.

## Verification

```
flutter analyze --no-fatal-infos   no errors, no warnings
flutter test                       644 passed, 4 skipped
just rules-verify                  all checks passed
```

## docs-impact:none — reason

`docs/.manifest.yaml` maps no document to `client-mobile/`. No architectural decision changes —
ADR-0011 already anticipated an unsupported version being reported to the user rather than
surfacing as a bad tag; this is the client honouring it.

## Deliberately out of scope

- **client-desktop**, which has the same defect (`String::from_utf8_lossy`) — that is #232, kept
  separate so each client's UI decision is reviewable on its own.
- **The group receive path**, unreachable now that group sending is refused (#229).

## Budget

6 files, 397 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
