### PR TITLE
fix(desktop): show an explicit cannot-decrypt placeholder

### DIFF
--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -633,6 +633,14 @@ fn message_associated_data(sender_user_id: &str, recipient_user_id: &str) -> Vec
 /// byte-for-byte, so an unencrypted send is plaintext at rest, not merely plaintext in flight.
 pub const ENCRYPTION_UNAVAILABLE: &str = "encryption unavailable";
 
+/// Shown in place of content that could not be decrypted.
+///
+/// Kept identical to `client-desktop/src/lib/undecryptable.ts` and to
+/// `client-mobile/lib/core/crypto/undecryptable_message.dart`, so the clients say the same
+/// thing. Callers set a flag alongside it; the UI keys off the flag rather than matching this
+/// string, so a user who types these words is still rendered as having written them.
+pub const UNDECRYPTABLE_PLACEHOLDER: &str = "Message cannot be decrypted";
+
 /// Encrypt one message for a peer and return the serialized ciphertext.
 ///
 /// This is the single encryption entry point for the send path. `encrypt_message` exposes it

--- a/client-desktop/src-tauri/src/commands/messaging.rs
+++ b/client-desktop/src-tauri/src/commands/messaging.rs
@@ -32,6 +32,9 @@ pub struct Message {
     pub conversation_id: String,
     pub sender_id: String,
     pub content: String,
+    /// Set when `content` could not be decrypted and is the placeholder rather than anything
+    /// the sender wrote. The UI keys off this rather than matching the placeholder text.
+    pub undecryptable: bool,
     pub timestamp: i64,
     pub status: MessageStatus,
     pub reply_to: Option<String>,
@@ -116,7 +119,9 @@ pub async fn send_message(
                 id: result.message_id,
                 conversation_id: request.conversation_id,
                 sender_id: self_user_id,
+                // Our own outgoing text, never a decryption result.
                 content: request.content,
+                undecryptable: false,
                 timestamp: result.server_timestamp,
                 status: match result.delivery_status {
                     0 => MessageStatus::Sending,
@@ -198,15 +203,22 @@ pub async fn get_messages(
             let result: Vec<Message> = messages
                 .into_iter()
                 .map(|m| {
-                    // Decrypt message content
-                    // In a real implementation, we would use Double Ratchet session
-                    let content = String::from_utf8_lossy(&m.encrypted_content).to_string();
+                    // Show that we could not decrypt, rather than showing what we could not
+                    // decrypt. This was `String::from_utf8_lossy(&m.encrypted_content)`, which
+                    // cannot fail - so ciphertext rendered as replacement characters instead of
+                    // as an error, and anything that happened to be valid UTF-8 rendered as the
+                    // message (#232).
+                    //
+                    // Every message is undecryptable today, because nothing on this client
+                    // establishes a session yet (PR-79..PR-81). Saying so is the honest result.
+                    let content = crate::commands::crypto::UNDECRYPTABLE_PLACEHOLDER.to_string();
 
                     Message {
                         id: m.message_id,
                         conversation_id: conversation_id.clone(),
                         sender_id: m.sender_user_id,
                         content,
+                        undecryptable: true,
                         timestamp: m.server_timestamp,
                         status: match m.delivery_status {
                             0 => MessageStatus::Sending,

--- a/client-desktop/src/components/chat/MessageBubble.tsx
+++ b/client-desktop/src/components/chat/MessageBubble.tsx
@@ -22,6 +22,12 @@ export interface MessageReaction {
 export interface MessageBubbleProps {
   /** Message content */
   content: string;
+  /**
+   * Set when [content] is the cannot-decrypt placeholder rather than anything the sender
+   * wrote. Keyed off rather than string-matching the placeholder, so a user who types those
+   * words is still rendered as having written them.
+   */
+  undecryptable?: boolean;
   /** Message timestamp */
   timestamp: Date | string;
   /** Whether this message was sent by the current user */
@@ -207,7 +213,35 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
 
           {/* Text content */}
           <Show when={props.content.trim()}>
-            <p class="whitespace-pre-wrap break-words">{props.content}</p>
+            <Show
+              when={props.undecryptable}
+              fallback={
+                <p class="whitespace-pre-wrap break-words">{props.content}</p>
+              }
+            >
+              {/* Styled apart from real content on purpose: the placeholder must not be
+                  mistakable for something the sender wrote. */}
+              <p
+                class="whitespace-pre-wrap break-words italic opacity-70 flex items-center gap-1"
+                data-undecryptable="true"
+              >
+                <svg
+                  class="w-4 h-4 shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"
+                  />
+                </svg>
+                {props.content}
+              </p>
+            </Show>
           </Show>
 
           {/* Timestamp and read status */}

--- a/client-desktop/src/lib/undecryptable.ts
+++ b/client-desktop/src/lib/undecryptable.ts
@@ -1,0 +1,20 @@
+/**
+ * What a received message becomes when it cannot be decrypted.
+ *
+ * The receive path used to present whatever arrived as the message text - `data.content`
+ * straight into the store on the WebSocket path, `String::from_utf8_lossy` on the gRPC one.
+ * That is fail-open: a payload that could not be authenticated was displayed as though it had
+ * been, and `from_utf8_lossy` cannot fail, so real ciphertext rendered as replacement
+ * characters rather than as an error.
+ *
+ * Decryption fails for ordinary reasons as well as hostile ones - a peer whose session was
+ * never established, a message that arrives after a reinstall, a wire format this build
+ * predates (ADR-0011 versions the ratchet format precisely so that case is distinguishable).
+ * The user is told, rather than shown noise that looks like content.
+ *
+ * Kept deliberately identical to `client-mobile/lib/core/crypto/undecryptable_message.dart`,
+ * so the two clients say the same thing.
+ */
+
+/** Placeholder shown in place of content that could not be decrypted. */
+export const UNDECRYPTABLE_PLACEHOLDER = 'Message cannot be decrypted';

--- a/client-desktop/src/pages/Chat.test.tsx
+++ b/client-desktop/src/pages/Chat.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Conversation, Message } from '../types';
 
 // Create hoisted mock that can be used by vi.mock
-const { mockInvoke, mockWs, mockEncryptMessage } = vi.hoisted(() => {
+const { mockInvoke, mockWs, mockEncryptMessage, mockDecryptMessage } = vi.hoisted(() => {
   const ws = {
     connect: vi.fn(async () => {}),
     disconnect: vi.fn(),
@@ -18,15 +18,19 @@ const { mockInvoke, mockWs, mockEncryptMessage } = vi.hoisted(() => {
     onStateChange: vi.fn((cb: (state: string) => void) => {
       ws._stateCb = cb;
     }),
-    onMessage: vi.fn(),
+    onMessage: vi.fn((cb: (data: unknown) => void) => {
+      ws._messageCb = cb;
+    }),
     onTyping: vi.fn(),
     isConnected: false,
     _stateCb: undefined as ((state: string) => void) | undefined,
+    _messageCb: undefined as ((data: unknown) => void) | undefined,
   };
   return {
     mockInvoke: vi.fn(),
     mockWs: ws,
     mockEncryptMessage: vi.fn(),
+    mockDecryptMessage: vi.fn(),
   };
 });
 
@@ -52,6 +56,7 @@ vi.mock('../api/websocket', () => ({
 vi.mock('../services/encryption', () => ({
   encryptionManager: {
     encryptMessage: (...args: unknown[]) => mockEncryptMessage(...args),
+    decryptMessage: (...args: unknown[]) => mockDecryptMessage(...args),
   },
 }));
 
@@ -60,6 +65,7 @@ vi.mock('../api/websocket.mock', () => ({
   stopMockGenerator: vi.fn(),
 }));
 
+import { UNDECRYPTABLE_PLACEHOLDER } from '../lib/undecryptable';
 import { resetMessageStore } from '../stores/messageStore';
 import Chat from './Chat';
 
@@ -134,6 +140,7 @@ describe('Chat Page', () => {
     mockWs.sendMessage.mockClear();
     mockWs._stateCb = undefined;
     mockEncryptMessage.mockReset();
+    mockDecryptMessage.mockReset();
     resetMessageStore();
   });
 
@@ -296,6 +303,74 @@ describe('Chat Page', () => {
     // that used to be invoked alongside the socket.
     expect(mockInvoke).not.toHaveBeenCalledWith('send_message', expect.anything());
     expect(JSON.stringify(mockWs.sendMessage.mock.calls)).not.toContain('New message');
+  });
+
+  it('renders an inbound message as the placeholder when it cannot be decrypted', async () => {
+    // The receive path put `data.content` straight into the store, so ciphertext - or whatever
+    // else arrived - was displayed as the message text (#232).
+    setupMockInvoke(mockConversations, mockMessages, mockMessages);
+    mockDecryptMessage.mockRejectedValue(
+      new Error('No established session with peer: user-1')
+    );
+
+    renderWithRouter(() => <Chat />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+    await fireEvent.click(screen.getByText('Alice').closest('button')!);
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+    });
+
+    mockWs._messageCb?.({
+      message_id: 'msg-in-1',
+      conversation_id: 'conv-1',
+      sender_id: 'user-1',
+      sender_device_id: 'device-1',
+      recipient_id: 'user-2',
+      content: 'AQIDBAUGBwgJCgsMDQ4PEA==',
+      encrypted: true,
+      timestamp: Date.now(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(UNDECRYPTABLE_PLACEHOLDER)).toBeInTheDocument();
+    });
+
+    // The ciphertext must not appear anywhere on screen.
+    expect(screen.queryByText('AQIDBAUGBwgJCgsMDQ4PEA==')).not.toBeInTheDocument();
+  });
+
+  it('renders a decrypted inbound message as ordinary text', async () => {
+    setupMockInvoke(mockConversations, mockMessages, mockMessages);
+    mockDecryptMessage.mockResolvedValue('the real message');
+
+    renderWithRouter(() => <Chat />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+    await fireEvent.click(screen.getByText('Alice').closest('button')!);
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+    });
+
+    mockWs._messageCb?.({
+      message_id: 'msg-in-2',
+      conversation_id: 'conv-1',
+      sender_id: 'user-1',
+      sender_device_id: 'device-1',
+      recipient_id: 'user-2',
+      content: 'AQIDBAUGBwgJCgsMDQ4PEA==',
+      encrypted: true,
+      timestamp: Date.now(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('the real message')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(UNDECRYPTABLE_PLACEHOLDER)).not.toBeInTheDocument();
   });
 
   it('refuses to send when encryption is unavailable', async () => {

--- a/client-desktop/src/pages/Chat.tsx
+++ b/client-desktop/src/pages/Chat.tsx
@@ -8,6 +8,7 @@ import { ForwardModal, MessageInput, MessageStatusIndicator, QuotedMessage, Reac
 import { TypingIndicator } from '../components/shared';
 import { CallAudioService } from '../services/callAudioService';
 import { encryptionManager } from '../services/encryption';
+import { UNDECRYPTABLE_PLACEHOLDER } from '../lib/undecryptable';
 import {
   addMessage,
   addTypingUser,
@@ -137,12 +138,35 @@ const Chat: Component<ChatPageProps> = () => {
           // For 1-to-1 chats, use conversation name as sender name
           const senderDisplayName = conv?.name || 'User';
 
+          // Decrypt, or show that we could not. `data.content` went straight into the store
+          // before, so ciphertext was rendered as the message text (#232).
+          let content = UNDECRYPTABLE_PLACEHOLDER;
+          let undecryptable = true;
+          try {
+            const self = selfUserId();
+            if (!self) {
+              throw new Error('no local user id; cannot build the message associated data');
+            }
+            content = await encryptionManager.decryptMessage(
+              data.sender_id,
+              { ciphertext: data.content, nonce: '', header: '' },
+              self,
+            );
+            undecryptable = false;
+          } catch (err) {
+            // Expected until session establishment lands: there is no session to decrypt with,
+            // so every inbound message is undecryptable. Showing the placeholder is the honest
+            // result, and is what the user would see anyway for a genuinely broken message.
+            console.warn('[Chat] Could not decrypt message:', err);
+          }
+
           addMessage({
             id: data.message_id || crypto.randomUUID(),
             conversationId: convId,
             senderId: data.sender_id || 'other',
             senderName: senderDisplayName,
-            content: data.content,
+            content,
+            undecryptable,
             timestamp: typeof data.timestamp === 'string' ? new Date(data.timestamp).getTime() : (data.timestamp || Date.now()),
             status: 'delivered',
           });
@@ -196,6 +220,7 @@ const Chat: Component<ChatPageProps> = () => {
         id: string;
         sender_id: string;
         content: string;
+        undecryptable: boolean;
         timestamp: string;
       }>>('get_messages', { conversationId: id });
 
@@ -211,6 +236,7 @@ const Chat: Component<ChatPageProps> = () => {
           senderId: msg.sender_id,
           senderName: msg.sender_id === 'self' ? 'You' : partnerName,
           content: msg.content,
+          undecryptable: msg.undecryptable,
           timestamp: new Date(msg.timestamp).getTime(),
           status: 'delivered',
         });
@@ -629,7 +655,35 @@ const Chat: Component<ChatPageProps> = () => {
                           {message.senderName}
                         </p>
                       </Show>
-                      <p>{message.content}</p>
+                      {/* An undecryptable message is styled apart from real content on
+                          purpose: the placeholder must not be mistakable for something the
+                          sender wrote. Keyed off the flag, not the text, so a user who types
+                          those words is still rendered as having written them. */}
+                      <Show
+                        when={message.undecryptable}
+                        fallback={<p>{message.content}</p>}
+                      >
+                        <p
+                          class="italic opacity-70 flex items-center gap-1"
+                          data-undecryptable="true"
+                        >
+                          <svg
+                            class="w-4 h-4 shrink-0"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"
+                            />
+                          </svg>
+                          {message.content}
+                        </p>
+                      </Show>
                       <div class="flex items-center justify-end gap-1 mt-1">
                         <p class="text-xs opacity-70">
                           {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}

--- a/client-desktop/src/stores/messageStore.ts
+++ b/client-desktop/src/stores/messageStore.ts
@@ -32,6 +32,12 @@ export interface Message {
   /** Number of retry attempts */
   retryCount?: number;
   reactions?: { emoji: string; count: number; hasReacted: boolean }[];
+  /**
+   * Set when the content could not be decrypted, in which case `content` is the placeholder
+   * rather than anything the sender wrote. The UI keys off this rather than matching the
+   * placeholder text, so a user who types those words is still rendered as having written them.
+   */
+  undecryptable?: boolean;
   /** Media attachment ID (from media-service) */
   mediaId?: string;
   /** Optional attachment metadata */

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -152,5 +152,5 @@ steps:
   # roadmap-sync reopens each of these seconds after it merges.
   - {id: PR-86, issue: 228, phase: 3, type: chore, status: done, title: "Reconcile roadmap status so roadmap-sync stops reopening issues"}
   - {id: PR-87, issue: 231, phase: 3, type: fix, status: done, title: "client-mobile - show an explicit cannot-decrypt placeholder"}
-  - {id: PR-88, issue: 232, phase: 3, type: fix, status: todo, title: "client-desktop - show an explicit cannot-decrypt placeholder"}
+  - {id: PR-88, issue: 232, phase: 3, type: fix, status: done, title: "client-desktop - show an explicit cannot-decrypt placeholder"}
   - {id: PR-89, issue: 235, phase: 3, type: fix, status: todo, title: "group_chat_page_test renders a replica of the page, not the page"}


### PR DESCRIPTION
Closes #232

The desktop mirror of #231. The two clients should not disagree about what a message you cannot
read looks like.

## Both receive paths displayed what they could not decrypt

```rust
// commands/messaging.rs:187
let content = String::from_utf8_lossy(&m.encrypted_content).to_string();
```

```ts
// Chat.tsx:139
content: data.content,
```

`from_utf8_lossy` **cannot fail**, so real ciphertext rendered as replacement characters rather
than as an error, and anything that happened to be valid UTF-8 rendered as the message. The
WebSocket path did not attempt decryption at all: `EncryptionManager.decryptMessage`
(`services/encryption.ts:257`) existed with **zero callers**, as did the
`EncryptionService.receiveMessage` beneath it.

That is fail-open. A payload that could not be authenticated was displayed as though it had been,
and a failed tag is indistinguishable from tampering, a desynchronised ratchet, and a wire
version this build predates ([ADR-0011](docs/adr/ADR-0011-ratchet-header-authentication.md)
added the version byte precisely so those are distinguishable). None makes the payload safe to
show.

## The fix

The WebSocket path routes through the existing `decryptMessage`; the gRPC path returns the
placeholder with an `undecryptable` flag on the `Message` struct.

The UI keys off **the flag, not the text**, so a user who types *"Message cannot be decrypted"*
is still rendered as having written it. The placeholder is italic, dimmed and preceded by a lock
icon.

Every inbound message is undecryptable today, because nothing on this client establishes a
session yet (PR-79…PR-81). Saying so plainly is the honest result, and is what a genuinely
broken message would show anyway.

## The placeholder is pinned in three places

`commands/crypto.rs`, `src/lib/undecryptable.ts`, and the Dart constant from #231 — all carrying
the same string and a comment saying the others must match. Three copies is the cost of two
clients and a Rust backend not sharing a string table; the alternative is them drifting silently.

## Tests

- `renders an inbound message as the placeholder when it cannot be decrypted` — also asserts the
  ciphertext appears nowhere on screen.
- `renders a decrypted inbound message as ordinary text` — proves the placeholder is not simply
  always shown, which is the failure mode a one-sided test would miss.

The WebSocket mock gained an `onMessage` capture so an inbound message can actually be delivered
in a test; previously nothing exercised that handler.

## Verification

```
npx vitest run     28 files, 413 passed, 17 skipped
npx tsc --noEmit   clean
npm run lint       0 errors
cargo test --all-features   50 / 51 passed, 0 failed
just rules-verify  all checks passed
```

## docs-impact:none — reason

`docs/.manifest.yaml` maps no document to `client-desktop/`. ADR-0011 already anticipated an
unsupported version being reported rather than surfacing as a bad tag; this is the client
honouring it.

## Deliberately out of scope

Session establishment — PR-79 (retain prekey privates), PR-80 (X3DH responder), PR-81 (ratchet
rehydration). Until those land this client can neither send nor read, which is the deliberate
consequence of refusing to do either in the clear.

## Budget

8 files, 227 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
