### PR TITLE
fix(desktop): restore the ratchet store from persisted state

### DIFF
--- a/backend/crates/crypto/src/double_ratchet.rs
+++ b/backend/crates/crypto/src/double_ratchet.rs
@@ -448,6 +448,21 @@ impl DoubleRatchet {
         self.skipped_message_keys.len()
     }
 
+    /// Whether this ratchet can send.
+    ///
+    /// A responder built by [`Self::init_bob`] deliberately has no sending chain key: it gains
+    /// one only when its first `decrypt` performs the DH ratchet against the initiator's
+    /// public key. So a ratchet can be well-formed, restorable, and still unable to send a
+    /// single message.
+    ///
+    /// A client needs this on two paths. It must not persist a responder before its first
+    /// successful decrypt, and it must discard a restored session that reports `false` here and
+    /// run a fresh key agreement instead - because the alternative is a session the UI shows as
+    /// active that refuses every send.
+    pub fn can_send(&self) -> bool {
+        self.sending_chain_key.is_some()
+    }
+
     /// Serialize Double Ratchet state for persistent storage
     ///
     /// Format (all little-endian):

--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -54,7 +54,13 @@ static SESSION_STORE: LazyLock<Mutex<SessionStore>> = LazyLock::new(|| {
 });
 
 /// Global storage for Double Ratchet states (cannot be Clone, stored separately)
-/// Key is peer_id, value is the serialized Double Ratchet state
+/// Key is peer_id, value is the live Double Ratchet.
+///
+/// Rehydrated from `SessionData.state` by `load_from_secure_storage`. It used to start empty
+/// and never be populated, while the metadata beside it *was* restored - so after a restart
+/// `get_session` reported an active session and every send failed with "no Double Ratchet
+/// session". A session the UI shows as present and that refuses every message is worse than no
+/// session, which would at least trigger a fresh key agreement.
 static RATCHET_STORE: LazyLock<Mutex<HashMap<String, guardyn_crypto::DoubleRatchet>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
@@ -80,14 +86,74 @@ fn load_from_secure_storage(store: &mut SessionStore) -> Result<(), String> {
         store.one_time_prekeys = prekeys;
     }
 
-    // Load sessions
+    // Load sessions, and rehydrate the ratchet each one carries.
     if let Ok(sessions) = storage.get_sessions() {
         tracing::info!("Loaded {} sessions from secure storage", sessions.len());
-        store.sessions = sessions;
+        let (restored, ratchets) = rehydrate_ratchets(sessions);
+        match RATCHET_STORE.lock() {
+            Ok(mut guard) => {
+                guard.extend(ratchets);
+                store.sessions = restored;
+            }
+            Err(e) => {
+                // Without the ratchets the metadata is the exact half-state this step removes.
+                tracing::error!("Ratchet store is poisoned, starting with no sessions: {}", e);
+            }
+        }
     }
 
     store.loaded_from_storage = true;
     Ok(())
+}
+
+/// Restore every stored ratchet into `RATCHET_STORE`, returning the sessions worth keeping.
+///
+/// A session is dropped - rather than kept without its ratchet - in three cases: its state is
+/// empty, it fails to deserialize, or it deserializes into a ratchet that cannot send. The
+/// last is the subtle one. A responder has no sending chain key until its first `decrypt`
+/// performs the DH ratchet, so a ratchet can be well-formed and still unable to send a single
+/// message. `client-mobile` learned this and deletes such a session so a fresh X3DH runs
+/// (`crypto_service.dart:508-513`); keeping it would resurrect a half-session that fails on
+/// every send while looking established.
+///
+/// Dropping the metadata alongside the ratchet is the point: the two must agree, and it was
+/// their disagreement that produced a session the UI reported as active and that refused
+/// everything.
+#[allow(clippy::type_complexity)]
+fn rehydrate_ratchets(
+    sessions: HashMap<String, SessionData>,
+) -> (
+    HashMap<String, SessionData>,
+    HashMap<String, guardyn_crypto::DoubleRatchet>,
+) {
+    let mut restored = HashMap::with_capacity(sessions.len());
+    let mut ratchets = HashMap::with_capacity(sessions.len());
+
+    for (peer_id, session) in sessions {
+        if session.state.is_empty() {
+            tracing::warn!("Session has no stored ratchet state, dropping it");
+            continue;
+        }
+        match guardyn_crypto::DoubleRatchet::deserialize(&session.state) {
+            Ok(ratchet) if ratchet.can_send() => {
+                ratchets.insert(peer_id.clone(), ratchet);
+                restored.insert(peer_id, session);
+            }
+            Ok(_) => {
+                tracing::warn!(
+                    "Stored session cannot send - it was persisted before its first decrypt \
+                     completed the ratchet. Dropping it so a fresh key agreement runs."
+                );
+            }
+            Err(e) => {
+                // No key material in the message: `CryptoError` reports shape, not content.
+                tracing::warn!("Stored ratchet state could not be restored: {}", e);
+            }
+        }
+    }
+
+    tracing::info!("Restored {} ratchet session(s)", restored.len());
+    (restored, ratchets)
 }
 
 /// Save identity keypair to secure storage
