### PR TITLE
fix(desktop): retain the private half of every published prekey

### DIFF
--- a/backend/crates/crypto/src/x3dh.rs
+++ b/backend/crates/crypto/src/x3dh.rs
@@ -174,6 +174,34 @@ impl SignedPreKey {
     pub fn ratchet_secret(&self) -> StaticSecret {
         self.secret.clone()
     }
+
+    /// Rebuild a signed pre-key from a secret held in client storage.
+    ///
+    /// A client that publishes a bundle must be able to answer an X3DH run against it later,
+    /// which means restoring the exact key it published - not generating a new one under the
+    /// same `key_id`. Regenerating produces a fresh random secret, so the responder derives a
+    /// different shared secret and every message fails to decrypt with no signal about why.
+    ///
+    /// The signature is supplied rather than recomputed: it was made over this public key by
+    /// the identity key at publication time, and the peer verifies against the copy the server
+    /// serves. Re-signing here would work only while the identity key is unchanged and would
+    /// hide the case where it is not.
+    pub fn from_secret_bytes(
+        key_id: u32,
+        secret: [u8; 32],
+        signature: Vec<u8>,
+        timestamp: i64,
+    ) -> Self {
+        let secret = StaticSecret::from(secret);
+        let public = X25519PublicKey::from(&secret);
+        Self {
+            key_id,
+            public,
+            secret,
+            signature,
+            timestamp,
+        }
+    }
 }
 
 /// One-time pre-key (X25519)
@@ -206,6 +234,35 @@ impl OneTimePreKey {
     pub fn dh(&self, other_public: &X25519PublicKey) -> Vec<u8> {
         let shared = self.secret.diffie_hellman(other_public);
         shared.as_bytes().to_vec()
+    }
+
+    /// The X25519 secret backing this pre-key, for a client that must persist it.
+    ///
+    /// One-time pre-keys are published and then answered against much later - after an app
+    /// restart, on a device that has forgotten everything not written down. Unlike `dh`, which
+    /// serves a live key, this exists so the key can outlive the process that made it.
+    ///
+    /// Taking a secret out of its struct is the thing this module otherwise refuses to do, so:
+    /// do not use it to re-implement `dh`, and never log or serialize the returned value in
+    /// the clear. Its one legitimate destination is an OS keychain.
+    pub fn secret(&self) -> StaticSecret {
+        self.secret.clone()
+    }
+
+    /// Rebuild a one-time pre-key from a secret held in client storage.
+    ///
+    /// See [`SignedPreKey::from_secret_bytes`] for why restoring beats regenerating. The `key_id` is
+    /// load-bearing in a way it is not elsewhere: `common.KeyBundle` carries no key ids, so an
+    /// initiator reports the id as the index the key occupied in the published array, and DH4
+    /// only matches if this key is the one that sat at that index.
+    pub fn from_secret_bytes(key_id: u32, secret: [u8; 32]) -> Self {
+        let secret = StaticSecret::from(secret);
+        let public = X25519PublicKey::from(&secret);
+        Self {
+            key_id,
+            public,
+            secret,
+        }
     }
 }
 
