### PR TITLE
feat(desktop): attach the X3DH prekey message to the first send

### DIFF
--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -64,6 +64,35 @@ static SESSION_STORE: LazyLock<Mutex<SessionStore>> = LazyLock::new(|| {
 static RATCHET_STORE: LazyLock<Mutex<HashMap<String, guardyn_crypto::DoubleRatchet>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// The X3DH prekey message an initiator owes its peer, keyed by peer id.
+///
+/// A responder cannot complete X3DH without the initiator's identity key, ephemeral key and the
+/// id of the one-time pre-key it consumed. Those travel once, on the first message of a
+/// session, in `SendMessageRequest.x3dh_prekey`.
+///
+/// In memory only, and deliberately so: it is derivable from a session that already exists, and
+/// it is owed for exactly as long as it takes one message to send. If the process ends first
+/// the peer never received anything to answer, so both sides start again from nothing.
+static PENDING_PREKEY: LazyLock<Mutex<HashMap<String, String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// The prekey message owed to `peer_id`, if any. Does not consume it - see
+/// [`clear_pending_prekey`].
+pub(crate) fn peek_pending_prekey(peer_id: &str) -> Option<String> {
+    PENDING_PREKEY.lock().ok()?.get(peer_id).cloned()
+}
+
+/// Drop the prekey message owed to `peer_id`, once a message carrying it has actually been
+/// accepted by the server.
+///
+/// Clearing on send rather than on attach is what makes a failed send retryable. Re-sending it
+/// is harmless: a responder that already has a session ignores the prekey message.
+pub(crate) fn clear_pending_prekey(peer_id: &str) {
+    if let Ok(mut pending) = PENDING_PREKEY.lock() {
+        pending.remove(peer_id);
+    }
+}
+
 /// Load keys from secure storage into the session store
 fn load_from_secure_storage(store: &mut SessionStore) -> Result<(), String> {
     let storage = SecureStorage::default_instance();
@@ -700,12 +729,24 @@ pub async fn perform_x3dh(
         use_one_time_key,
     ).map_err(|e| format!("X3DH key agreement failed: {}", e))?;
 
+    // Park what the peer will need to answer. It rides the first message of this session.
+    let used_prekey_id = if use_one_time_key { Some(0) } else { None };
+    let prekey_message = guardyn_crypto::x3dh::X3DHPrekeyMessage::new(
+        identity_keypair.public_bytes(),
+        ephemeral_public.as_bytes().to_vec(),
+        used_prekey_id,
+    );
+    PENDING_PREKEY
+        .lock()
+        .map_err(|e| e.to_string())?
+        .insert(recipient_id.clone(), prekey_message.to_base64());
+
     tracing::info!("X3DH key agreement successful with {}", recipient_id);
 
     Ok(X3DHResult {
         shared_secret: hex::encode(&shared_secret),
         ephemeral_key: hex::encode(ephemeral_public.as_bytes()),
-        used_prekey_id: if use_one_time_key { Some(0) } else { None },
+        used_prekey_id,
     })
 }
 
@@ -1453,6 +1494,28 @@ mod tests {
                 state,
             },
         )
+    }
+
+    /// What `perform_x3dh` parks must survive the trip and parse back. `x3dh_prekey` is an
+    /// opaque base64 string on the wire that no type checks, so the format is worth pinning at
+    /// the end that produces it - the end that consumes it arrives with #258.
+    #[test]
+    fn test_the_parked_prekey_message_round_trips() {
+        let identity = guardyn_crypto::x3dh::IdentityKeyPair::generate().unwrap();
+        let ephemeral = guardyn_crypto::x3dh::OneTimePreKey::generate(0);
+
+        let parked = guardyn_crypto::x3dh::X3DHPrekeyMessage::new(
+            identity.public_bytes(),
+            ephemeral.public_bytes(),
+            Some(0),
+        )
+        .to_base64();
+
+        let parsed = guardyn_crypto::x3dh::X3DHPrekeyMessage::from_base64(&parked).unwrap();
+
+        assert_eq!(parsed.sender_identity_key, identity.public_bytes());
+        assert_eq!(parsed.ephemeral_key, ephemeral.public_bytes());
+        assert_eq!(parsed.used_one_time_key_id, Some(0));
     }
 
     /// The restart round-trip. A session established before the process ended must decrypt the