@@ -815,8 +881,13 @@ pub async fn init_session(
             .map_err(|e| format!("Failed to init Double Ratchet: {}", e))?
     };
 
-    // Serialize ratchet state for persistence
-    let ratchet_state = ratchet.serialize();
+    // A responder has no sending chain key until its first `decrypt` performs the DH ratchet
+    // against the initiator's public key, so it cannot be persisted yet: what would be written
+    // is a session that reloads unable to send, and `rehydrate_ratchets` would rightly discard
+    // it - losing the ratchet that was about to become usable. `encrypt_for_peer` and
+    // `decrypt_message` persist after each operation, so the first successful decrypt writes it.
+    // (client-mobile reached the same conclusion: crypto_service.dart:436-441.)
+    let can_persist = ratchet.can_send();
 
     let session = SessionData {
         peer_id: peer_id.clone(),
@@ -826,7 +897,7 @@ pub async fn init_session(
             .as_secs(),
         messages_sent: 0,
         messages_received: 0,
-        state: ratchet_state, // Store serialized Double Ratchet state
+        state: ratchet.serialize(),
     };
 
     // Store ratchet in memory
@@ -835,12 +906,17 @@ pub async fn init_session(
         ratchet_store.insert(peer_id.clone(), ratchet);
     }
 
-    // Store session metadata and persist
+    // Store session metadata, and persist only what will survive a reload.
     let mut store = SESSION_STORE.lock().map_err(|e| e.to_string())?;
     store.sessions.insert(peer_id.clone(), session.clone());
-    persist_sessions(&store.sessions)?;
-
-    tracing::info!("Double Ratchet session established and persisted with peer: {}", peer_id);
+    if can_persist {
+        persist_sessions(&store.sessions)?;
+        tracing::info!("Double Ratchet session established and persisted");
+    } else {
+        tracing::info!(
+            "Responder session established in memory; it is persisted after its first decrypt"
+        );
+    }
     Ok(SessionInfo {
         peer_id: session.peer_id,
         established_at: session.established_at,
@@ -1364,6 +1440,115 @@ mod tests {
 
         let err = key_bundle_from_proto(&bundle).expect_err("must refuse");
         assert!(err.contains("signature"), "{err}");
+    }
+
+    fn stored_session(peer: &str, state: Vec<u8>) -> (String, SessionData) {
+        (
+            peer.to_string(),
+            SessionData {
+                peer_id: peer.to_string(),
+                established_at: 0,
+                messages_sent: 0,
+                messages_received: 0,
+                state,
+            },
+        )
+    }
+
+    /// The restart round-trip. A session established before the process ended must decrypt the
+    /// next message after it restarts.
+    ///
+    /// `RATCHET_STORE` used to start empty and never be populated, while the metadata beside it
+    /// was restored - so `get_session` reported an active session and `encrypt_for_peer` failed
+    /// with "no Double Ratchet session" for ever.
+    #[test]
+    fn test_a_session_survives_a_restart() {
+        let alice_material = guardyn_crypto::x3dh::X3DHKeyMaterial::generate(1).unwrap();
+        let bob_material = guardyn_crypto::x3dh::X3DHKeyMaterial::generate(1).unwrap();
+        let bob_bundle = bob_material.export_bundle();
+
+        let (secret, ephemeral) = guardyn_crypto::x3dh::X3DHProtocol::initiate_key_agreement(
+            &alice_material.identity_key,
+            &bob_bundle,
+            true,
+        )
+        .unwrap();
+        let bob_secret = guardyn_crypto::x3dh::X3DHProtocol::respond_key_agreement(
+            &bob_material,
+            &alice_material.identity_key.public_bytes(),
+            ephemeral.as_bytes(),
+            Some(0),
+        )
+        .unwrap();
+
+        let peer_public: [u8; 32] = bob_bundle.signed_pre_key.clone().try_into().unwrap();
+        let mut alice = guardyn_crypto::DoubleRatchet::init_alice(
+            &secret,
+            guardyn_crypto::X25519PublicKey::from(peer_public),
+        )
+        .unwrap();
+        let mut bob = guardyn_crypto::DoubleRatchet::init_bob(
+            &bob_secret,
+            bob_material.signed_pre_key.ratchet_secret(),
+        )
+        .unwrap();
+
+        let aad = message_associated_data("alice", "bob");
+
+        // Bob cannot send until his first decrypt completes the ratchet, so he must not be
+        // persisted before it.
+        assert!(!bob.can_send(), "a fresh responder has no sending chain");
+        bob.decrypt(&alice.encrypt(b"hello", &aad).unwrap(), &aad)
+            .unwrap();
+        assert!(bob.can_send(), "the first decrypt completes the ratchet");
+
+        // The process ends here. Only what was persisted comes back.
+        let stored: HashMap<_, _> = [stored_session("alice", bob.serialize())].into();
+        let (restored_sessions, mut restored_ratchets) = rehydrate_ratchets(stored);
+
+        assert_eq!(restored_sessions.len(), 1, "the session must come back");
+        let bob_again = restored_ratchets
+            .get_mut("alice")
+            .expect("the ratchet must come back");
+
+        let second = alice.encrypt(b"after the restart", &aad).unwrap();
+        assert_eq!(bob_again.decrypt(&second, &aad).unwrap(), b"after the restart");
+    }
+
+    /// A responder persisted before its first decrypt reloads unable to send. Keeping it would
+    /// resurrect a half-session that looks established and refuses everything, so it is dropped
+    /// and a fresh key agreement runs instead (client-mobile: crypto_service.dart:508-513).
+    #[test]
+    fn test_a_session_that_cannot_send_is_dropped_rather_than_restored() {
+        let bob_material = guardyn_crypto::x3dh::X3DHKeyMaterial::generate(1).unwrap();
+        let bob = guardyn_crypto::DoubleRatchet::init_bob(
+            &[7u8; 32],
+            bob_material.signed_pre_key.ratchet_secret(),
+        )
+        .unwrap();
+        assert!(!bob.can_send());
+
+        let stored: HashMap<_, _> = [stored_session("alice", bob.serialize())].into();
+        let (sessions, ratchets) = rehydrate_ratchets(stored);
+
+        assert!(sessions.is_empty(), "the metadata must go with the ratchet");
+        assert!(ratchets.is_empty());
+    }
+
+    /// Metadata without a usable ratchet is the exact half-state this step removes, so a
+    /// session whose state is missing or corrupt is dropped rather than half-restored.
+    #[test]
+    fn test_sessions_without_restorable_state_are_dropped() {
+        let stored: HashMap<_, _> = [
+            stored_session("empty", Vec::new()),
+            stored_session("corrupt", vec![0xff; 9]),
+        ]
+        .into();
+
+        let (sessions, ratchets) = rehydrate_ratchets(stored);
+
+        assert!(sessions.is_empty(), "no session should survive: {sessions:?}");
+        assert!(ratchets.is_empty());
     }
 
     /// The whole responder path, end to end, over the pieces `respond_x3dh` and `init_session`

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 946
+tokens: 956
 supersedes: []
 ---
 
@@ -19,15 +19,15 @@ supersedes: []
 |---|---|---|---|
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
-| 3 | 58 | 67 | `█████████░` |
-| 4 | 0 | 11 | `░░░░░░░░░░` |
-| **all** | **84** | **104** | |
+| 3 | 59 | 67 | `█████████░` |
+| 4 | 0 | 12 | `░░░░░░░░░░` |
+| **all** | **85** | **105** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 20 of 104
+- **Open steps:** 20 of 105
 
 ## Gates
 
@@ -59,7 +59,6 @@ supersedes: []
 | PR-62 | 3 | [#191](https://github.com/guardyn/guardyn/issues/191) | Clear the 132 client-desktop clippy errors |
 | PR-63 | 3 | [#192](https://github.com/guardyn/guardyn/issues/192) | Reconcile the desktop coverage thresholds with reality |
 | PR-65 | 3 | [#199](https://github.com/guardyn/guardyn/issues/199) | Stop Build Linux flaking in linuxdeploy |
-| PR-81 | 3 | — | client-desktop - restore the ratchet store from persisted state |
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
 | PR-83 | 3 | — | Clear the 314 flutter analyze info diagnostics |
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
@@ -74,3 +73,4 @@ supersedes: []
 | PR-44 | 4 | [#55](https://github.com/guardyn/guardyn/issues/55) | Deployment parity - call-service k8s Deployment and image digest pins |
 | PR-91 | 4 | [#241](https://github.com/guardyn/guardyn/issues/241) | Generate docs/INDEX.md and the tokens: counts |
 | PR-93 | 4 | [#246](https://github.com/guardyn/guardyn/issues/246) | Consume the one-time pre-key that GetKeyBundle serves |
+| PR-94 | 4 | [#253](https://github.com/guardyn/guardyn/issues/253) | Partition client-desktop SecureStorage per account |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -152,7 +152,7 @@ steps:
   # The initiator path is complete and has nothing to feed it: AuthClient::get_key_bundle has
   # no callers and NewConversationModal carries a TODO where the fetch belongs.
   - {id: PR-80b, issue: 250, phase: 3, type: feat, status: done, title: "client-desktop - wire get_key_bundle to the frontend"}
-  - {id: PR-81, issue: null, phase: 3, type: fix, status: todo, title: "client-desktop - restore the ratchet store from persisted state"}
+  - {id: PR-81, issue: 252, phase: 3, type: fix, status: done, title: "client-desktop - restore the ratchet store from persisted state"}
   # Deferred deliberately, each with a stated reason in its step above.
   - {id: PR-82, issue: 211, phase: 3, type: chore, status: todo, title: "Add an FFI-backed mobile CI job"}
   - {id: PR-83, issue: null, phase: 3, type: chore, status: todo, title: "Clear the 314 flutter analyze info diagnostics"}
@@ -177,3 +177,6 @@ steps:
   # The other half of the prekey story. Consumption is a protocol change - mutating RPC,
   # exhaustion behaviour, replenishment - so it waits rather than riding along with PR-79.
   - {id: PR-93, issue: 246, phase: 4, type: security, status: todo, title: "Consume the one-time pre-key that GetKeyBundle serves"}
+  # Latent until a second account is used on one machine, but PR-81 grew its consequence:
+  # ratchets now outlive the process, so a cross-read session can decrypt real messages.
+  - {id: PR-94, issue: 253, phase: 4, type: security, status: todo, title: "Partition client-desktop SecureStorage per account"}

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -87,6 +87,14 @@ A replayed prekey message fails because the one-time key is already consumed.
    the matching secret rather than generating a fresh key. This is not an implementation
    detail - if the responder invents its own key the two sides derive different root and
    chain keys, and every AEAD tag check fails while both sides appear healthy.
+0a. **A responder has no sending chain key until its first successful decrypt.** `init_bob`
+   deliberately leaves it unset; the DH ratchet that creates it runs on the first inbound
+   message. Two consequences bind any client that persists sessions: do not write a responder
+   session before that first decrypt, and **discard a restored session that cannot send** so a
+   fresh key agreement runs. Restoring one produces a session the UI reports as established
+   that refuses every send - strictly worse than no session at all, which would re-run X3DH.
+0b. **Ratchet state and session metadata are persisted and restored together.** Restoring one
+   without the other is the same half-state seen from the other side.
 1. Plaintext is padded with PADMÉ before encryption, so ciphertext length leaks at most
    about 10% of the plaintext length.
 2. A message key is derived per message and discarded after use: compromise of one key must


### PR DESCRIPTION
Closes #252

Last of the three session steps. Every session the desktop established died with the process.

## The defect

`RATCHET_STORE` (`commands/crypto.rs:56`) started empty and was **never populated from disk**,
while `SESSION_STORE` immediately above it *did* call `load_from_secure_storage`.

The state was always being written — `SessionData.state` carries `ratchet.serialize()` and is
persisted at three sites. Only the read was missing: `DoubleRatchet::deserialize` appeared
nowhere in the desktop crate outside a unit test.

**What the user saw.** After a restart, `get_session` and `list_sessions` reported an active
session with a peer, because the metadata came back. `encrypt_for_peer` then failed with *"no
Double Ratchet session with peer …"* and the send was refused. The UI said the session was
there and every message refused — worse than a clean absence, which would at least have
triggered a fresh key agreement.

## Two rules from `client-mobile`

Both learned the hard way there; `crypto_service.dart` carries the reasoning.

**A responder is not persisted before its first successful decrypt** (`:436-441`). `init_bob`
deliberately leaves the sending chain key unset; the DH ratchet that creates it runs on the
first inbound message. Persisting earlier writes a session that reloads unable to send.

**A restored ratchet that cannot send is discarded** (`:508-513`), along with its metadata, so
a fresh X3DH runs instead of a half-session being resurrected.

Dropping the metadata *with* the ratchet is the point — the two disagreeing is exactly what
produced the reported-but-refusing session. A session whose state is empty or fails to
deserialize goes the same way.

## `DoubleRatchet::can_send`

New, and what both rules test. A ratchet can be well-formed, restorable, and still unable to
send a single message; nothing exposed that distinction before.

## Tests

`rehydrate_ratchets` is pure and returns both maps rather than reaching into the global store,
so the restart round-trip is testable: Alice and Bob establish, Bob decrypts (which completes
his ratchet), the process "ends", and only what was persisted comes back — then Bob decrypts a
second message.

**All three tests fail** if `rehydrate_ratchets` is reverted to returning the metadata with no
ratchets, which is precisely the old behaviour:

```
test ..._a_session_survives_a_restart ... FAILED
test ..._a_session_that_cannot_send_is_dropped_rather_than_restored ... FAILED
test ..._sessions_without_restorable_state_are_dropped ... FAILED
```

## Documentation

`docs/spec/SRS.md` §"Message encryption" gains rules 0a and 0b: a responder has no sending
chain key until its first decrypt, with the two persistence consequences that follow; and
ratchet state and session metadata are persisted and restored together.

## A defect this makes worse, filed not fixed

**#253** — `SecureStorage::default_instance()` is hardcoded to user `"default"`
(`services/secure_storage.rs:51-53`), so the per-user namespacing the type implements is never
used and two accounts on one machine share a namespace. Before this PR the damage was bounded
by a single run, since ratchets were rebuilt on every start. Ratchets now outlive the process,
so a session belonging to one account could be loaded under another. Still latent — it needs a
second login, and there is no account-switching UI — but the consequence grew, so it is filed
rather than left as an observation.

## Deliberately out of scope

The final flip. `commands/messaging.rs:112` still hardcodes `x3dh_prekey: None`, nothing reads
the inbound field, and `get_messages` still returns the unconditional cannot-decrypt
placeholder. That is the next and last step; this one is what makes it safe to take, because a
session that did not survive a restart would have made the flip look like an intermittent
failure.

## Verification

```
cargo test --lib (client-desktop/src-tauri)   # 62 passed
cargo test -p guardyn-crypto                  # 98 + 20 passed
cargo fmt --all -- --check   (backend)        # clean
cargo clippy -p guardyn-crypto --all-targets -- -D warnings   # clean
just rules-verify / just docs-verify          # all pass
```

Budget: **5 files, 245 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)