### PR TITLE
security(infra): remove the E2EE kill-switch environment variables

### DIFF
--- a/.claude/rules/00-invariants.md
+++ b/.claude/rules/00-invariants.md
@@ -20,7 +20,7 @@ If a task appears to require it, stop and ask the user.
 |---|---|---|---|---|
 | `ZK-INIT` | I-1 | Tracing is initialised only via `guardyn_common::observability::init_tracing` | PASS | `rules-verify` |
 | `ZK-PII` | I-1 | No log macro is passed a raw IP, email or phone number | PASS | `rules-verify` |
-| `E2EE-FLAG` | I-2 | No configuration key can turn encryption off | FAIL (4) | PR-32b, PR-32c |
+| `E2EE-FLAG` | I-2 | No configuration key can turn encryption off | PASS | `rules-verify` |
 | `E2EE-DUP` | I-2 | No handler has a non-E2EE twin | PASS | `rules-verify` |
 | `PQ-DEFAULT` | I-3 | The `pq` feature is on by default in the crypto crate | FAIL | PR-38 |
 | `PQ-WIRE` | I-3 | The wire contract carries ML-KEM key material | FAIL | PR-36 |
@@ -53,12 +53,20 @@ already the zero-knowledge relay. Collapsing the other way would have traded an 
 an I-1 one. §1 also says four such pairs existed; the measured count was **two**
 (`send_message`, `receive_messages`). PR-31d (#153) amends §1.
 
+`E2EE-FLAG` passed with PR-32c. PR-32b removed the flags from the code, so `E2eeConfig` and
+`MlsConfig` no longer exist and nothing in the backend reads an encryption switch; PR-32c then
+deleted the variables that were still being set in `docker-compose.dev.yml` and the two k8s
+manifests. Between those two steps the variables were inert - which is worth remembering, because
+a deployment file that looks like a kill switch reads as one whether or not any code consults it,
+and the prod overlay's `GUARDYN_E2EE_ENABLED: "true"` was actively misleading about where
+encryption came from.
+
 `PQ-WIRE` fails while `crypto/src/pqxdh.rs` is a complete hybrid X25519 + ML-KEM-768
 implementation. It is unreached, not absent — no proto field can carry the public key.
 
-**A known failure is not licence to patch it.** Three of the remaining failures have an owned
-step - `E2EE-FLAG` (PR-32b, PR-32c), `PQ-DEFAULT` (PR-38) and `PQ-WIRE` (PR-36) - and fixing one
-outside that step breaks the micro-step contract.
+**A known failure is not licence to patch it.** Both remaining failures have an owned step -
+`PQ-DEFAULT` (PR-38) and `PQ-WIRE` (PR-36) - and fixing one outside that step breaks the
+micro-step contract.
 
 `ZK-PII` and `SOV-DOMAIN` were both found while writing this file, with no owning step. Each had
 an issue opened before any fix. `ZK-PII` is now closed by #81 and enforced by `rules-verify`;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,10 +4,9 @@
 # Stop:  docker compose -f docker-compose.dev.yml down
 # Reset: docker compose -f docker-compose.dev.yml down -v
 #
-# E2EE Configuration:
-#   By default, E2EE is DISABLED for easier development/debugging.
-#   To enable E2EE testing, set GUARDYN_E2EE_ENABLED=true in messaging-service.
-#   See docs/ENCRYPTION_ARCHITECTURE.md for details.
+# E2EE is not configurable. The server never sees plaintext, in development as in
+# production - it relays opaque bytes (docs/adr/ADR-0010-pure-relay-server.md). There is no
+# switch to make debugging easier, because a switch is what invariant I-2 forbids.
 
 version: "3.9"
 
@@ -239,13 +238,6 @@ services:
       REDPANDA_BROKERS: redpanda:9092
       GUARDYN_OBSERVABILITY__OTLP_ENDPOINT: ""
       GUARDYN_OBSERVABILITY__LOG_LEVEL: debug
-      # E2EE Configuration - disabled for local development (easier debugging)
-      # Set to "true" to enable end-to-end encryption testing
-      GUARDYN_E2EE_ENABLED: "false"
-      GUARDYN_E2EE_X3DH_ENABLED: "true"
-      GUARDYN_E2EE_DOUBLE_RATCHET_ENABLED: "true"
-      # MLS Configuration - disabled for local development
-      GUARDYN_MLS_ENABLED: "false"
     ports:
       - "50052:50052"
       - "8081:8081"      # WebSocket

--- a/docs/ops/DEPLOYMENT.md
+++ b/docs/ops/DEPLOYMENT.md
@@ -51,6 +51,26 @@ and `SCYLLA_HOSTS`; setting only `GUARDYN_PORT` and `GUARDYN_DATABASE__SCYLLADB_
 it binding the wrong port and dialling the Kubernetes ScyllaDB FQDN. Compose now sets both
 forms. Unifying this is tracked separately.
 
+### There is no encryption switch
+
+`messaging-service` used to carry `GUARDYN_E2EE_ENABLED`, `GUARDYN_MLS_ENABLED` and four
+companions in Compose and both k8s overlays. **They are gone, and nothing replaces them.**
+
+The server is a pure relay ([ADR-0010](../adr/ADR-0010-pure-relay-server.md)): the ratchet and
+MLS run on the clients, it stores `encrypted_content` byte-for-byte and holds no key material,
+so there is nothing left for such a flag to select. Invariant I-2 forbids one existing at all.
+
+Two details worth keeping straight when reading older deployment files or git history:
+
+- The dev overlay set `GUARDYN_E2EE_ENABLED: "false"` with a comment offering it as a debugging
+  convenience. Encryption was never something an operator could turn off for convenience.
+- The prod overlay set it to `"true"`, which read as though production encryption depended on
+  it. It did not. After PR-32a/32b the code stopped consulting these variables entirely, so for
+  a period they were inert while still appearing authoritative — which is precisely why they
+  had to be deleted rather than left as harmless.
+
+`rules-verify` enforces their absence (`E2EE-FLAG`), so reintroducing one fails CI.
+
 ## Kubernetes
 
 ```sh
@@ -104,4 +124,5 @@ and any `*.key` are gitignored and must never reach the repository.
 | `infra/k8s/base/envoy/ingress.yaml:18` hardcodes `envoy.guardyn.local` | breaks the `${DOMAIN}` rule above | **unowned** |
 | Production images are tagged, not digest-pinned | a tag can be moved under a running cluster | PR-44 |
 | `infra/secrets/.gitignore` ignores `*.enc.yaml` — the **encrypted** file — while the plaintext `app-secrets.yaml` is tracked | exactly inverted: the safe artefact is excluded and the unsafe one committed. The tracked values are placeholders, so no live credential is exposed *yet* | PR-42 |
+| `client-desktop` cannot establish a session, so it refuses every one-to-one send | desktop messaging is non-functional until the session stack lands — deliberate, since the alternative was plaintext at rest | PR-79…PR-81 |
 | `infra/justfile` is a second, divergent task file whose `k8s:deploy` references a values file that does not exist | dead code that will mislead | unowned |

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -136,6 +136,21 @@ encrypted the client's plaintext server-side and decrypted on the way back out, 
 unsuffixed handler relayed ciphertext untouched. The fix is to delete the twin, never to rename
 it or to exempt the path.
 
+**If `E2EE-FLAG` fails**, something has reintroduced a switch that can turn encryption off —
+`GUARDYN_E2EE_ENABLED` or `GUARDYN_MLS_ENABLED`, in code or in a deployment file. **I-2** is
+that encryption cannot be disabled, so there is no correct value for such a variable and no
+environment that may set one. Delete it; do not set it to `"true"`.
+
+The check covers deployment files as well as Rust, and that is the point. Between PR-32b and
+PR-32c the flags were gone from the code but still present in Compose and both k8s overlays —
+inert, yet reading exactly like an operational control. The prod overlay set
+`GUARDYN_E2EE_ENABLED: "true"`, which invited the conclusion that production encryption
+depended on it; #163 reasoned from precisely that and concluded desktop plaintext was safe at
+rest. It was not. A file that looks like a kill switch is treated as one.
+
+If you need to understand what the server does with message payloads, the answer is in
+[ADR-0010](../adr/ADR-0010-pure-relay-server.md): nothing. It relays opaque bytes.
+
 **If `ZK-PII` fails**, a log macro is being handed a raw IP address, email or phone number.
 All three are PII under `AGENTS.md` §4, and **I-1** forbids PII in any log, span or metric.
 Do not silence it by renaming the field — the address is the problem, not the label. For a

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -29,7 +29,7 @@ project_sync_enabled: true
 
 invariants:
   - {id: I-1, name: Zero-Knowledge,   met: partial, note: "rate_limit.rs logs a raw IP; span fields are not redacted"}
-  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78], note: "server side is done and no longer reads the flags, so PR-32c is unblocked; client-desktop still sends plaintext (PR-78) and client-mobile still sends groups in the clear (PR-76)"}
+  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78], note: "no switch can disable encryption - E2EE-FLAG passes and rules-verify now enforces it - and no client path transmits plaintext. Remaining: client-desktop cannot establish a session so it refuses every send (PR-79..PR-81), and mobile groups refuse for want of MLS"}
   - {id: I-3, name: Post-Quantum,     met: false,   closed_by: [PR-36, PR-37, PR-38, PR-39, PR-40]}
   - {id: I-4, name: Data Sovereignty, met: partial, note: "envoy/ingress.yaml hardcodes a domain"}
 