--- a/client-desktop/src-tauri/src/commands/messaging.rs
+++ b/client-desktop/src-tauri/src/commands/messaging.rs
@@ -102,6 +102,11 @@ pub async fn send_message(
                 format!("Failed to send message: {}", e)
             })?;
 
+    // The first message of a session carries what the peer needs to answer it: our identity
+    // key, the ephemeral key X3DH ran with, and the id of the one-time pre-key we consumed.
+    // Without it the recipient holds ciphertext it can never derive a key for.
+    let x3dh_prekey = crate::commands::crypto::peek_pending_prekey(&request.recipient_id);
+
     // Create outgoing message - use recipient_id (user ID), not conversation_id
     let outgoing = OutgoingMessage {
         recipient_user_id: request.recipient_id.clone(),
@@ -109,12 +114,16 @@ pub async fn send_message(
         message_type: 0, // TEXT message
         client_message_id: uuid::Uuid::new_v4().to_string(),
         media_id: None,
-        x3dh_prekey: None,
+        x3dh_prekey,
     };
 
     // Send via gRPC
     match state.messaging().send_message(outgoing).await {
         Ok(result) => {
+            // Cleared only now. A send that failed leaves it parked, so the retry still carries
+            // it; a peer that already has a session ignores a repeat (#258).
+            crate::commands::crypto::clear_pending_prekey(&request.recipient_id);
+
             let message = Message {
                 id: result.message_id,
                 conversation_id: request.conversation_id,

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 956
+tokens: 1050
 supersedes: []
 ---
 
@@ -19,15 +19,15 @@ supersedes: []
 |---|---|---|---|
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
-| 3 | 59 | 67 | `█████████░` |
-| 4 | 0 | 12 | `░░░░░░░░░░` |
-| **all** | **85** | **105** | |
+| 3 | 60 | 70 | `█████████░` |
+| 4 | 0 | 13 | `░░░░░░░░░░` |
+| **all** | **86** | **109** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 20 of 105
+- **Open steps:** 23 of 109
 
 ## Gates
 
@@ -59,6 +59,8 @@ supersedes: []
 | PR-62 | 3 | [#191](https://github.com/guardyn/guardyn/issues/191) | Clear the 132 client-desktop clippy errors |
 | PR-63 | 3 | [#192](https://github.com/guardyn/guardyn/issues/192) | Reconcile the desktop coverage thresholds with reality |
 | PR-65 | 3 | [#199](https://github.com/guardyn/guardyn/issues/199) | Stop Build Linux flaking in linuxdeploy |
+| PR-81c | 3 | [#258](https://github.com/guardyn/guardyn/issues/258) | client-desktop - decrypt on receive |
+| PR-95 | 3 | [#255](https://github.com/guardyn/guardyn/issues/255) | X3DHPrekeyMessage one-time key id endianness differs between Rust and Dart |
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
 | PR-83 | 3 | — | Clear the 314 flutter analyze info diagnostics |
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
@@ -71,6 +73,7 @@ supersedes: []
 | PR-42 | 4 | [#53](https://github.com/guardyn/guardyn/issues/53) | Fix the inverted secrets gitignore |
 | PR-43 | 4 | [#54](https://github.com/guardyn/guardyn/issues/54) | Wire the compose observability stack |
 | PR-44 | 4 | [#55](https://github.com/guardyn/guardyn/issues/55) | Deployment parity - call-service k8s Deployment and image digest pins |
+| PR-96 | 4 | [#257](https://github.com/guardyn/guardyn/issues/257) | kube-bootstrap races the cert-manager webhook CA |
 | PR-91 | 4 | [#241](https://github.com/guardyn/guardyn/issues/241) | Generate docs/INDEX.md and the tokens: counts |
 | PR-93 | 4 | [#246](https://github.com/guardyn/guardyn/issues/246) | Consume the one-time pre-key that GetKeyBundle serves |
 | PR-94 | 4 | [#253](https://github.com/guardyn/guardyn/issues/253) | Partition client-desktop SecureStorage per account |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -153,6 +153,13 @@ steps:
   # no callers and NewConversationModal carries a TODO where the fetch belongs.
   - {id: PR-80b, issue: 250, phase: 3, type: feat, status: done, title: "client-desktop - wire get_key_bundle to the frontend"}
   - {id: PR-81, issue: 252, phase: 3, type: fix, status: done, title: "client-desktop - restore the ratchet store from persisted state"}
+  # The flip. Everything needed to hold a session now exists; two wires remain unconnected.
+  - {id: PR-81b, issue: 256, phase: 3, type: feat, status: done, title: "client-desktop - encrypt on send"}
+  - {id: PR-81c, issue: 258, phase: 3, type: feat, status: todo, title: "client-desktop - decrypt on receive"}
+  # Masked while every one-time key id on the wire is 0, which is byte-order invariant. Must
+  # land before PR-93 makes other ids reachable.
+  - {id: PR-95, issue: 255, phase: 3, type: security, status: todo, title: "X3DHPrekeyMessage one-time key id endianness differs between Rust and Dart"}
+  - {id: PR-96, issue: 257, phase: 4, type: fix, status: todo, title: "kube-bootstrap races the cert-manager webhook CA"}
   # Deferred deliberately, each with a stated reason in its step above.
   - {id: PR-82, issue: 211, phase: 3, type: chore, status: todo, title: "Add an FFI-backed mobile CI job"}
   - {id: PR-83, issue: null, phase: 3, type: chore, status: todo, title: "Clear the 314 flutter analyze info diagnostics"}


### PR DESCRIPTION
Closes #256

The send half of the final flip.

## Split, and why

This branch originally carried send **and** receive. Together they came to **11 files and 423
lines** — over both §2.3 limits, and `GIT-BUDGET` fails when both are exceeded. Split at the
send/receive seam per `.claude/rules/10-git-workflow.md`, each half with its own issue. Receive
is **#258**.

## The defect

`commands/messaging.rs` hardcoded:

```rust
x3dh_prekey: None,
```

A responder cannot complete X3DH without the initiator's identity key, the ephemeral key the
agreement ran with, and the id of the one-time pre-key it consumed. Those travel exactly once,
on the first message of a session, in `SendMessageRequest.x3dh_prekey`. The field exists end to
end — `services/messaging_client.rs`, `messaging.proto`, `src/api/websocket.types.ts:147` — and
nothing ever populated it.

So the desktop encrypted messages the recipient held and could **never derive a key for**.

## Cleared on send, not on attach

The parked message is dropped only once the server has accepted a message carrying it. That
makes a failed send retryable: the prekey message stays parked and the retry still carries it.
Clearing on attach would make a single dropped send permanently unanswerable.

Re-sending is harmless — a responder that already has a session ignores a repeat, which #258
must guarantee and which its issue states.

## The store is in-memory on purpose

It is derivable from a session that already exists, and it is owed for exactly as long as one
message takes to send. If the process ends first, the peer received nothing to answer, so both
sides start again from nothing. Persisting it would add a second thing to keep in sync with the
session for no gain.

## Test

`test_the_parked_prekey_message_round_trips` pins the format at the end that produces it.
`x3dh_prekey` is an opaque base64 string on the wire that no type checks, so identity key,
ephemeral key and one-time key id must survive the trip — the consuming end arrives with #258.

## Known limitation, carried forward

**#255** — `X3DHPrekeyMessage` encodes the one-time key id **little-endian in Rust and
big-endian in Dart**, and the Dart comment cites cross-platform compatibility as its reason.
Invisible today only because `0` is byte-order invariant and `0` is the only id either client
sends. It breaks when #246 makes other ids reachable. Found while writing this step; filed, not
fixed here.

## Deliberately out of scope

Reading the inbound `x3dh_prekey` and removing the unconditional cannot-decrypt placeholder in
`get_messages` — **#258**. The four documents that still describe desktop messaging as
non-functional (`roadmap.yaml`'s I-2 note, `ROADMAP.md`, `PRD.md`, `DEPLOYMENT.md`) are updated
there, when it becomes true rather than half true.

## Verification

```
cargo test --lib (client-desktop/src-tauri)   # 63 passed
just rules-verify / just docs-verify          # all pass
```

Budget: **4 files, 96 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)