### PR TITLE
feat(desktop): decrypt on receive

### DIFF
--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -1057,6 +1057,164 @@ pub const UNDECRYPTABLE_PLACEHOLDER: &str = "Message cannot be decrypted";
 /// because nothing on the desktop establishes a session yet; the callers are nevertheless
 /// written against the real contract so that landing session establishment needs no change
 /// here.
+/// Establish the responder side of a session from the prekey message that arrived with a
+/// peer's first message. A no-op when a session already exists.
+///
+/// The single implementation of the inbound path: `get_messages` calls it directly and the
+/// frontend reaches it through the `accept_session` command, so history and live delivery
+/// cannot drift apart.
+///
+/// Re-arrival is normal rather than exceptional. The initiator keeps attaching the prekey
+/// message until a send is accepted, so a retry or a duplicate delivery brings it again -
+/// acting on it twice would replace a ratchet that has already advanced and lose every message
+/// after the first.
+pub(crate) fn ensure_responder_session(peer_id: &str, x3dh_prekey: &str) -> Result<(), String> {
+    if RATCHET_STORE
+        .lock()
+        .map_err(|e| e.to_string())?
+        .contains_key(peer_id)
+    {
+        return Ok(());
+    }
+
+    let prekey = guardyn_crypto::x3dh::X3DHPrekeyMessage::from_base64(x3dh_prekey)
+        .map_err(|e| format!("Malformed X3DH prekey message: {}", e))?;
+
+    let store = SESSION_STORE.lock().map_err(|e| e.to_string())?;
+    let identity_data = store
+        .identity_keypair
+        .as_ref()
+        .ok_or_else(|| "Identity keys not generated".to_string())?;
+    let private_bytes = hex::decode(&identity_data.private_key)
+        .map_err(|e| format!("Invalid stored identity private key: {}", e))?;
+    let identity_keypair = guardyn_crypto::x3dh::IdentityKeyPair::from_private_bytes(&private_bytes)
+        .map_err(|e| format!("Failed to restore identity keypair: {}", e))?;
+
+    let signed_prekey_data = store
+        .signed_prekey
+        .as_ref()
+        .ok_or_else(|| "Signed prekey not generated".to_string())?;
+    let signed_prekey = restore_signed_prekey(signed_prekey_data)?;
+    let one_time_prekeys = store
+        .one_time_prekeys
+        .iter()
+        .map(restore_one_time_prekey)
+        .collect::<Result<Vec<_>, String>>()?;
+    drop(store);
+
+    let ratchet_secret = signed_prekey.ratchet_secret();
+    let key_material = guardyn_crypto::x3dh::X3DHKeyMaterial {
+        identity_key: identity_keypair,
+        signed_pre_key: signed_prekey,
+        one_time_pre_keys: one_time_prekeys,
+    };
+
+    let shared_secret = guardyn_crypto::x3dh::X3DHProtocol::respond_key_agreement(
+        &key_material,
+        &prekey.sender_identity_key,
+        &prekey.ephemeral_key,
+        prekey.used_one_time_key_id,
+    )
+    .map_err(|e| format!("X3DH respond failed: {}", e))?;
+
+    let ratchet = guardyn_crypto::DoubleRatchet::init_bob(&shared_secret, ratchet_secret)
+        .map_err(|e| format!("Failed to init Double Ratchet: {}", e))?;
+
+    let session = SessionData {
+        peer_id: peer_id.to_string(),
+        established_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+        messages_sent: 0,
+        messages_received: 0,
+        state: ratchet.serialize(),
+    };
+
+    RATCHET_STORE
+        .lock()
+        .map_err(|e| e.to_string())?
+        .insert(peer_id.to_string(), ratchet);
+    SESSION_STORE
+        .lock()
+        .map_err(|e| e.to_string())?
+        .sessions
+        .insert(peer_id.to_string(), session);
+
+    // Not persisted here: a responder has no sending chain key until its first decrypt performs
+    // the DH ratchet, and `rehydrate_ratchets` rightly discards a session that cannot send.
+    // `decrypt_from_peer` writes it once that decrypt succeeds.
+    tracing::info!("Responder session established from an inbound prekey message");
+    Ok(())
+}
+
+/// Establish the responder side of a session, for the frontend's live-delivery path.
+#[tauri::command]
+pub async fn accept_session(peer_id: String, x3dh_prekey: String) -> Result<(), String> {
+    ensure_responder_session(&peer_id, &x3dh_prekey)
+}
+
+/// Decrypt a message received from `sender_id`, returning `None` when it cannot be decrypted.
+///
+/// The mirror of [`encrypt_for_peer`]. `None` rather than an error, because "we could not read
+/// this" is a normal outcome the UI renders as a placeholder, not a failure of the operation
+/// that is fetching messages - one unreadable message must not blank a whole conversation.
+///
+/// The associated data names the parties by role, originator first, so both ends compute the
+/// same bytes: the sender here is the peer, not the local user (ADR-0011).
+pub(crate) fn decrypt_from_peer(
+    ciphertext: &[u8],
+    sender_id: &str,
+    self_user_id: &str,
+) -> Option<String> {
+    let encrypted = match guardyn_crypto::double_ratchet::EncryptedMessage::from_bytes(ciphertext) {
+        Ok(message) => message,
+        Err(e) => {
+            tracing::debug!("Message is not a well-formed ciphertext: {}", e);
+            return None;
+        }
+    };
+
+    let associated_data = message_associated_data(sender_id, self_user_id);
+
+    let mut ratchet_store = RATCHET_STORE.lock().ok()?;
+    let ratchet = ratchet_store.get_mut(sender_id)?;
+    let padded = match ratchet.decrypt(&encrypted, &associated_data) {
+        Ok(plaintext) => plaintext,
+        Err(e) => {
+            tracing::debug!("Double Ratchet could not decrypt: {}", e);
+            return None;
+        }
+    };
+    // Take the state now, while the ratchet is still borrowed and known to have advanced.
+    let state = ratchet.serialize();
+    drop(ratchet_store);
+
+    let plaintext = guardyn_crypto::unpad_message(&padded)
+        .map_err(|e| tracing::debug!("PADME unpad failed: {}", e))
+        .ok()?;
+
+    // The ratchet advanced, so the stored state is now stale. Persisting here is also what
+    // writes a responder session for the first time: it is deliberately not persisted at
+    // creation, because it cannot send until this decrypt completes it (see init_session).
+    if let Ok(mut store) = SESSION_STORE.lock() {
+        if let Some(session) = store.sessions.get_mut(sender_id) {
+            session.messages_received += 1;
+            session.state = state;
+        }
+        let sessions = store.sessions.clone();
+        drop(store);
+        if let Err(e) = persist_sessions(&sessions) {
+            // The message decrypted; losing the write costs a re-agreement, not the message.
+            tracing::warn!("Could not persist the advanced ratchet state: {}", e);
+        }
+    }
+
+    String::from_utf8(plaintext)
+        .map_err(|_| tracing::debug!("Decrypted bytes are not valid UTF-8"))
+        .ok()
+}
+
 pub(crate) fn encrypt_for_peer(
     plaintext: &str,
     recipient_id: &str,
@@ -1516,6 +1674,45 @@ mod tests {
         assert_eq!(parsed.sender_identity_key, identity.public_bytes());
         assert_eq!(parsed.ephemeral_key, ephemeral.public_bytes());
         assert_eq!(parsed.used_one_time_key_id, Some(0));
+    }
+
+    /// `decrypt_from_peer` must never hand back the bytes it failed to read. This is the #232
+    /// guarantee at the Rust boundary: the old code used `String::from_utf8_lossy`, which
+    /// cannot fail, so ciphertext rendered as replacement characters and anything that happened
+    /// to be valid UTF-8 rendered as the message.
+    #[test]
+    fn test_decrypt_returns_nothing_for_bytes_that_are_not_a_message() {
+        // Valid UTF-8, so a lossy conversion would have rendered it as the message text.
+        assert_eq!(
+            decrypt_from_peer(b"this is not a ciphertext", "someone", "me"),
+            None
+        );
+        assert_eq!(decrypt_from_peer(&[], "someone", "me"), None);
+        assert_eq!(decrypt_from_peer(&[0xff; 80], "someone", "me"), None);
+    }
+
+    /// A well-formed ciphertext from a peer we have no session with is unreadable, not an
+    /// error: the fetch that found it must still return every other message.
+    #[test]
+    fn test_decrypt_returns_nothing_when_there_is_no_session() {
+        let material = guardyn_crypto::x3dh::X3DHKeyMaterial::generate(1).unwrap();
+        let peer_public: [u8; 32] = material
+            .signed_pre_key
+            .public_bytes()
+            .try_into()
+            .unwrap();
+        let mut sender = guardyn_crypto::DoubleRatchet::init_alice(
+            &[3u8; 32],
+            guardyn_crypto::X25519PublicKey::from(peer_public),
+        )
+        .unwrap();
+        let aad = message_associated_data("stranger-with-no-session", "me");
+        let ciphertext = sender.encrypt(b"hello", &aad).unwrap().to_bytes();
+
+        assert_eq!(
+            decrypt_from_peer(&ciphertext, "stranger-with-no-session", "me"),
+            None
+        );
     }
 
     /// The restart round-trip. A session established before the process ended must decrypt the

--- a/client-desktop/src-tauri/src/commands/messaging.rs
+++ b/client-desktop/src-tauri/src/commands/messaging.rs
@@ -204,6 +204,10 @@ pub async fn get_messages(
         limit
     );
 
+    let self_user_id = state
+        .user_id()
+        .ok_or_else(|| "Not authenticated: no local user id".to_string())?;
+
     match state.messaging().get_messages(
         conversation_id.clone(),
         limit.unwrap_or(50) as i32,
@@ -212,22 +216,44 @@ pub async fn get_messages(
             let result: Vec<Message> = messages
                 .into_iter()
                 .map(|m| {
+                    // A message that arrives with a prekey message is a peer opening a session
+                    // with us. Establish the responder side before trying to read it; a failure
+                    // here is not fatal to the fetch, it just leaves this message unreadable.
+                    if let Some(prekey) = m.x3dh_prekey.as_deref().filter(|p| !p.is_empty()) {
+                        if let Err(e) = crate::commands::crypto::ensure_responder_session(
+                            &m.sender_user_id,
+                            prekey,
+                        ) {
+                            tracing::warn!("Could not establish a responder session: {}", e);
+                        }
+                    }
+
                     // Show that we could not decrypt, rather than showing what we could not
                     // decrypt. This was `String::from_utf8_lossy(&m.encrypted_content)`, which
                     // cannot fail - so ciphertext rendered as replacement characters instead of
                     // as an error, and anything that happened to be valid UTF-8 rendered as the
                     // message (#232).
                     //
-                    // Every message is undecryptable today, because nothing on this client
-                    // establishes a session yet (PR-79..PR-81). Saying so is the honest result.
-                    let content = crate::commands::crypto::UNDECRYPTABLE_PLACEHOLDER.to_string();
+                    // The placeholder is no longer unconditional: it is what a genuine failure
+                    // looks like. Messages predating this client's session, or sent while a
+                    // session was being re-established, legitimately cannot be read - and must
+                    // still say so rather than render bytes.
+                    let decrypted = crate::commands::crypto::decrypt_from_peer(
+                        &m.encrypted_content,
+                        &m.sender_user_id,
+                        &self_user_id,
+                    );
+                    let undecryptable = decrypted.is_none();
+                    let content = decrypted.unwrap_or_else(|| {
+                        crate::commands::crypto::UNDECRYPTABLE_PLACEHOLDER.to_string()
+                    });
 
                     Message {
                         id: m.message_id,
                         conversation_id: conversation_id.clone(),
                         sender_id: m.sender_user_id,
                         content,
-                        undecryptable: true,
+                        undecryptable,
                         timestamp: m.server_timestamp,
                         status: match m.delivery_status {
                             0 => MessageStatus::Sending,

--- a/client-desktop/src-tauri/src/main.rs
+++ b/client-desktop/src-tauri/src/main.rs
@@ -160,6 +160,7 @@ fn main() {
             commands::crypto::generate_one_time_prekeys,
             commands::crypto::perform_x3dh,
             commands::crypto::respond_x3dh,
+            commands::crypto::accept_session,
             commands::crypto::init_session,
             commands::crypto::get_session,
             commands::crypto::list_sessions,

--- a/client-desktop/src/api/crypto.ts
+++ b/client-desktop/src/api/crypto.ts
@@ -226,6 +226,16 @@ export async function performX3DH(
 }
 
 /**
+ * Establish the responder side of a session from a peer's prekey message.
+ *
+ * Does the X3DH response and the ratchet seeding in one step, and is a no-op when a session
+ * already exists.
+ */
+export async function acceptSessionCommand(peerId: string, x3dhPrekey: string): Promise<void> {
+  await invoke('accept_session', { peerId, x3dhPrekey });
+}
+
+/**
  * Complete X3DH key agreement as responder (Bob), from the prekey message the initiator
  * attached to its first message.
  *
@@ -465,28 +475,17 @@ export class EncryptionService {
    * Answer a peer that opened a session with us, from the prekey message it attached to its
    * first message.
    *
-   * The mirror of `startSession`. Nothing is passed for `peerPublicKey`: the responder's
-   * initial ratchet key is its own signed pre-key - the key the initiator ran X3DH against -
-   * which the Rust side restores from secure storage.
+   * The mirror of `startSession`. The whole exchange happens in Rust: `get_messages` takes the
+   * same path for history, and two implementations of it would drift. Calling this again for a
+   * peer that already has a session is a no-op, which matters because the initiator keeps
+   * attaching the prekey message until a send is accepted.
    */
-  async acceptSession(
-    peerId: string,
-    peerIdentityKey: string,
-    peerEphemeralKey: string,
-    usedOneTimeKeyId?: number
-  ): Promise<SessionInfo> {
+  async acceptSession(peerId: string, x3dhPrekey: string): Promise<void> {
     if (!this.initialized) {
       throw new Error('EncryptionService not initialized');
     }
 
-    const x3dhResult = await respondX3DH(
-      peerIdentityKey,
-      peerEphemeralKey,
-      usedOneTimeKeyId,
-      peerId
-    );
-
-    return initSession(peerId, x3dhResult.sharedSecret, false);
+    await acceptSessionCommand(peerId, x3dhPrekey);
   }
 
   /**

--- a/client-desktop/src/pages/Chat.tsx
+++ b/client-desktop/src/pages/Chat.tsx
@@ -147,6 +147,13 @@ const Chat: Component<ChatPageProps> = () => {
             if (!self) {
               throw new Error('no local user id; cannot build the message associated data');
             }
+            // A message carrying a prekey message is a peer opening a session with us. Answer
+            // it before trying to read the message it came with, or there is no ratchet to
+            // decrypt with. Repeats are a no-op, which matters because the initiator keeps
+            // attaching it until a send is accepted.
+            if (data.x3dh_prekey) {
+              await encryptionManager.acceptSession(data.sender_id, data.x3dh_prekey);
+            }
             content = await encryptionManager.decryptMessage(
               data.sender_id,
               { ciphertext: data.content, nonce: '', header: '' },
@@ -154,9 +161,10 @@ const Chat: Component<ChatPageProps> = () => {
             );
             undecryptable = false;
           } catch (err) {
-            // Expected until session establishment lands: there is no session to decrypt with,
-            // so every inbound message is undecryptable. Showing the placeholder is the honest
-            // result, and is what the user would see anyway for a genuinely broken message.
+            // No longer the expected case. A message can still be genuinely unreadable - it
+            // predates this device's session, or arrived while one was being re-established -
+            // and the placeholder is what that must look like. Rendering the bytes instead is
+            // the defect #232 fixed.
             console.warn('[Chat] Could not decrypt message:', err);
           }
 

--- a/client-desktop/src/services/encryption.ts
+++ b/client-desktop/src/services/encryption.ts
@@ -179,6 +179,40 @@ class EncryptionManager {
   }
 
   /**
+   * Answer a peer that opened a session with us, from the prekey message its first message
+   * carried.
+   *
+   * The mirror of `establishSession`. A repeat is a no-op - the initiator keeps attaching the
+   * prekey message until a send is accepted, so the same one arrives again on a retry or a
+   * duplicate delivery, and acting on it twice would replace a ratchet that has already
+   * advanced.
+   */
+  async acceptSession(peerId: string, x3dhPrekey: string): Promise<void> {
+    if (!this.initialized) {
+      throw new Error('EncryptionManager not initialized');
+    }
+
+    try {
+      await encryptionService.acceptSession(peerId, x3dhPrekey);
+      this.updatePeerState(peerId, {
+        peerId,
+        status: 'established',
+        lastUpdated: Date.now(),
+      });
+      this.emit({ type: 'session_established', peerId, timestamp: Date.now() });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.updatePeerState(peerId, {
+        peerId,
+        status: 'error',
+        errorMessage,
+        lastUpdated: Date.now(),
+      });
+      throw error;
+    }
+  }
+
+  /**
    * Get encryption status for a peer
    */
   getPeerStatus(peerId: string): EncryptionStatus {

--- a/docs/ops/DEPLOYMENT.md
+++ b/docs/ops/DEPLOYMENT.md
@@ -124,5 +124,4 @@ and any `*.key` are gitignored and must never reach the repository.
 | `infra/k8s/base/envoy/ingress.yaml:18` hardcodes `envoy.guardyn.local` | breaks the `${DOMAIN}` rule above | **unowned** |
 | Production images are tagged, not digest-pinned | a tag can be moved under a running cluster | PR-44 |
 | `infra/secrets/.gitignore` ignores `*.enc.yaml` — the **encrypted** file — while the plaintext `app-secrets.yaml` is tracked | exactly inverted: the safe artefact is excluded and the unsafe one committed. The tracked values are placeholders, so no live credential is exposed *yet* | PR-42 |
-| `client-desktop` cannot establish a session, so it refuses every one-to-one send | desktop messaging is non-functional until the session stack lands — deliberate, since the alternative was plaintext at rest | PR-79…PR-81 |
 | `infra/justfile` is a second, divergent task file whose `k8s:deploy` references a values file that does not exist | dead code that will mislead | unowned |

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -56,7 +56,7 @@ reason phases 3 and 4 exist.
 
 | Invariant | State | Closed by |
 |---|---|---|
-| **I-2** Always-On E2EE | server-side encryption removed and no flag remains; **both clients still transmit plaintext** | PR-30′, PR-31a–d, PR-32a–c, PR-75–PR-81 (Phase 3) |
+| **I-2** Always-On E2EE | server-side encryption removed, no flag remains, no client transmits plaintext, and desktop one-to-one messaging runs over the encrypted path; **mobile groups still refuse for want of MLS** | PR-30′, PR-31a–d, PR-32a–c, PR-75–PR-81c (Phase 3) |
 | **I-3** Post-Quantum | `pq` is off by default and no proto field carries an ML-KEM key, so no server can publish one | PR-36…PR-40 (Phase 4) |
 
 Until those land, **the product must not be described as always-encrypted or

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1050
+tokens: 1029
 supersedes: []
 ---
 
@@ -19,15 +19,15 @@ supersedes: []
 |---|---|---|---|
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
-| 3 | 60 | 70 | `█████████░` |
+| 3 | 61 | 70 | `█████████░` |
 | 4 | 0 | 13 | `░░░░░░░░░░` |
-| **all** | **86** | **109** | |
+| **all** | **87** | **109** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 23 of 109
+- **Open steps:** 22 of 109
 
 ## Gates
 
@@ -44,8 +44,8 @@ supersedes: []
 |---|---|---|---|
 | I-1 | Zero-Knowledge | partial | — |
 | | | | *rate_limit.rs logs a raw IP; span fields are not redacted* |
-| I-2 | Always-On E2EE | partial | PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78 |
-| | | | *no switch can disable encryption - E2EE-FLAG passes and rules-verify now enforces it - and no client path transmits plaintext. Remaining: client-desktop cannot establish a session so it refuses every send (PR-79..PR-81), and mobile groups refuse for want of MLS* |
+| I-2 | Always-On E2EE | partial | PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78, PR-79, PR-80, PR-80b, PR-81, PR-81b, PR-81c |
+| | | | *no switch can disable encryption - E2EE-FLAG passes and rules-verify enforces it - no client path transmits plaintext, and client-desktop one-to-one messaging now runs over the encrypted path. Remaining: mobile groups refuse for want of MLS* |
 | I-3 | Post-Quantum | false | PR-36, PR-37, PR-38, PR-39, PR-40 |
 | I-4 | Data Sovereignty | partial | — |
 | | | | *envoy/ingress.yaml hardcodes a domain* |
@@ -59,7 +59,6 @@ supersedes: []
 | PR-62 | 3 | [#191](https://github.com/guardyn/guardyn/issues/191) | Clear the 132 client-desktop clippy errors |
 | PR-63 | 3 | [#192](https://github.com/guardyn/guardyn/issues/192) | Reconcile the desktop coverage thresholds with reality |
 | PR-65 | 3 | [#199](https://github.com/guardyn/guardyn/issues/199) | Stop Build Linux flaking in linuxdeploy |
-| PR-81c | 3 | [#258](https://github.com/guardyn/guardyn/issues/258) | client-desktop - decrypt on receive |
 | PR-95 | 3 | [#255](https://github.com/guardyn/guardyn/issues/255) | X3DHPrekeyMessage one-time key id endianness differs between Rust and Dart |
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
 | PR-83 | 3 | — | Clear the 314 flutter analyze info diagnostics |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -29,7 +29,7 @@ project_sync_enabled: true
 
 invariants:
   - {id: I-1, name: Zero-Knowledge,   met: partial, note: "rate_limit.rs logs a raw IP; span fields are not redacted"}
-  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78], note: "no switch can disable encryption - E2EE-FLAG passes and rules-verify now enforces it - and no client path transmits plaintext. Remaining: client-desktop cannot establish a session so it refuses every send (PR-79..PR-81), and mobile groups refuse for want of MLS"}
+  - {id: I-2, name: Always-On E2EE,   met: partial, closed_by: [PR-30, PR-31a, PR-31b, PR-32a, PR-32b, PR-32c, PR-75, PR-76, PR-77, PR-78, PR-79, PR-80, PR-80b, PR-81, PR-81b, PR-81c], note: "no switch can disable encryption - E2EE-FLAG passes and rules-verify enforces it - no client path transmits plaintext, and client-desktop one-to-one messaging now runs over the encrypted path. Remaining: mobile groups refuse for want of MLS"}
   - {id: I-3, name: Post-Quantum,     met: false,   closed_by: [PR-36, PR-37, PR-38, PR-39, PR-40]}
   - {id: I-4, name: Data Sovereignty, met: partial, note: "envoy/ingress.yaml hardcodes a domain"}
 
@@ -155,7 +155,7 @@ steps:
   - {id: PR-81, issue: 252, phase: 3, type: fix, status: done, title: "client-desktop - restore the ratchet store from persisted state"}
   # The flip. Everything needed to hold a session now exists; two wires remain unconnected.
   - {id: PR-81b, issue: 256, phase: 3, type: feat, status: done, title: "client-desktop - encrypt on send"}
-  - {id: PR-81c, issue: 258, phase: 3, type: feat, status: todo, title: "client-desktop - decrypt on receive"}
+  - {id: PR-81c, issue: 258, phase: 3, type: feat, status: done, title: "client-desktop - decrypt on receive"}
   # Masked while every one-time key id on the wire is 0, which is byte-order invariant. Must
   # land before PR-93 makes other ids reachable.
   - {id: PR-95, issue: 255, phase: 3, type: security, status: todo, title: "X3DHPrekeyMessage one-time key id endianness differs between Rust and Dart"}

--- a/docs/spec/PRD.md
+++ b/docs/spec/PRD.md
@@ -124,8 +124,9 @@ Stated plainly, because a PRD that implies capability is a PRD that misleads.
   cannot publish one (PR-36…PR-40).
 - **Always-on encryption, end to end.** The server side is done: the E2EE handler fork, the
   configuration flags and the deployment variables are all gone (PR-32a/b/c), and both clients
-  now refuse to send rather than transmit plaintext (#226, #229, #163). What remains is that
-  `client-desktop` cannot yet establish a session, so it refuses every send — encryption is
-  never bypassed, but desktop one-to-one messaging does not function until PR-79…PR-81 land.
+  refuse to send rather than transmit plaintext (#226, #229, #163). `client-desktop` one-to-one
+  messaging now works over that path: it establishes a session, encrypts every send and
+  decrypts what it receives (PR-79…PR-81c). What remains is **groups**, where `client-mobile`
+  refuses to send for want of MLS.
 - **A browser client.** Envoy routes three of six services; media, calls and notifications
   are not reachable from a browser today.


### PR DESCRIPTION
Closes #258

The receive half of the final flip, split from #256. **This closes the I-2 clause that has
stood since the fail-closed wave**: `client-desktop` one-to-one messaging now runs over the
encrypted path, end to end.

## The defect

`get_messages` hardcoded the placeholder for *every* inbound message, and nothing read the
inbound `x3dh_prekey` on either transport. With #259 attaching the prekey message on send, a
desktop client could open a session with a peer and still refuse to read what came back.

## What stays, and why

`ENCRYPTION_UNAVAILABLE`, `UNDECRYPTABLE_PLACEHOLDER`, the `encrypt_for_peer` refusal and every
one of their regression tests **stay**. What goes is the *unconditional* placeholder — the
hardcoding, not the mechanism.

A message that predates this device's session, or arrives while one is being re-established,
genuinely cannot be read and must still say so rather than render bytes. That is the #232
guarantee. Removing the guards would reopen the I-2 violation the fail-closed wave closed.

## One implementation, two transports

History arrives through `get_messages` and live delivery through the frontend. Two
implementations of the responder path would drift, and a session established on one path has to
be the same session the other decrypts with — so the exchange lives in Rust
(`ensure_responder_session`), and the frontend reaches it through a single command.

That also meant rewriting `EncryptionService.acceptSession`, added in #249 with no callers, to
delegate rather than re-do the steps.

## Repeats must be a no-op

The initiator keeps attaching the prekey message until a send is accepted (#259), so a retry or
a duplicate delivery brings the same one again. Acting on it twice would **replace a ratchet
that has already advanced and lose every message after the first**, so
`ensure_responder_session` returns early when a session exists.

## `decrypt_from_peer` returns `None`, not an error

Being unable to read one message is a normal outcome the UI renders as a placeholder — not a
failure of the fetch that found it. One unreadable message must not blank a conversation.

It is also where a responder session is **first persisted**. PR-81 deliberately does not write
one at creation, because a responder has no sending chain key until its first decrypt performs
the DH ratchet, and `rehydrate_ratchets` rightly discards a session that cannot send.

## Tests

- `decrypt_returns_nothing_for_bytes_that_are_not_a_message` — the #232 guarantee at the Rust
  boundary. The inputs include **valid UTF-8**, which the old `from_utf8_lossy` would have
  rendered as the message text.
- `decrypt_returns_nothing_when_there_is_no_session` — a well-formed ciphertext from an unknown
  peer is unreadable, not an error.

## Documentation

Four documents claimed desktop messaging was non-functional; all four are corrected here rather
than in #259, so they change when it becomes true rather than half true:
`roadmap.yaml`'s I-2 note, `docs/roadmap/ROADMAP.md`, `docs/spec/PRD.md`, and the known-issues
row in `docs/ops/DEPLOYMENT.md`.

## Known limitation, carried forward

**#255** — the one-time key id is little-endian in Rust and big-endian in Dart. Masked while
every id on the wire is `0`, which is byte-order invariant, so desktop↔mobile works today. It
must be fixed before #246 makes other ids reachable.

## Not verified here

`just test-two-client-messaging` (Android ↔ Linux) needs a running stack and two devices. Per
ADR-0011:94 it is the **only** check that proves the two implementations interoperate — every
desktop test is Rust-against-Rust, which passes just as happily when both sides share a bug.
Flagged for a manual run.

## Verification

```
cargo test --lib (client-desktop/src-tauri)   # 65 passed
npx tsc --noEmit                              # clean
npm run lint                                  # 0 errors (54 pre-existing warnings)
npx vitest run                                # 413 passed, 17 skipped
just rules-verify / just docs-verify          # all pass
```

Budget: **11 files, 340 lines** — inside the contract on the line limit, which is the disjunct
that applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)