@@ -82,7 +82,7 @@ steps:
   - {id: PR-31d, issue: 153, phase: 3, type: docs, status: done, title: "ADR-0010 - the server is a pure relay"}
   - {id: PR-32a, issue: 43, phase: 3, type: security, status: done, title: "Delete the server-side E2EE handlers"}
   - {id: PR-32b, issue: 154, phase: 3, type: security, status: done, title: "Delete the E2EE and MLS configuration flags"}
-  - {id: PR-32c, issue: 155, phase: 3, type: security, status: todo, title: "Remove the E2EE kill-switch environment variables"}
+  - {id: PR-32c, issue: 155, phase: 3, type: security, status: done, title: "Remove the E2EE kill-switch environment variables"}
   - {id: PR-33, issue: 44, phase: 3, type: security, status: done, title: "Add cargo-fuzz targets for attacker-controlled parsers"}
   - {id: PR-34, issue: 45, phase: 3, type: security, status: done, title: "Add proptest suites for crypto invariants"}
   - {id: PR-35, issue: 46, phase: 3, type: chore, status: done, gate: G3, title: "Add baseline test coverage for notification-service and call-service"}

--- a/docs/spec/PRD.md
+++ b/docs/spec/PRD.md
@@ -122,7 +122,10 @@ Stated plainly, because a PRD that implies capability is a PRD that misleads.
 - **Post-quantum end to end.** The hybrid implementation exists in `crates/crypto`, but the
   `pq` feature is off by default and no proto field carries an ML-KEM key, so the server
   cannot publish one (PR-36…PR-40).
