### PR TITLE
feat(docs): generate STATE.md from roadmap.yaml and check it

### DIFF
--- a/.claude/rules/40-doc-sync.md
+++ b/.claude/rules/40-doc-sync.md
@@ -1,7 +1,7 @@
 ---
 id: rules-doc-sync
 type: rules
-status: draft
+status: accepted
 owns: [docs/]
 read_when: [changing any source file, adding a document, before opening a PR]
 ---
@@ -9,10 +9,12 @@ read_when: [changing any source file, adding a document, before opening a PR]
 # 40 · Documentation sync
 
 The algorithm that keeps documentation from drifting. It is a **mechanism, not a
-convention**: once PR-15 and PR-16 land, drift is a build failure rather than a review nit.
+convention**: drift is a build failure, not a review nit.
 
-`status: draft` until PR-15 ships `docs/.manifest.yaml` and `just docs-verify`. The
-algorithm below is what an agent follows by hand in the meantime.
+This file was `status: draft` pending PR-15 and PR-16. Both landed —
+[`docs/.manifest.yaml`](../../docs/.manifest.yaml), `just docs-verify` and
+[`docs.yml`](../../.github/workflows/docs.yml) all exist and run on every pull request — so
+the algorithm below is executed, not followed by hand.
 
 ## The loop, per micro-step
 
@@ -25,7 +27,7 @@ algorithm below is what an agent follows by hand in the meantime.
    not acceptable.
 5. Run `just docs-verify` before pushing.
 
-## The five checks
+## The six checks
 
 | # | Check | Fails when |
 |---|---|---|
@@ -34,6 +36,7 @@ algorithm below is what an agent follows by hand in the meantime.
 | 3 | Glossary | a term defined in `GLOSSARY.md` appears under one of its `forbidden_aliases` |
 | 4 | Links | a relative link does not resolve, **or** a tracked document links into `_local/` |
 | 5 | Language | Cyrillic appears in `docs/**` outside the allowlisted policy file |
+| 6 | Staleness | `docs/roadmap/STATE.md` differs from what `just docs-state` renders today |
 
 Check 2 is the one that matters. The rest catch mistakes; check 2 catches **neglect**.
 
@@ -48,16 +51,40 @@ type: adr                 # adr | spec | ops | roadmap | index | glossary | rule
 status: accepted          # draft | accepted | superseded | deprecated
 owns: [backend/crates/crypto/src/pqxdh.rs]
 read_when: [touching crypto, changing key bundles]
-tokens: 820               # measured, regenerated - never hand-edited
+tokens: 820               # an estimate; only STATE.md's is generated and checked (#241)
 supersedes: []
 ---
 ```
 
 ## Regenerated, never hand-edited
 
-`docs/INDEX.md`, `docs/roadmap/STATE.md` and every `tokens:` value are **generated**.
-`docs-verify` fails if a generated file is stale. Editing one by hand will be reverted by
-the next generation run — change the generator or the source, not the output.
+`docs/roadmap/STATE.md` is **generated** by `just docs-state` from `docs/roadmap/roadmap.yaml`,
+and check 6 fails if the committed file differs. Editing it by hand will be reverted by the
+next generation run — change `roadmap.yaml` or the generator, not the output.
+
+Generation runs in one direction: `roadmap.yaml` → `STATE.md`. The generator never writes the
+YAML and never reads GitHub. `roadmap.yaml` records the **desired** state, so refreshing it
+from live issue state would invert the direction of truth — the mistake that reopened
+twenty-one correctly-closed issues before #228.
+
+### What this section used to claim, and why the correction matters
+
+It read: *"`docs/INDEX.md`, `docs/roadmap/STATE.md` and every `tokens:` value are generated.
+`docs-verify` fails if a generated file is stale."* **None of that was true.** PR-15 shipped
+five checks and scoped the generator out, so three documents carried a header telling the
+reader they were machine-derived while nothing derived them and nothing noticed them rotting.
+`STATE.md` went stale inside the same phase that created it and ended up sixty steps behind
+the YAML — worse than no such file, because the header made the wrong answer look
+authoritative. That was [#101](https://github.com/guardyn/guardyn/issues/101).
+
+`docs/INDEX.md` and the per-document `tokens:` values are **still hand-written** and are
+still not checked. They are [#241](https://github.com/guardyn/guardyn/issues/241). Until that
+lands, treat a `tokens:` value as an estimate somebody typed — several documents carry a
+literal `tokens: 0`. The one exception is `STATE.md`'s own, which its generator computes as
+characters ÷ 4 over the body, and which check 6 therefore holds to.
+
+A rule that describes a mechanism nobody built trains readers to disbelieve the rules. State
+what is enforced; name the rest as an open issue.
 
 ## Why this exists
 

--- a/Justfile
+++ b/Justfile
@@ -497,9 +497,14 @@ install-hooks:
     @git config core.hooksPath .githooks
     @echo "[hooks] core.hooksPath -> .githooks"
 
-# Verify the documentation base: frontmatter, impact, glossary, links, language.
+# Verify the documentation base: frontmatter, impact, glossary, links, language, staleness.
 docs-verify:
     @bash infra/scripts/docs-verify.sh
+
+# docs-verify check 6 fails when the committed file differs from this output.
+# Regenerate docs/roadmap/STATE.md from docs/roadmap/roadmap.yaml.
+docs-state:
+    @bash infra/scripts/docs-state.sh --write
 
 # Reconcile docs/roadmap/roadmap.yaml into GitHub Issues and the Project board.
 # Dry by default; pass 0 to write. Requires GUARDYN_PROJECT_TOKEN for the board half.

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -89,7 +89,7 @@ cheap for a local cluster.
 just docs-verify
 ```
 