@@ -818,5 +875,108 @@ mod tests {
         // Too long
         let result = IdentityKeyPair::from_private_bytes(&[0u8; 64]);
         assert!(result.is_err());
+    }
+
+    /// A restored pre-key must be indistinguishable from the original, not merely
+    /// well-formed. `client-desktop` used to "restore" by regenerating under the same
+    /// `key_id`, which produced a fresh random secret - the public halves differed, so the
+    /// responder derived a different shared secret and every message failed to decrypt with
+    /// no signal about why. Asserting on the DH output is what catches that; asserting the
+    /// key merely exists does not.
+    #[test]
+    fn test_restored_signed_pre_key_agrees_with_the_original() {
+        let identity = IdentityKeyPair::generate().expect("identity");
+        let original = SignedPreKey::generate(7, &identity).expect("signed pre-key");
+        let peer = OneTimePreKey::generate(0);
+
+        let restored = SignedPreKey::from_secret_bytes(
+            original.key_id,
+            original.ratchet_secret().to_bytes(),
+            original.signature.clone(),
+            original.timestamp,
+        );
+
+        assert_eq!(restored.key_id, original.key_id);
+        assert_eq!(restored.public_bytes(), original.public_bytes());
+        assert_eq!(restored.signature, original.signature);
+        assert_eq!(restored.dh(&peer.public), original.dh(&peer.public));
+    }
+
+    #[test]
+    fn test_restored_one_time_pre_key_agrees_with_the_original() {
+        let original = OneTimePreKey::generate(3);
+        let peer = OneTimePreKey::generate(0);
+
+        let restored =
+            OneTimePreKey::from_secret_bytes(original.key_id, original.secret().to_bytes());
+
+        assert_eq!(restored.key_id, original.key_id);
+        assert_eq!(restored.public_bytes(), original.public_bytes());
+        assert_eq!(restored.dh(&peer.public), original.dh(&peer.public));
+    }
+
+    /// The failure mode the restore constructors exist to prevent, asserted directly: a key
+    /// regenerated under the same id is a different key.
+    #[test]
+    fn test_regenerating_under_the_same_key_id_yields_a_different_key() {
+        let identity = IdentityKeyPair::generate().expect("identity");
+        let original = SignedPreKey::generate(7, &identity).expect("signed pre-key");
+        let regenerated = SignedPreKey::generate(7, &identity).expect("signed pre-key");
+
+        assert_eq!(regenerated.key_id, original.key_id, "same id");
+        assert_ne!(
+            regenerated.public_bytes(),
+            original.public_bytes(),
+            "a regenerated pre-key must not be mistaken for the published one"
+        );
+    }
+
+    /// End to end: a responder that restores its published material derives the same secret
+    /// the initiator did. This is the property PR-80 depends on.
+    #[test]
+    fn test_responder_restored_from_storage_agrees_with_initiator() {
+        let bob_identity = IdentityKeyPair::generate().expect("bob identity");
+        let bob_spk = SignedPreKey::generate(1, &bob_identity).expect("bob spk");
+        let bob_otk = OneTimePreKey::generate(0);
+
+        let bundle = X3DHKeyBundle {
+            identity_key: bob_identity.public_bytes(),
+            signed_pre_key: bob_spk.public_bytes(),
+            signed_pre_key_id: bob_spk.key_id,
+            signed_pre_key_signature: bob_spk.signature.clone(),
+            one_time_pre_keys: vec![OneTimePreKeyPublic {
+                key_id: bob_otk.key_id,
+                public_key: bob_otk.public_bytes(),
+            }],
+        };
+
+        let alice_identity = IdentityKeyPair::generate().expect("alice identity");
+        let (alice_secret, alice_ephemeral) =
+            X3DHProtocol::initiate_key_agreement(&alice_identity, &bundle, true).expect("initiate");
+
+        // Bob comes back after a restart holding only what he persisted.
+        let restored = X3DHKeyMaterial {
+            identity_key: bob_identity,
+            signed_pre_key: SignedPreKey::from_secret_bytes(
+                bob_spk.key_id,
+                bob_spk.ratchet_secret().to_bytes(),
+                bob_spk.signature.clone(),
+                bob_spk.timestamp,
+            ),
+            one_time_pre_keys: vec![OneTimePreKey::from_secret_bytes(
+                bob_otk.key_id,
+                bob_otk.secret().to_bytes(),
+            )],
+        };
+
+        let bob_secret = X3DHProtocol::respond_key_agreement(
+            &restored,
+            &alice_identity.public_bytes(),
+            alice_ephemeral.as_bytes(),
+            Some(bob_otk.key_id),
+        )
+        .expect("respond");
+
+        assert_eq!(alice_secret, bob_secret, "both ends must derive one secret");
     }
 }

--- a/client-desktop/src-tauri/src/commands/auth.rs
+++ b/client-desktop/src-tauri/src/commands/auth.rs
@@ -4,7 +4,6 @@
 
 use crate::proto::common::{KeyBundle, Timestamp};
 use crate::state::AppState;
-use guardyn_crypto::x3dh::X3DHProtocol;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
@@ -39,20 +38,30 @@ pub struct AuthResponse {
     pub error: Option<String>,
 }
 