-- **Always-on encryption.** `GUARDYN_E2EE_ENABLED` still exists and the non-E2EE handler is
-  the registered one (PR-32).
+- **Always-on encryption, end to end.** The server side is done: the E2EE handler fork, the
+  configuration flags and the deployment variables are all gone (PR-32a/b/c), and both clients
+  now refuse to send rather than transmit plaintext (#226, #229, #163). What remains is that
+  `client-desktop` cannot yet establish a session, so it refuses every send — encryption is
+  never bypassed, but desktop one-to-one messaging does not function until PR-79…PR-81 land.
 - **A browser client.** Envoy routes three of six services; media, calls and notifications
   are not reachable from a browser today.

--- a/docs/spec/SAD.md
+++ b/docs/spec/SAD.md
@@ -53,7 +53,7 @@ Ten members in the `backend/` workspace.
 | Crate | Kind | Depends on | Role |
 |---|---|---|---|
 | `auth-service` | binary | common, crypto | Identity, devices, contacts, key bundles. 13 handlers. |
-| `messaging-service` | binary | common, crypto | Messages, conversations, groups, reactions, receipts. 32 handlers. |
+| `messaging-service` | binary | common, crypto | Messages, conversations, groups, reactions, receipts. 32 handlers. Relays `encrypted_content` byte-for-byte and holds no key material, so it exposes **no cryptographic configuration** — see [ADR-0010](../adr/ADR-0010-pure-relay-server.md). |
 | `presence-service` | binary | common | Reachability and status. 8 handlers. |
 | `media-service` | binary | common | Encrypted blob upload and retrieval. 9 handlers. |
 | `call-service` | binary | common, crypto | Call signalling and SFrame key exchange. |

--- a/infra/k8s/base/apps/messaging-service.yaml
+++ b/infra/k8s/base/apps/messaging-service.yaml
@@ -58,25 +58,9 @@ spec:
           value: "info"
         - name: RUST_LOG
           value: "info,guardyn_messaging_service=debug"
-        # Feature Flags for Cryptography
-        # E2EE Configuration - set GUARDYN_E2EE_ENABLED=true to enable end-to-end encryption
-        - name: GUARDYN_E2EE_ENABLED
-          value: "false"  # Gradual rollout: set to "true" to enable E2EE for 1-on-1 chats
-        - name: GUARDYN_E2EE_X3DH_ENABLED
-          value: "true"
-        - name: GUARDYN_E2EE_DOUBLE_RATCHET_ENABLED
-          value: "true"
-        - name: GUARDYN_E2EE_MAX_SKIPPED_KEYS
-          value: "1000"
-        # MLS Configuration - set GUARDYN_MLS_ENABLED=true to enable group encryption
-        - name: GUARDYN_MLS_ENABLED
-          value: "false"  # Gradual rollout: set to "true" to enable MLS group encryption
-        - name: GUARDYN_MLS_MAX_GROUP_SIZE
-          value: "256"
-        - name: GUARDYN_MLS_KEY_PACKAGE_TTL_DAYS
-          value: "30"
-        - name: GUARDYN_MLS_CIPHERSUITE
-          value: "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519"
+        # No cryptographic feature flags. The ratchet and MLS run on the clients; this
+        # service relays opaque bytes and holds no key material, so it has nothing to
+        # configure - see docs/adr/ADR-0010-pure-relay-server.md.
         # Service Endpoints
         - name: AUTH_SERVICE_ENDPOINT
           value: "http://auth-service.apps.svc.cluster.local:50051"

--- a/infra/k8s/overlays/prod/patches/production-overrides.yaml
+++ b/infra/k8s/overlays/prod/patches/production-overrides.yaml
@@ -115,11 +115,6 @@ spec:
               cpu: 2000m
               memory: 2Gi
           env:
-            # Production: Enable E2EE and MLS encryption
-            - name: GUARDYN_E2EE_ENABLED
-              value: "true"
-            - name: GUARDYN_MLS_ENABLED
-              value: "true"
             - name: GUARDYN_OBSERVABILITY__LOG_LEVEL
               value: "info"
             - name: RUST_LOG

--- a/infra/scripts/rules-verify.sh
+++ b/infra/scripts/rules-verify.sh
@@ -133,6 +133,30 @@ check_e2ee_dup() {
   fi
 }
 
+# ------------------------------------------------------------------ E2EE-FLAG
+# No deployment file may carry a switch that turns encryption off. PR-32b removed
+# the flags from the code, so nothing reads them; PR-32c removed the variables that
+# were still being set. Both halves matter - between them the variables were inert,
+# but a deployment file that looks like a kill switch reads as one whether or not
+# any code consults it, and the prod overlay set GUARDYN_E2EE_ENABLED: "true" as
+# though that were where encryption came from.
+check_e2ee_flag() {
+  local hits
+  #
+  # Excludes this script, which contains the pattern it searches for - the same
+  # self-match ORG-LOCAL and LANG-MD already carve out. A rule may state its own
+  # violation.
+  hits="$(grep -rln 'GUARDYN_E2EE_ENABLED\|GUARDYN_MLS_ENABLED' \
+            backend/crates backend/proto infra docker-compose.dev.yml 2>/dev/null \
+            | grep -v '^infra/scripts/rules-verify.sh$' || true)"
+  if [ -n "$hits" ]; then
+    fail "E2EE-FLAG: a configuration key can turn encryption off"
+    show "$hits"
+  else
+    pass "E2EE-FLAG: no encryption kill switch in code or deployment"
+  fi
+}
+
 # -------------------------------------------------------------------- ZK-PII
 # A log macro handed a raw IP, email or phone number. AGENTS.md §4 lists all
 # three as PII, and I-1 forbids PII in any log, span or metric.
@@ -239,6 +263,7 @@ check_rs_unwrap
 check_rs_unsafe
 check_zk_init
 check_e2ee_dup
+check_e2ee_flag
 check_zk_pii
 check_proto_edit
 check_lang_md


### PR DESCRIPTION
Closes #155

Removes `GUARDYN_E2EE_ENABLED`, `GUARDYN_MLS_ENABLED` and their four companions
(`E2EE_X3DH_ENABLED`, `E2EE_DOUBLE_RATCHET_ENABLED`, `E2EE_MAX_SKIPPED_KEYS`, the three
`MLS_*` settings) from `docker-compose.dev.yml` and both Kubernetes overlays. Nothing replaces
them.

## This is cleanup, not the behaviour change G3 anticipated

The sign-off treated PR-32c as the moment encryption stopped being optional. It was not — the
switches stopped doing anything several steps earlier:

```
$ grep -rn "e2ee_enabled\|E2eeConfig\|MlsConfig" backend/
(no output)
```

PR-32a removed the handler fork and PR-32b removed the config types. `send_message.rs:76` stores
`encrypted_content` byte-for-byte; the ratchet and MLS run on the clients
([ADR-0010](docs/adr/ADR-0010-pure-relay-server.md)).

## So why remove them at all?

Because **a deployment file that looks like a kill switch reads as one whether or not any code
consults it**, and both overlays were actively misleading:

- Dev set `GUARDYN_E2EE_ENABLED: "false"` under a comment offering it as a debugging
  convenience. Encryption was never something an operator could turn off for convenience.
- Prod set it to `"true"`, which read as though production encryption depended on it. It did
  not — and that is exactly the reasoning #163 used to argue desktop plaintext was safe at rest.

Inert-but-authoritative is the worst of both states.

## The block on #163 is also gone

`roadmap.yaml` recorded `blocked_by: 163`, on the reasoning that removing the flag would turn a
server-holds-the-key problem into a no-encryption-at-all one for `client-desktop`. That premise
expired when the server stopped encrypting. The block was lifted in #228 and the desktop leak
closed on its own merits in #163.

## E2EE-FLAG was a predicate nothing executed

`.claude/rules/00-invariants.md` listed it as `FAIL (4)` — and it was documented only, never
wired into `rules-verify`, so claiming it now passes would have rested on a grep I ran by hand.
It is now a real check.

Verified by reintroducing a variable and watching it fail rather than by trusting it:

```
FAIL E2EE-FLAG: a configuration key can turn encryption off
       docker-compose.dev.yml
```

It excludes its own source, like `ORG-LOCAL` and `LANG-MD` — the check contains the pattern it
searches for. A rule may state its own violation.

## Documentation — required, not optional

`docs/.manifest.yaml` maps `infra/k8s/` → `DEPLOYMENT.md` + `SAD.md`, and
`docker-compose.dev.yml` → `DEPLOYMENT.md`, so `docs-verify` check 2 hard-fails without these.

- **DEPLOYMENT.md** — a new *"There is no encryption switch"* section stating what was removed
  and why, including that the variables were inert before deletion. Also adds the desktop send
  regression to the known-gaps table.
- **SAD.md** — `messaging-service` exposes no cryptographic configuration.
- **PRD.md** — its "Always-on encryption" gap claimed *"`GUARDYN_E2EE_ENABLED` still exists and
  the non-E2EE handler is the registered one"*. Both untrue. Replaced with what actually
  remains: desktop cannot establish a session, so it refuses every send.

## Verification

```
just rules-verify    all checks passed, including the new E2EE-FLAG
just docs-verify     all five checks passed
grep GUARDYN_E2EE\|GUARDYN_MLS over backend/ infra/ docker-compose.dev.yml -> nothing
```

## Deliberately out of scope

The historical mentions in `AGENTS.md:55`, `implementation_plan.md:65`, `ROADMAP.md:74` and
`ADR-0010:90`. Those are narrative records of what *was* true, and rewriting them would erase the
history that explains why the predicate exists.

## Budget

9 files, 116 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