-Five checks — frontmatter, impact, glossary, links, language — defined in
+Six checks — frontmatter, impact, glossary, links, language, staleness — defined in
 [`../../.claude/rules/40-doc-sync.md`](../../.claude/rules/40-doc-sync.md) and run in CI on
 every pull request. Check 2 is the one that matters: changing a source path without
 updating the documents mapped to it in `docs/.manifest.yaml` fails the build, unless the PR
@@ -232,6 +232,22 @@ pass is never skipped.
 just roadmap-sync        # dry: print the plan, write nothing
 just roadmap-sync 0      # write
 ```
+
+### Regenerating STATE.md
+
+[`STATE.md`](../roadmap/STATE.md) is rendered from `roadmap.yaml`, in that direction only:
+
+```sh
+just docs-state          # rewrite docs/roadmap/STATE.md
+```
+
+Run it in the same pull request that changes a step's `status`, a gate's `status`, or an
+invariant. `docs-verify` check 6 regenerates the file into a temp path and fails on any
+difference, so a forgotten run is caught by CI rather than by a reader trusting a stale
+number. **Never hand-edit `STATE.md`** — the next generation run reverts it.
+
+It renders only what the YAML records. If something you want in there is not in
+`roadmap.yaml`, add it to the YAML; do not add it to the output.
 
 It runs in CI on every push to `main` that touches `roadmap.yaml`, and a manual
 `workflow_dispatch` defaults to dry.

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,22 +4,14 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 397
+tokens: 949
 supersedes: []
 ---
 
 # State
 
-**Derived from [`roadmap.yaml`](roadmap.yaml). Do not hand-edit** — when the two disagree, the
-YAML wins.
-
-> This file *claims* to be generated and to be checked by `docs-verify`. Neither is true yet:
-> no generator exists and `docs-verify` has no staleness check. That is
-> [#101](https://github.com/guardyn/guardyn/issues/101), and until it lands this file is
-> maintained by hand and can rot between gates. It was last reconciled against the YAML and
-> against GitHub on the date below.
-
-Reconciled: 2026-09-07
+**Generated from [`roadmap.yaml`](roadmap.yaml) by `just docs-state`. Do not hand-edit** -
+`docs-verify` check 6 regenerates this file and fails on any difference.
 
 ## Progress
 
@@ -27,53 +19,59 @@ Reconciled: 2026-09-07
 |---|---|---|---|
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
-| 3 | 0 | 12 | `░░░░░░░░░░` |
-| 4 | 0 | 9 | `░░░░░░░░░░` |
-| **all** | **26** | **47** | |
+| 3 | 54 | 65 | `████████░░` |
+| 4 | 0 | 10 | `░░░░░░░░░░` |
+| **all** | **80** | **101** | |
 
 ## Position
 
-- **Current phase:** 2 — complete
-- **Next gate:** **G2, reached** after PR-23. Awaiting explicit user approval.
-- **Next step:** PR-24 — Add `common/src/redact.rs` (#35), and it must not start before G2 is
-  approved.
+- **Current phase:** 3
+- **Next gate:** G4
+- **Open steps:** 21 of 101
 
 ## Gates
 
-| Gate | After | Status |
-|---|---|---|
-| G1 | PR-17 | **passed** |
-| G2 | PR-23 | **reached — awaiting approval** |
-| G3 | PR-35 | not reached |
-| G4 | PR-44 | not reached |
+| Gate | After | Phase | Status |
+|---|---|---|---|
+| G1 | PR-17 | 1 | passed |
+| G2 | PR-23 | 2 | passed |
+| G3 | PR-35 | 3 | passed |
+| G4 | PR-44 | 4 | not-reached |
 
 ## Invariants
-
-Unchanged by Phase 2, which touched tracking and build strategy rather than behaviour.
 
 | # | Name | Met | Closed by |
 |---|---|---|---|
 | I-1 | Zero-Knowledge | partial | — |
-| | | | *2 services log outside init_tracing; rate_limit.rs logs a raw IP* |
-| I-2 | Always-On E2EE | False | PR-32 |
-| I-3 | Post-Quantum | False | PR-36, PR-37, PR-38, PR-39, PR-40 |
+| | | | *rate_limit.rs logs a raw IP; span fields are not redacted* |
+| I-2 | Always-On E2EE | partial | PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78 |
+| | | | *no switch can disable encryption - E2EE-FLAG passes and rules-verify now enforces it - and no client path transmits plaintext. Remaining: client-desktop cannot establish a session so it refuses every send (PR-79..PR-81), and mobile groups refuse for want of MLS* |
+| I-3 | Post-Quantum | false | PR-36, PR-37, PR-38, PR-39, PR-40 |
 | I-4 | Data Sovereignty | partial | — |
 | | | | *envoy/ingress.yaml hardcodes a domain* |
 
-## Blocked
+## Open steps
 
-**P-1** — `project_sync_enabled: false`. No token available to CI can read or write the
-Project v2 board: the organization rejects fine-grained PATs over a 366-day lifetime, and the
-fallback OAuth token has no `project` scope. Needs a human to create `GUARDYN_PROJECT_TOKEN`
-with `repo` + `project` scope.
-
-Its blast radius shrank in Phase 2. Phase is now tracked by **milestones**, which are plain
-REST, so `roadmap-sync` and `pr-link` both do real work with the ambient token; only the board
-half waits.
-
-## Carried into Phase 3
-
-| | |
-|---|---|
-| [#116](https://github.com/guardyn/guardyn/issues/116) | Phase 1 straggler — `desktop-build.yml` test job can never pass |
-| [#101](https://github.com/guardyn/guardyn/issues/101) | `docs-verify` has no staleness check, and this file is maintained by hand because of it |
+| Step | Phase | Issue | Title |
+|---|---|---|---|
+| PR-56 | 3 | [#188](https://github.com/guardyn/guardyn/issues/188) | Regenerate or drop the stale client-desktop protobuf |
+| PR-57 | 3 | [#180](https://github.com/guardyn/guardyn/issues/180) | Make roadmap-sync detect drift and create issues |
+| PR-62 | 3 | [#191](https://github.com/guardyn/guardyn/issues/191) | Clear the 132 client-desktop clippy errors |
+| PR-63 | 3 | [#192](https://github.com/guardyn/guardyn/issues/192) | Reconcile the desktop coverage thresholds with reality |
+| PR-65 | 3 | [#199](https://github.com/guardyn/guardyn/issues/199) | Stop Build Linux flaking in linuxdeploy |
+| PR-79 | 3 | — | client-desktop - retain private prekey material |
+| PR-80 | 3 | — | client-desktop - implement the X3DH responder path |
+| PR-81 | 3 | — | client-desktop - restore the ratchet store from persisted state |
+| PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
+| PR-83 | 3 | — | Clear the 314 flutter analyze info diagnostics |
+| PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
+| PR-36 | 4 | [#47](https://github.com/guardyn/guardyn/issues/47) | Extend protos with ML-KEM key material fields |
+| PR-37 | 4 | [#48](https://github.com/guardyn/guardyn/issues/48) | Persist and serve ML-KEM public keys in auth-service |
+| PR-38 | 4 | [#49](https://github.com/guardyn/guardyn/issues/49) | Enable the pq feature across backend services |
+| PR-39 | 4 | [#50](https://github.com/guardyn/guardyn/issues/50) | Wire PqxdhProtocol into messaging-service session establishment |
+| PR-40 | 4 | [#51](https://github.com/guardyn/guardyn/issues/51) | Add fuzz, proptest and bench coverage for the hybrid PQ path |
+| PR-41 | 4 | [#52](https://github.com/guardyn/guardyn/issues/52) | Make rate limiting distributed or document the single-replica constraint |
+| PR-42 | 4 | [#53](https://github.com/guardyn/guardyn/issues/53) | Fix the inverted secrets gitignore |
+| PR-43 | 4 | [#54](https://github.com/guardyn/guardyn/issues/54) | Wire the compose observability stack |
+| PR-44 | 4 | [#55](https://github.com/guardyn/guardyn/issues/55) | Deployment parity - call-service k8s Deployment and image digest pins |
+| PR-91 | 4 | [#241](https://github.com/guardyn/guardyn/issues/241) | Generate docs/INDEX.md and the tokens: counts |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -33,11 +33,19 @@ invariants:
   - {id: I-3, name: Post-Quantum,     met: false,   closed_by: [PR-36, PR-37, PR-38, PR-39, PR-40]}
   - {id: I-4, name: Data Sovereignty, met: partial, note: "envoy/ingress.yaml hardcodes a domain"}
 
+# `status` is the gate's own state, recorded here rather than inferred from its step.
+# A gate step reaching `done` means its WORK landed; it does not mean the user approved the
+# gate, and AGENTS.md 2.5 makes that approval the thing that lets the next phase begin. Only
+# one of those two facts is derivable from a step, so the other needs somewhere to live.
+#
+#   not-reached - the gate's step has not landed
+#   reached     - the step landed, approval outstanding
+#   passed      - the user approved
 gates:
-  - {id: G1, after: PR-17, phase: 1, description: "Purge, agent contract, documentation core, CI truthfulness"}
-  - {id: G2, after: PR-23, phase: 2, description: "Board sync, SSOT rules, protobuf unification"}
-  - {id: G3, after: PR-35, phase: 3, description: "ZK logging, store hygiene, E2EE repair, fuzzing. Behaviour-change sign-off required"}
-  - {id: G4, after: PR-44, phase: 4, description: "Hybrid PQXDH end to end, launch optimization"}
+  - {id: G1, after: PR-17, phase: 1, status: passed, description: "Purge, agent contract, documentation core, CI truthfulness"}
+  - {id: G2, after: PR-23, phase: 2, status: passed, description: "Board sync, SSOT rules, protobuf unification"}
+  - {id: G3, after: PR-35, phase: 3, status: passed, description: "ZK logging, store hygiene, E2EE repair, fuzzing. Behaviour-change sign-off required"}
+  - {id: G4, after: PR-44, phase: 4, status: not-reached, description: "Hybrid PQXDH end to end, launch optimization"}
 
 steps:
   - {id: PR-00, issue: 56, phase: 1, type: docs, status: done, title: "Land implementation_plan.md as the execution charter"}
@@ -154,3 +162,8 @@ steps:
   - {id: PR-87, issue: 231, phase: 3, type: fix, status: done, title: "client-mobile - show an explicit cannot-decrypt placeholder"}
   - {id: PR-88, issue: 232, phase: 3, type: fix, status: done, title: "client-desktop - show an explicit cannot-decrypt placeholder"}
   - {id: PR-89, issue: 235, phase: 3, type: fix, status: todo, title: "group_chat_page_test renders a replica of the page, not the page"}
+  # Tracking mechanism. STATE.md has claimed to be generated since PR-14 while nothing
+  # generated it, so it rotted sixty steps behind this file. PR-90 builds the generator and
+  # the check that fails on drift; PR-91 is the half of #101 that did not fit the budget.
+  - {id: PR-90, issue: 101, phase: 3, type: feat, status: done, title: "Generate STATE.md from roadmap.yaml and fail docs-verify on drift"}
+  - {id: PR-91, issue: 241, phase: 4, type: feat, status: todo, title: "Generate docs/INDEX.md and the tokens: counts"}

--- a/infra/scripts/docs-state.sh
+++ b/infra/scripts/docs-state.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# Render docs/roadmap/STATE.md from docs/roadmap/roadmap.yaml. Run via `just docs-state`.
+#
+# STATE.md has carried a "generated, never hand-edited" header since PR-14 while nothing
+# generated it. It rotted sixty steps behind the YAML, which is worse than having no such
+# file: the header tells the reader the number is machine-derived and therefore trustworthy.
+# This script is the missing half, and docs-verify check 6 is what makes the drift fail a
+# build rather than wait for someone to notice.
+#
+# One direction only: roadmap.yaml -> STATE.md. This script never writes the YAML and never
+# reads GitHub. roadmap.yaml:7-15 makes `status` the DESIRED state, so copying it back from
+# live issues would invert the direction of truth - the mistake that reopened twenty-one
+# correctly-closed issues before #228.
+#
+# It renders only what the YAML can support. The hand-maintained file carried "Blocked" and
+# "Carried into Phase N" sections that were prose about facts recorded nowhere; a generator
+# cannot derive them, and inventing them is how a generated file starts lying again.
+#
+# Bash, awk and sed only - no YAML parser. docs-verify.sh:13-14 sets that constraint, and
+# I-4 makes every added runtime dependency a cost paid by every self-hoster.
+#
+# Usage:
+#   docs-state.sh            print the rendered document to stdout
+#   docs-state.sh --write    write it to docs/roadmap/STATE.md
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+ROADMAP="docs/roadmap/roadmap.yaml"
+TARGET="docs/roadmap/STATE.md"
+
+[ -f "$ROADMAP" ] || { echo "docs-state: missing $ROADMAP" >&2; exit 1; }
+
+WRITE=0
+case "${1:-}" in
+  --write) WRITE=1 ;;
+  "") ;;
+  *) echo "usage: docs-state.sh [--write]" >&2; exit 2 ;;
+esac
+
+# ---------------------------------------------------------------------------- parsing
+#
+# Every entry is a single-line flow mapping, the same shape roadmap-sync.sh parses. Keep it
+# on one line or neither tool sees it.
+
+# Value of a scalar field. Stops at the first comma, so it is correct for id/phase/status
+# and for any unquoted value without one - not for closed_by or note, which have their own
+# extractors below.
+field() { sed -n "s/.*[{,][[:space:]]*$2:[[:space:]]*\\([^,}]*\\).*/\\1/p" <<<"$1" | head -1 | sed 's/[[:space:]]*$//'; }
+
+# Quoted field: title and note are double-quoted and may contain commas.
+qfield() { sed -n "s/.*[{,][[:space:]]*$2:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" <<<"$1" | head -1; }
+
+# Bracketed list: closed_by: [PR-30, PR-31a]
+lfield() { sed -n "s/.*[{,][[:space:]]*$2:[[:space:]]*\\[\\([^]]*\\)\\].*/\\1/p" <<<"$1" | head -1; }
+
+# Entries of one top-level block, from `key:` up to the next top-level key.
+block() { sed -n "/^$1:/,/^[a-z_]*:/p" "$ROADMAP" | sed -n 's/^[[:space:]]*-[[:space:]]*{\(.*\)}[[:space:]]*$/{\1}/p'; }
+
+INVARIANTS="$(block invariants)"
+GATES="$(block gates)"
+STEPS="$(sed -n '/^steps:/,$p' "$ROADMAP" | sed -n 's/^[[:space:]]*-[[:space:]]*{\(.*\)}[[:space:]]*$/{\1}/p')"
+
+[ -n "$STEPS" ] || { echo "docs-state: no steps parsed from $ROADMAP - has the format changed?" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------- helpers
+
+# A ten-cell progress bar. Rounds to nearest so 0 and 100 per cent are the only extremes
+# that can render as an empty or full bar.
+bar() {
+  local d="$1" t="$2" filled=0 i out=""
+  [ "$t" -gt 0 ] && filled=$(( (d * 10 + t / 2) / t ))
+  for ((i = 0; i < 10; i++)); do
+    if [ "$i" -lt "$filled" ]; then out="$out█"; else out="$out░"; fi
+  done
+  printf '%s' "$out"
+}
+
+phases_present() {
+  while IFS= read -r s; do [ -n "$s" ] && field "$s" phase; done <<<"$STEPS" | sort -u -n
+}
+
+# ---------------------------------------------------------------------------- body
+
+render_body() {
+  echo
+  echo "# State"
+  echo
+  echo "**Generated from [\`roadmap.yaml\`](roadmap.yaml) by \`just docs-state\`. Do not hand-edit** -"
+  echo "\`docs-verify\` check 6 regenerates this file and fails on any difference."
+  echo
+  echo "## Progress"
+  echo
+  echo "| Phase | Done | Total | |"
+  echo "|---|---|---|---|"
+
+  local all_done=0 all_total=0 p d t
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    d=0; t=0
+    while IFS= read -r s; do
+      [ -n "$s" ] || continue
+      [ "$(field "$s" phase)" = "$p" ] || continue
+      t=$((t + 1))
+      [ "$(field "$s" status)" = "done" ] && d=$((d + 1))
+    done <<<"$STEPS"
+    all_done=$((all_done + d)); all_total=$((all_total + t))
+    printf '| %s | %s | %s | `%s` |\n' "$p" "$d" "$t" "$(bar "$d" "$t")"
+  done < <(phases_present)
+
+  printf '| **all** | **%s** | **%s** | |\n' "$all_done" "$all_total"
+
+  # ---- position
+  #
+  # "Current phase" is the lowest phase with an open step. There is deliberately no "next
+  # step" line: the YAML records which steps are open, not which one comes next, and file
+  # order is not a sequencing claim. Naming one would be the generator inventing a fact.
+  local current="" g gid gstatus next_gate=""
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    while IFS= read -r s; do
+      [ -n "$s" ] || continue
+      [ "$(field "$s" phase)" = "$p" ] || continue
+      if [ "$(field "$s" status)" != "done" ] && [ -z "$current" ]; then current="$p"; fi
+    done <<<"$STEPS"
+    [ -n "$current" ] && break
+  done < <(phases_present)
+
+  while IFS= read -r g; do
+    [ -n "$g" ] || continue
+    gid="$(field "$g" id)"; gstatus="$(field "$g" status)"
+    if [ "$gstatus" != "passed" ] && [ -z "$next_gate" ]; then next_gate="$gid"; fi
+  done <<<"$GATES"
+
+  echo
+  echo "## Position"
+  echo
+  if [ -n "$current" ]; then
+    echo "- **Current phase:** $current"
+  else
+    echo "- **Current phase:** none - every step is done"
+  fi
+  echo "- **Next gate:** ${next_gate:-none - every gate has passed}"
+  echo "- **Open steps:** $((all_total - all_done)) of $all_total"
+
+  # ---- gates
+  echo
+  echo "## Gates"
+  echo
+  echo "| Gate | After | Phase | Status |"
+  echo "|---|---|---|---|"
+  while IFS= read -r g; do
+    [ -n "$g" ] || continue
+    printf '| %s | %s | %s | %s |\n' \
+      "$(field "$g" id)" "$(field "$g" after)" "$(field "$g" phase)" "$(field "$g" status)"
+  done <<<"$GATES"
+
+  # ---- invariants
+  echo
+  echo "## Invariants"
+  echo
+  echo "| # | Name | Met | Closed by |"
+  echo "|---|---|---|---|"
+  local inv closed note
+  while IFS= read -r inv; do
+    [ -n "$inv" ] || continue
+    closed="$(lfield "$inv" closed_by)"
+    note="$(qfield "$inv" note)"
+    printf '| %s | %s | %s | %s |\n' \
+      "$(field "$inv" id)" "$(field "$inv" name)" "$(field "$inv" met)" "${closed:-—}"
+    [ -n "$note" ] && printf '| | | | *%s* |\n' "$note"
+  done <<<"$INVARIANTS"
+
+  # ---- open steps
+  echo
+  echo "## Open steps"
+  echo
+  if [ "$all_done" = "$all_total" ]; then
+    echo "None."
+  else
+    echo "| Step | Phase | Issue | Title |"
+    echo "|---|---|---|---|"
+    # Grouped by phase, file order within a phase. The YAML does not encode sequencing, so
+    # file order is presentation, not a claim about what comes next.
+    local sid sph sis
+    while IFS= read -r p; do
+      [ -n "$p" ] || continue
+      while IFS= read -r s; do
+        [ -n "$s" ] || continue
+        [ "$(field "$s" status)" = "done" ] && continue
+        sph="$(field "$s" phase)"
+        [ "$sph" = "$p" ] || continue
+        sid="$(field "$s" id)"; sis="$(field "$s" issue)"
+        if [ "$sis" = "null" ] || [ -z "$sis" ]; then
+          sis="—"
+        else
+          sis="[#$sis](https://github.com/guardyn/guardyn/issues/$sis)"
+        fi
+        printf '| %s | %s | %s | %s |\n' "$sid" "$sph" "$sis" "$(qfield "$s" title)"
+      done <<<"$STEPS"
+    done < <(phases_present)
+  fi
+}
+
+# ---------------------------------------------------------------------------- assemble
+#
+# `tokens:` is measured over the BODY, not the whole file. Counting the whole file would be
+# a fixed point - the number changes the length that produced it - and the body is what a
+# reader actually pays to load. Four characters per token is the conventional approximation;
+# it is an estimate and the frontmatter contract does not claim otherwise.
+
+BODY="$(render_body)"
+TOKENS=$(( ${#BODY} / 4 ))
+
+OUT="$(cat <<EOF
+---
+id: roadmap-state
+type: roadmap
+status: accepted
+owns: [docs/roadmap/roadmap.yaml]
+read_when: [asking where the work is, reporting at a gate]
+tokens: $TOKENS
+supersedes: []
+---
+$BODY
+EOF
+)"
+
+if [ "$WRITE" = "1" ]; then
+  printf '%s\n' "$OUT" > "$TARGET"
+  echo "docs-state: wrote $TARGET ($TOKENS tokens)"
+else
+  printf '%s\n' "$OUT"
+fi

--- a/infra/scripts/docs-verify.sh
+++ b/infra/scripts/docs-verify.sh
@@ -9,6 +9,7 @@
 #   3 glossary     no forbidden alias used in place of a canonical term
 #   4 links        every relative link resolves; no tracked doc links into _local/
 #   5 language     no Cyrillic in docs/ outside the allowlist
+#   6 staleness    a generated document matches what its generator renders today
 #
 # Bash, awk and git only. Adding a YAML or Markdown parser would mean a runtime this
 # repository does not otherwise depend on, and I-4 makes every added dependency a cost.
@@ -201,12 +202,41 @@ check_language() {
   [ "$bad" = 0 ] && pass "language: no Cyrillic in tracked Markdown outside the allowlist"
 }
 
+# ---------------------------------------------------------------------------- 6. staleness
+#
+# .claude/rules/40-doc-sync.md has declared since PR-15 that generated documents are
+# regenerated rather than hand-edited and that docs-verify fails when one goes stale. Nothing
+# enforced it, and STATE.md rotted sixty steps behind roadmap.yaml while carrying a header
+# telling the reader it was machine-derived (#101).
+#
+# Scope is deliberately STATE.md alone. docs/INDEX.md and the per-document `tokens:` counts
+# make the same claim and have no generator yet - that is #241, and pretending to check them
+# here would be the same empty promise one level down.
+check_staleness() {
+  local gen="infra/scripts/docs-state.sh" target="docs/roadmap/STATE.md" tmp
+  if [ ! -x "$gen" ]; then
+    fail "staleness: $gen is missing or not executable"; return
+  fi
+  tmp="$(mktemp)" || { fail "staleness: cannot create a temp file"; return; }
+  if ! bash "$gen" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp"; fail "staleness: $gen exited non-zero"; return
+  fi
+  if ! diff -q "$target" "$tmp" > /dev/null 2>&1; then
+    fail "staleness: $target differs from \`just docs-state\` - regenerate it, do not hand-edit"
+    diff -u "$target" "$tmp" | head -20
+    rm -f "$tmp"; return
+  fi
+  rm -f "$tmp"
+  pass "staleness: $target matches its generator"
+}
+
 echo "docs-verify (base: $BASE)"
 check_frontmatter
 check_impact
 check_glossary
 check_links
 check_language
+check_staleness
 
 if [ "$failures" -gt 0 ]; then
   printf "\n${RED}%d check(s) failed${NC}\n" "$failures"


### PR DESCRIPTION
Closes #101

## The defect

`docs/roadmap/STATE.md` has carried a *"generated, never hand-edited"* header since PR-14
while **nothing generated it**. It rotted roughly sixty steps behind `roadmap.yaml`: it
claimed `Current phase: 2 — complete`, `G2 reached — awaiting approval` and `Phase 3: 0/12`,
while `roadmap.yaml` recorded 53 Phase-3 steps done and `PR-35` (`gate: G3`) closed.

That is worse than having no such file. `STATE.md` is what a gate report and a returning
agent read to answer *"where is the work?"*, and the header tells the reader the answer is
machine-derived and therefore trustworthy.

## What landed

- **`infra/scripts/docs-state.sh`** — renders `STATE.md` from `roadmap.yaml`. bash, awk and
  sed only; `docs-verify.sh:13-14` sets that constraint and I-4 makes every added runtime a
  cost paid by every self-hoster.
- **`docs-verify` check 6** — regenerates into a temp path and fails on any difference. It
  was tested by reintroducing the exact drift it exists to catch (`Current phase: 2 —
  complete`); it failed, printed the diff, and passed again once reverted. A check nobody has
  seen fail is the `continue-on-error` mistake PR-17 removed.
- **`just docs-state`**, documented in `docs/ops/RUNBOOK.md`.
- **`STATE.md` regenerated** — now Phase 3, G4 next, 21 open steps of 101.

## Decisions worth arguing with

**Generation runs in one direction.** #101 also asked the generator to refresh `roadmap.yaml`
step statuses *from* live issue state. Refused: `roadmap.yaml:7-15` makes `status` the
**desired** state, and copying it back inverts the direction of truth — the mistake that
reopened twenty-one correctly-closed issues before #228. The generator never writes the YAML
and never reads GitHub.

**Gates gain a `status:` field.** A gate step reaching `done` means its *work* landed; it does
not mean the gate was approved, and `AGENTS.md` §2.5 makes that approval the thing that lets
the next phase begin. Only one of those two facts is derivable from a step, so the other
needed somewhere to live. **G3 is recorded `passed` on the user's explicit confirmation** in
this session, consistent with `ADR-0011:57-58`.

**It renders only what the YAML records.** The hand-maintained file carried `Blocked` and
`Carried into Phase 3` sections that were prose about facts recorded nowhere. A generator
cannot derive those, and inventing them is how a generated file starts lying again. The
`Blocked` section was itself already stale — it claimed `project_sync_enabled: false` while
`roadmap.yaml:28` has been `true` since P-1 was resolved.

**There is deliberately no "next step" line.** The YAML records which steps are *open*, not
which one comes next; file order is not a sequencing claim. An `Open steps` table replaces it.

**`Reconciled: <date>` is dropped** — a timestamp inside a generated file fails check 6 on
every regeneration.

**`tokens:` is measured over the body, not the whole file.** Counting the whole file is a
fixed point: the number changes the length that produced it.

**No new `docs/.manifest.yaml` mapping.** A `roadmap.yaml → STATE.md` entry would be strictly
weaker than check 6 and would fire on PRs whose render is unchanged.

## The rule that was false

`.claude/rules/40-doc-sync.md` stated that `docs/INDEX.md`, `STATE.md` and every `tokens:`
value are generated and that `docs-verify` fails on staleness. **None of it was true** — PR-15
shipped five checks and scoped the generator out. The claim is corrected rather than quietly
deleted, and the section now says plainly what is enforced and what is not. `INDEX.md` and the
corpus-wide `tokens:` values are still hand-written and still unchecked; several documents
carry a literal `tokens: 0`.

The file's own `status: draft` is lifted: it was draft pending PR-15 and PR-16, both of which
have landed.

## Deliberately out of scope

- **`docs/INDEX.md` and corpus-wide `tokens:` generation** — the other half of #101. Split
  before the branch was opened because all four of #101's proposals in one PR exceed the §2.3
  budget, and an `INDEX.md` generator has to reproduce a hand-written file byte for byte.
  Tracked as **#241** (PR-91).
- **The `implementation_plan.md` ↔ `roadmap.yaml` step-count drift.** The charter is frozen at
  44 steps; the YAML has grown to 101 through hotfix and repair steps never back-written. A
  second drift axis, independent of this one, and not this step's to fix.
- **#180** (`roadmap-sync` cannot create issues) is untouched. It is why #241 was created with
  `gh issue create` rather than by the sync.

## Verification

```
just docs-verify   # 6 checks, all pass; check 6 proven to fail on drift
just rules-verify  # all pass; NAME-SH still at its frozen budget of 5
```

Budget: **7 files, 446 lines** — inside the contract on the file limit (≤8 files), which is
the disjunct that applies. No exemption invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)