-/// Generate a key bundle for registration/login
+/// Generate a key bundle for registration/login, keeping every private half on the device.
+///
+/// This used to call `X3DHProtocol::generate_key_bundle()`, which mints an entire fresh key
+/// set - identity key included - and returns only the public bundle. So the identity key the
+/// server served for this account was not the identity key the device held, and no pre-key
+/// secret was kept at all. A peer could fetch the bundle and start a session; this client
+/// could never answer it.
 fn generate_key_bundle() -> Result<KeyBundle, String> {
     tracing::debug!("Generating key bundle...");
-    let bundle = X3DHProtocol::generate_key_bundle()
-        .map_err(|e| {
-            tracing::error!("Failed to generate key bundle: {}", e);
-            format!("Failed to generate key bundle: {}", e)
-        })?;
-    
+    let bundle = crate::commands::crypto::generate_and_persist_key_bundle(
+        crate::commands::crypto::published_one_time_prekey_count(),
+    )
+    .map_err(|e| {
+        tracing::error!("Failed to generate key bundle: {}", e);
+        e
+    })?;
+
     tracing::debug!("Key bundle generated successfully");
     Ok(KeyBundle {
         identity_key: bundle.identity_key,
         signed_pre_key: bundle.signed_pre_key,
         signed_pre_key_signature: bundle.signed_pre_key_signature,
+        // Order is the contract: the server stores these with `.enumerate()`, and an initiator
+        // reports the one it used by that index, since `common.KeyBundle` carries no key ids.
         one_time_pre_keys: bundle.one_time_pre_keys
             .into_iter()
             .map(|k| k.public_key)

--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -142,6 +142,33 @@ pub struct PreKeyData {
     pub signature: String,
 }
 
+/// The public half of a pre-key - everything the frontend is allowed to see.
+///
+/// [`PreKeyData`] serves two destinations with one serde impl: the OS credential manager,
+/// which must receive `private_key`, and the frontend, which must not. It was safe only while
+/// `private_key` was always empty and `skip_serializing_if` dropped it. Now that the secret is
+/// retained, returning `PreKeyData` from a command would hand it to the renderer, where it
+/// would sit in JS memory and reachable from a devtools console or a crash dump.
+///
+/// The shape is unchanged from the frontend's side: `src/api/crypto.ts` already declares
+/// exactly these three fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublicPreKeyData {
+    pub key_id: u32,
+    pub public_key: String,
+    pub signature: String,
+}
+
+impl From<&PreKeyData> for PublicPreKeyData {
+    fn from(data: &PreKeyData) -> Self {
+        Self {
+            key_id: data.key_id,
+            public_key: data.public_key.clone(),
+            signature: data.signature.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyBundle {
     pub identity_key: String,
@@ -250,7 +277,7 @@ pub async fn has_identity_keys() -> Result<bool, String> {
 
 /// Generate signed prekey
 #[tauri::command]
-pub async fn generate_signed_prekey() -> Result<PreKeyData, String> {
+pub async fn generate_signed_prekey() -> Result<PublicPreKeyData, String> {
     tracing::info!("Generating signed prekey");
 
     let mut store = SESSION_STORE.lock().map_err(|e| e.to_string())?;
@@ -271,21 +298,26 @@ pub async fn generate_signed_prekey() -> Result<PreKeyData, String> {
     let prekey = PreKeyData {
         key_id: signed_prekey.key_id,
         public_key: hex::encode(signed_prekey.public_bytes()),
-        private_key: String::new(), // SignedPreKey doesn't expose private key directly, stored internally
+        // Retained, not dropped. The comment here used to claim `SignedPreKey` kept the secret
+        // internally; it does not - the struct is a value holding a `StaticSecret` that dies
+        // with it. Publishing a pre-key whose private half no one kept means no peer can ever
+        // be answered.
+        private_key: hex::encode(signed_prekey.ratchet_secret().to_bytes()),
         signature: hex::encode(&signed_prekey.signature),
     };
 
     // Store in session and persist
+    let public = PublicPreKeyData::from(&prekey);
     store.signed_prekey = Some(prekey.clone());
     persist_signed_prekey(&prekey)?;
 
     tracing::info!("Signed prekey generated and persisted (key_id: {})", key_id);
-    Ok(prekey)
+    Ok(public)
 }
 
 /// Generate one-time prekeys (batch)
 #[tauri::command]
-pub async fn generate_one_time_prekeys(count: u32) -> Result<Vec<PreKeyData>, String> {
+pub async fn generate_one_time_prekeys(count: u32) -> Result<Vec<PublicPreKeyData>, String> {
     tracing::info!("Generating {} one-time prekeys", count);
 
     let mut store = SESSION_STORE.lock().map_err(|e| e.to_string())?;
@@ -300,10 +332,10 @@ pub async fn generate_one_time_prekeys(count: u32) -> Result<Vec<PreKeyData>, St
         let prekey = PreKeyData {
             key_id: otk.key_id,
             public_key: hex::encode(otk.public_bytes()),
-            private_key: String::new(), // Private key stored internally in the crypto lib
+            private_key: hex::encode(otk.secret().to_bytes()),
             signature: String::new(), // OTKs are not signed
         };
-        prekeys.push(prekey.clone());
+        prekeys.push(PublicPreKeyData::from(&prekey));
         store.one_time_prekeys.push(prekey);
     }
 
@@ -317,6 +349,143 @@ pub async fn generate_one_time_prekeys(count: u32) -> Result<Vec<PreKeyData>, St
 // =============================================================================
 // KEY BUNDLE COMMANDS
 // =============================================================================
+
+/// How many one-time pre-keys a published bundle carries.
+///
+/// Ten, not the hundred `X3DHProtocol::generate_key_bundle` uses, because every private half
+/// is now kept and the pool is stored as one blob in the OS credential manager. Windows caps a
+/// credential at 2560 bytes, which a hundred retained keys clear several times over - and a
+/// pool that cannot be persisted is worse than a small one, because the keys it names are
+/// published and unanswerable.
+///
+/// Nothing is lost today: `GetKeyBundle` scans and returns the whole set without consuming
+/// any, so every initiator is served index `0` for ever and the other ninety-nine were never
+/// reachable. Growing the pool belongs with the step that makes the server consume a key, and
+/// with `UploadPreKeys` replenishment - which is only safe to call as of #243.
+const PUBLISHED_ONE_TIME_PREKEY_COUNT: usize = 10;
+
+/// The one-time pre-key count a published bundle carries.
+pub(crate) fn published_one_time_prekey_count() -> usize {
+    PUBLISHED_ONE_TIME_PREKEY_COUNT
+}
+
+/// Build the key material for a bundle, and the storable records that carry its private
+/// halves. Pure: no keychain, no global store, so the "what we published is what we kept"
+/// property can be tested without an OS credential manager.
+///
+/// Returns the bundle to publish, the signed pre-key record, and the one-time pre-key records.
+#[allow(clippy::type_complexity)]
+fn build_key_material(
+    identity_keypair: &guardyn_crypto::x3dh::IdentityKeyPair,
+    signed_prekey_id: u32,
+    one_time_count: usize,
+) -> Result<
+    (
+        guardyn_crypto::x3dh::X3DHKeyBundle,
+        PreKeyData,
+        Vec<PreKeyData>,
+    ),
+    String,
+> {
+    let signed_prekey =
+        guardyn_crypto::x3dh::SignedPreKey::generate(signed_prekey_id, identity_keypair)
+            .map_err(|e| format!("Failed to generate signed prekey: {}", e))?;
+
+    let signed_prekey_data = PreKeyData {
+        key_id: signed_prekey.key_id,
+        public_key: hex::encode(signed_prekey.public_bytes()),
+        private_key: hex::encode(signed_prekey.ratchet_secret().to_bytes()),
+        signature: hex::encode(&signed_prekey.signature),
+    };
+
+    // Ids are zero-based and contiguous because `common.KeyBundle` carries no key ids at all:
+    // an initiator reports the id as the index the key occupied in the published array
+    // (auth-service `db.rs` assigns them with `.enumerate()`), so index and id must agree or
+    // DH4 is computed against the wrong key.
+    let mut one_time_prekeys = Vec::with_capacity(one_time_count);
+    let mut one_time_data = Vec::with_capacity(one_time_count);
+    for id in 0..one_time_count as u32 {
+        let otk = guardyn_crypto::x3dh::OneTimePreKey::generate(id);
+        one_time_data.push(PreKeyData {
+            key_id: otk.key_id,
+            public_key: hex::encode(otk.public_bytes()),
+            private_key: hex::encode(otk.secret().to_bytes()),
+            signature: String::new(),
+        });
+        one_time_prekeys.push(otk);
+    }
+
+    let material = guardyn_crypto::x3dh::X3DHKeyMaterial {
+        identity_key: identity_keypair.clone(),
+        signed_pre_key: signed_prekey,
+        one_time_pre_keys: one_time_prekeys,
+    };
+
+    Ok((material.export_bundle(), signed_prekey_data, one_time_data))
+}
+
+/// Generate a publishable key bundle and keep every private half.
+///
+/// This is the single generator for the material a peer will run X3DH against. It exists
+/// because there were three, none wired to the others, and the one that published
+/// (`commands::auth::generate_key_bundle`) called `X3DHProtocol::generate_key_bundle()` - which
+/// mints a whole fresh key set, identity key included, and returns only the public bundle.
+///
+/// The consequence was worse than dropped pre-key secrets: the identity key the server served
+/// for this user was not the identity key on the device. A peer verified the bundle against a
+/// key this client had never held, and the client could not have answered even if it had kept
+/// the pre-keys.
+///
+/// The identity keypair is loaded from secure storage and only generated when absent, so
+/// re-publishing on a later login keeps the account's identity stable.
+pub(crate) fn generate_and_persist_key_bundle(
+    one_time_count: usize,
+) -> Result<guardyn_crypto::x3dh::X3DHKeyBundle, String> {
+    let mut store = SESSION_STORE.lock().map_err(|e| e.to_string())?;
+
+    let identity_keypair = match store.identity_keypair.as_ref() {
+        Some(data) => {
+            let private_bytes = hex::decode(&data.private_key)
+                .map_err(|e| format!("Invalid stored identity private key: {}", e))?;
+            guardyn_crypto::x3dh::IdentityKeyPair::from_private_bytes(&private_bytes)
+                .map_err(|e| format!("Failed to restore identity keypair: {}", e))?
+        }
+        None => {
+            let keypair = guardyn_crypto::x3dh::IdentityKeyPair::generate()
+                .map_err(|e| format!("Failed to generate identity keys: {}", e))?;
+            let data = IdentityKeyData {
+                public_key: hex::encode(keypair.public_bytes()),
+                private_key: hex::encode(keypair.private_key_bytes()),
+            };
+            store.identity_keypair = Some(data.clone());
+            persist_identity_keypair(&data)?;
+            keypair
+        }
+    };
+
+    let key_id = store
+        .signed_prekey
+        .as_ref()
+        .map(|p| p.key_id + 1)
+        .unwrap_or(1);
+    let (bundle, signed_prekey_data, one_time_data) =
+        build_key_material(&identity_keypair, key_id, one_time_count)?;
+
+    // Persist before returning. A bundle that reaches the server while its private halves are
+    // still only in memory is exactly the unanswerable state this step exists to remove.
+    store.signed_prekey = Some(signed_prekey_data.clone());
+    store.one_time_prekeys = one_time_data.clone();
+    persist_signed_prekey(&signed_prekey_data)?;
+    persist_one_time_prekeys(&one_time_data)?;
+
+    tracing::info!(
+        "Key bundle generated and persisted: signed prekey id {}, {} one-time prekeys",
+        key_id,
+        one_time_data.len()
+    );
+
+    Ok(bundle)
+}
 
 /// Generate a complete key bundle for E2EE
 #[tauri::command]
@@ -1020,6 +1189,119 @@ mod tests {
 
         // Both should derive the same shared secret
         assert_eq!(alice_secret, bob_secret);
+    }
+
+    /// The property PR-79 exists to establish: every private half of a published bundle is
+    /// still on the device, and restoring from it reproduces the exact key that was published.
+    ///
+    /// Before this step, `commands::auth::generate_key_bundle` called
+    /// `X3DHProtocol::generate_key_bundle()`, which returns only `export_bundle()` and drops
+    /// the material - so the published pre-keys had no private half anywhere, and the
+    /// published *identity* key was not even the one the device held.
+    #[test]
+    fn test_published_bundle_is_backed_by_retained_private_keys() {
+        let identity = guardyn_crypto::x3dh::IdentityKeyPair::generate().unwrap();
+        let (bundle, signed, one_time) = build_key_material(&identity, 1, 3).unwrap();
+
+        assert_eq!(
+            bundle.identity_key,
+            identity.public_bytes(),
+            "the published identity key must be the device's own"
+        );
+
+        // Signed pre-key: restore from what was stored, and check it is the published key.
+        assert!(
+            !signed.private_key.is_empty(),
+            "signed prekey secret dropped"
+        );
+        let secret_bytes: [u8; 32] = hex::decode(&signed.private_key)
+            .unwrap()
+            .try_into()
+            .expect("32-byte secret");
+        let restored = guardyn_crypto::x3dh::SignedPreKey::from_secret_bytes(
+            signed.key_id,
+            secret_bytes,
+            hex::decode(&signed.signature).unwrap(),
+            0,
+        );
+        assert_eq!(
+            restored.public_bytes(),
+            bundle.signed_pre_key,
+            "the retained secret must reproduce the published signed pre-key"
+        );
+
+        // One-time pre-keys: same property, and ids must match their published index, because
+        // `common.KeyBundle` carries no ids and the initiator reports the index it used.
+        assert_eq!(one_time.len(), 3);
+        assert_eq!(bundle.one_time_pre_keys.len(), 3);
+        for (index, stored) in one_time.iter().enumerate() {
+            assert!(
+                !stored.private_key.is_empty(),
+                "one-time prekey {index} secret dropped"
+            );
+            assert_eq!(stored.key_id, index as u32, "id must equal published index");
+
+            let bytes: [u8; 32] = hex::decode(&stored.private_key)
+                .unwrap()
+                .try_into()
+                .expect("32-byte secret");
+            let restored =
+                guardyn_crypto::x3dh::OneTimePreKey::from_secret_bytes(stored.key_id, bytes);
+            assert_eq!(
+                restored.public_bytes(),
+                bundle.one_time_pre_keys[index].public_key,
+                "retained secret must reproduce published one-time prekey {index}"
+            );
+        }
+    }
+
+    /// `PreKeyData` must reach the keychain with its secret and the frontend without it. The
+    /// two destinations share no serde impl any more, and this pins that: the public view has
+    /// no field a secret could travel in.
+    #[test]
+    fn test_the_public_prekey_view_carries_no_secret() {
+        let identity = guardyn_crypto::x3dh::IdentityKeyPair::generate().unwrap();
+        let (_, signed, _) = build_key_material(&identity, 1, 1).unwrap();
+        assert!(
+            !signed.private_key.is_empty(),
+            "storage view keeps the secret"
+        );
+
+        let rendered = serde_json::to_string(&PublicPreKeyData::from(&signed)).unwrap();
+
+        assert!(
+            !rendered.contains(&signed.private_key),
+            "the secret reached the frontend view: {rendered}"
+        );
+        assert!(
+            !rendered.contains("private"),
+            "no secret-shaped field: {rendered}"
+        );
+        assert!(
+            rendered.contains(&signed.public_key),
+            "public key must survive"
+        );
+
+        // The storage view must still round-trip the secret, or persistence silently breaks.
+        let stored = serde_json::to_string(&signed).unwrap();
+        let back: PreKeyData = serde_json::from_str(&stored).unwrap();
+        assert_eq!(back.private_key, signed.private_key);
+    }
+
+    /// A published pool the credential manager cannot hold is worse than a small one: the keys
+    /// are advertised and unanswerable. Windows caps a credential blob at 2560 bytes.
+    #[test]
+    fn test_published_prekey_pool_fits_a_windows_credential() {
+        let identity = guardyn_crypto::x3dh::IdentityKeyPair::generate().unwrap();
+        let (_, _, one_time) =
+            build_key_material(&identity, 1, published_one_time_prekey_count()).unwrap();
+
+        let blob = serde_json::to_string(&one_time).unwrap();
+        assert!(
+            blob.len() < 2560,
+            "retained one-time prekey pool is {} bytes, over the Windows credential cap",
+            blob.len()
+        );
     }
 
     #[test]

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 949
+tokens: 964
 supersedes: []
 ---
 
@@ -19,15 +19,15 @@ supersedes: []
 |---|---|---|---|
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
-| 3 | 55 | 66 | `████████░░` |
-| 4 | 0 | 10 | `░░░░░░░░░░` |
-| **all** | **81** | **102** | |
+| 3 | 56 | 66 | `████████░░` |
+| 4 | 0 | 11 | `░░░░░░░░░░` |
+| **all** | **82** | **103** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 21 of 102
+- **Open steps:** 21 of 103
 
 ## Gates
 
@@ -59,7 +59,6 @@ supersedes: []
 | PR-62 | 3 | [#191](https://github.com/guardyn/guardyn/issues/191) | Clear the 132 client-desktop clippy errors |
 | PR-63 | 3 | [#192](https://github.com/guardyn/guardyn/issues/192) | Reconcile the desktop coverage thresholds with reality |
 | PR-65 | 3 | [#199](https://github.com/guardyn/guardyn/issues/199) | Stop Build Linux flaking in linuxdeploy |
-| PR-79 | 3 | — | client-desktop - retain private prekey material |
 | PR-80 | 3 | — | client-desktop - implement the X3DH responder path |
 | PR-81 | 3 | — | client-desktop - restore the ratchet store from persisted state |
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
@@ -75,3 +74,4 @@ supersedes: []
 | PR-43 | 4 | [#54](https://github.com/guardyn/guardyn/issues/54) | Wire the compose observability stack |
 | PR-44 | 4 | [#55](https://github.com/guardyn/guardyn/issues/55) | Deployment parity - call-service k8s Deployment and image digest pins |
 | PR-91 | 4 | [#241](https://github.com/guardyn/guardyn/issues/241) | Generate docs/INDEX.md and the tokens: counts |
+| PR-93 | 4 | [#246](https://github.com/guardyn/guardyn/issues/246) | Consume the one-time pre-key that GetKeyBundle serves |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -147,7 +147,7 @@ steps:
   - {id: PR-76, issue: 229, phase: 3, type: security, status: done, title: "client-mobile - fail closed on group messaging"}
   - {id: PR-77, issue: 230, phase: 3, type: security, status: done, title: "client-mobile - refuse the native to Dart crypto downgrade"}
   - {id: PR-78, issue: 163, phase: 3, type: security, status: done, title: "client-desktop - encrypt on the send path"}
-  - {id: PR-79, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - retain private prekey material"}
+  - {id: PR-79, issue: 245, phase: 3, type: fix, status: done, title: "client-desktop - retain private prekey material"}
   - {id: PR-80, issue: null, phase: 3, type: feat, status: todo, title: "client-desktop - implement the X3DH responder path"}
   - {id: PR-81, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - restore the ratchet store from persisted state"}
   # Deferred deliberately, each with a stated reason in its step above.
@@ -171,3 +171,6 @@ steps:
   # over the real one, so a single call bricks an account's bundle for every peer. Nothing
   # calls it today - it is disarmed before PR-79 goes near prekey replenishment.
   - {id: PR-92, issue: 243, phase: 3, type: security, status: done, title: "UploadPreKeys must not destroy the identity key"}
+  # The other half of the prekey story. Consumption is a protocol change - mutating RPC,
+  # exhaustion behaviour, replenishment - so it waits rather than riding along with PR-79.
+  - {id: PR-93, issue: 246, phase: 4, type: security, status: todo, title: "Consume the one-time pre-key that GetKeyBundle serves"}

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -52,6 +52,11 @@ it is recorded here so nobody "fixes" it.
 
 ## Session establishment (X3DH)
 
+0. **A client keeps the private half of everything it publishes.** A bundle is a promise to
+   answer an X3DH run against it, and the publisher is the only party that can. Generating a
+   bundle and discarding its secrets — or publishing an identity key the device does not hold
+   — produces an account other people can start sessions with and never reach. The failure is
+   silent and one-sided: the initiator succeeds, and only the responder's decrypt fails.
 1. The initiator fetches the responder's `KeyBundle`: identity key, signed pre-key with its
    signature, and one `OneTimePreKey` if any remain.
 2. The signed pre-key signature **must** verify against the identity key. Failure aborts —
@@ -64,6 +69,16 @@ it is recorded here so nobody "fixes" it.
 **Edge cases.** No one-time pre-keys left: proceed with the three-DH variant — never refuse,
 never fall back to an unauthenticated exchange. Bundle from an unknown device: `NOT_FOUND`.
 A replayed prekey message fails because the one-time key is already consumed.
+
+> **Rules 3 and the replay edge case are not implemented.** `auth-service` serves the
+> one-time pre-keys with a range scan and deletes nothing, so every initiator is handed index
+> `0` for ever, the fourth DH contributes the same secret to every session, and a replayed
+> prekey message succeeds rather than failing. Recorded rather than quietly corrected, because
+> the rules above are the intended behaviour and
+> [#246](https://github.com/guardyn/guardyn/issues/246) is the step that delivers them.
+>
+> Rule 0 holds on both clients as of PR-79; `common.KeyBundle` still carries no key ids, so an
+> initiator names the one-time key by the index it occupied in the published array.
 
 ## Message encryption (Double Ratchet)
 


### PR DESCRIPTION
Closes #245

First of the three steps that let `client-desktop` establish a session again.

## The defect was worse than the title

The bundle the desktop published had **no retained private half anywhere on the device**. But
the identity key was the real problem. `commands/auth.rs:43` — the only generator that
publishes — called `X3DHProtocol::generate_key_bundle()`, which builds a whole fresh
`X3DHKeyMaterial`, identity key included, and returns only `export_bundle()`.

So **the identity key the server served for an account was not the identity key on the
device.** A peer fetched the bundle, verified it against a key this client had never held,
opened a session — and the client could not have answered even if it had kept the pre-keys.

Three generators existed and none was wired to the others:

| | Where | Privates |
|---|---|---|
| a | `commands/crypto.rs:252-315` | dropped — `private_key: String::new()` |
| b | `commands/crypto.rs:322` (frontend calls this at startup) | discards `HybridPrivateKeys`; fresh unrelated keys every call |
| c | `commands/auth.rs:43` — **publishes** | drops the whole `X3DHKeyMaterial` |

The comments that justified (a) were factually wrong:

```rust
private_key: String::new(), // SignedPreKey doesn't expose private key directly, stored internally
private_key: String::new(), // Private key stored internally in the crypto lib
```

Nothing is stored internally. `SignedPreKey` (`x3dh.rs:129`) and `OneTimePreKey` (`x3dh.rs:184`)
each hold a `secret: StaticSecret` that drops with the struct. They are values, not handles.

## `guardyn-crypto`

`SignedPreKey::from_secret_bytes` and `OneTimePreKey::{secret, from_secret_bytes}`, beside the
existing `SignedPreKey::ratchet_secret` (added by #109). They take and return **bytes**, so a
client can persist a key without taking a dependency on `x25519-dalek`.

Four tests. The one that matters is
`test_regenerating_under_the_same_key_id_yields_a_different_key`: it asserts the failure mode
directly, because that is exactly what `respond_x3dh` does today
(`commands/crypto.rs:438`, `:442-444`) and why PR-80 cannot be written until this step exists.
`test_responder_restored_from_storage_agrees_with_initiator` proves the end-to-end property
PR-80 depends on.

## The desktop

One generator, rooted in the **persisted** identity keypair, which keeps every private half and
persists *before* returning — a bundle reaching the server while its secrets are only in memory
is the unanswerable state this removes. `build_key_material` is split out pure, with no keychain
and no global store, so the "what we published is what we kept" property is testable without an
OS credential manager.

## A leak this would have opened

`PreKeyData` served two destinations with one serde impl: the OS keychain, which **must**
receive `private_key`, and the frontend, which **must not**. That was safe only while the field
was always empty and `skip_serializing_if` dropped it. Retaining the secret would have started
handing pre-key secrets to the renderer, where they would sit in JS memory reachable from a
devtools console or a crash dump.

Commands now return `PublicPreKeyData`, which has no field a secret could travel in.
**No frontend change**: `src/api/crypto.ts:117-143` already declares exactly
`key_id`/`public_key`/`signature`.

## Behaviour change, stated plainly

**The published one-time pre-key pool drops from 100 to 10.** Retained secrets make the pool a
stored blob, and Windows caps a credential at 2560 bytes — a hundred retained keys clear that
several times over. A pool that cannot be persisted is worse than a small one, because the keys
it names are published and unanswerable.

Nothing is lost today: `GetKeyBundle` scans and returns without consuming, so every initiator is
served index `0` for ever and the other ninety-nine were never reachable (**#246**). A test pins
the pool under the Windows cap so the number cannot drift back up silently.

It is not a wire change — `repeated bytes` accepts any count — and the mobile client publishes
**one**.

## Documentation

`docs/spec/SRS.md` gains rule 0 of session establishment: *a client keeps the private half of
everything it publishes*. It also now records that rule 3 and the replay edge case
(*"a consumed one-time pre-key is never reissued"*, *"a replayed prekey message fails"*) are
**not implemented** — the spec was describing a replay defence that does not exist. Recorded
against #246 rather than quietly corrected, since those are the intended rules.

## Deliberately out of scope

- **Generator (b)**, the orphaned `generate_key_bundle` command the frontend calls at startup.
  Reconciling it touches the frontend; its own step.
- **One-time pre-key consumption** — #246.
- **`SecureStorage::default_instance()` is hardcoded to user `"default"`**
  (`secure_storage.rs:51-53`), so two accounts on one machine share a key namespace. Pre-existing;
  filed with the ratchet-persistence step, where it bites hardest.
- `respond_x3dh` still regenerates rather than restores. That is PR-80, which this unblocks.

## Verification

```
cargo test -p guardyn-crypto                    # 98 + 20 passed
cargo test --lib (client-desktop/src-tauri)     # 53 passed
cargo fmt --all -- --check   (backend)          # clean
cargo clippy -p guardyn-crypto --all-targets -- -D warnings   # clean
just rules-verify                               # all pass; RS-UNWRAP steady at 48
just docs-verify                                # all 6 pass
```

Budget: **6 files, 511 lines** — inside the contract on the file limit, which is the disjunct
that applies. Roughly 290 of those lines are tests and doc comments. No exemption invoked.

Two things `cargo fmt` did that are *not* in this diff, deliberately: it reformatted 26
untouched files in `src-tauri` (the crate has never been formatted, and CI only fmt-checks
`backend/`), and building rewrote the committed `src/proto/guardyn.media.rs` — that is **#188**,
and `PROTO-EDIT` would have failed on it. Both reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)