### PR TITLE
docs(roadmap): correct the Phase 4 scope before executing it

### DIFF
--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1012
+tokens: 1146
 supersedes: []
 ---
 
@@ -20,14 +20,14 @@ supersedes: []
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
 | 3 | 62 | 70 | `█████████░` |
-| 4 | 0 | 13 | `░░░░░░░░░░` |
-| **all** | **88** | **109** | |
+| 4 | 1 | 18 | `█░░░░░░░░░` |
+| **all** | **89** | **114** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 21 of 109
+- **Open steps:** 25 of 114
 
 ## Gates
 
@@ -65,7 +65,9 @@ supersedes: []
 | PR-36 | 4 | [#47](https://github.com/guardyn/guardyn/issues/47) | Extend protos with ML-KEM key material fields |
 | PR-37 | 4 | [#48](https://github.com/guardyn/guardyn/issues/48) | Persist and serve ML-KEM public keys in auth-service |
 | PR-38 | 4 | [#49](https://github.com/guardyn/guardyn/issues/49) | Enable the pq feature across backend services |
-| PR-39 | 4 | [#50](https://github.com/guardyn/guardyn/issues/50) | Wire PqxdhProtocol into messaging-service session establishment |
+| PR-97 | 4 | [#261](https://github.com/guardyn/guardyn/issues/261) | Version X3DHPrekeyMessage and carry an optional ML-KEM ciphertext |
+| PR-39 | 4 | [#50](https://github.com/guardyn/guardyn/issues/50) | client-desktop negotiates hybrid PQXDH |
+| PR-98 | 4 | [#262](https://github.com/guardyn/guardyn/issues/262) | Export the hybrid key agreement through crypto-ffi and route client-mobile through it |
 | PR-40 | 4 | [#51](https://github.com/guardyn/guardyn/issues/51) | Add fuzz, proptest and bench coverage for the hybrid PQ path |
 | PR-41 | 4 | [#52](https://github.com/guardyn/guardyn/issues/52) | Make rate limiting distributed or document the single-replica constraint |
 | PR-42 | 4 | [#53](https://github.com/guardyn/guardyn/issues/53) | Fix the inverted secrets gitignore |
@@ -75,3 +77,5 @@ supersedes: []
 | PR-91 | 4 | [#241](https://github.com/guardyn/guardyn/issues/241) | Generate docs/INDEX.md and the tokens: counts |
 | PR-93 | 4 | [#246](https://github.com/guardyn/guardyn/issues/246) | Consume the one-time pre-key that GetKeyBundle serves |
 | PR-94 | 4 | [#253](https://github.com/guardyn/guardyn/issues/253) | Partition client-desktop SecureStorage per account |
+| PR-99 | 4 | [#263](https://github.com/guardyn/guardyn/issues/263) | One-time pre-key ids break at TiKV lexicographic index >= 10 |
+| PR-100 | 4 | [#264](https://github.com/guardyn/guardyn/issues/264) | Add known-answer vectors for the sealed sender wire format |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -97,7 +97,14 @@ steps:
   - {id: PR-36, issue: 47, phase: 4, type: feat, status: todo, title: "Extend protos with ML-KEM key material fields"}
   - {id: PR-37, issue: 48, phase: 4, type: feat, status: todo, title: "Persist and serve ML-KEM public keys in auth-service"}
   - {id: PR-38, issue: 49, phase: 4, type: feat, status: todo, title: "Enable the pq feature across backend services"}
-  - {id: PR-39, issue: 50, phase: 4, type: feat, status: todo, title: "Wire PqxdhProtocol into messaging-service session establishment"}
+  # Retitled by PR-101. The original scope - "wire PqxdhProtocol into
+  # messaging-service/src/crypto.rs" - named a file PR-30' deleted, in a service ADR-0010
+  # made a pure relay. Following it would have put key agreement back on the server and
+  # breached I-1. Session establishment runs on the clients; PR-97 gives the prekey message
+  # somewhere to carry the ML-KEM ciphertext, and PR-98 is the same work on mobile.
+  - {id: PR-97, issue: 261, phase: 4, type: feat, status: todo, title: "Version X3DHPrekeyMessage and carry an optional ML-KEM ciphertext"}
+  - {id: PR-39, issue: 50, phase: 4, type: feat, status: todo, title: "client-desktop negotiates hybrid PQXDH"}
+  - {id: PR-98, issue: 262, phase: 4, type: feat, status: todo, title: "Export the hybrid key agreement through crypto-ffi and route client-mobile through it"}
   - {id: PR-40, issue: 51, phase: 4, type: security, status: todo, title: "Add fuzz, proptest and bench coverage for the hybrid PQ path"}
   - {id: PR-41, issue: 52, phase: 4, type: refactor, status: todo, title: "Make rate limiting distributed or document the single-replica constraint"}
   - {id: PR-42, issue: 53, phase: 4, type: security, status: todo, title: "Fix the inverted secrets gitignore"}
@@ -187,3 +194,10 @@ steps:
   # Latent until a second account is used on one machine, but PR-81 grew its consequence:
   # ratchets now outlive the process, so a cross-read session can decrypt real messages.
   - {id: PR-94, issue: 253, phase: 4, type: security, status: todo, title: "Partition client-desktop SecureStorage per account"}
+  # Found while mapping Phase 4. Both are the same class of latent id defect as PR-95, and
+  # both detonate on PR-93. Opened before any fix, per .claude/rules/00-invariants.md.
+  - {id: PR-99, issue: 263, phase: 4, type: fix, status: todo, title: "One-time pre-key ids break at TiKV lexicographic index >= 10"}
+  - {id: PR-100, issue: 264, phase: 4, type: security, status: todo, title: "Add known-answer vectors for the sealed sender wire format"}
+  # This step. The plan of record directed PR-39 at an I-1 breach for the second time; the
+  # correction is recorded rather than made silently.
+  - {id: PR-101, issue: 265, phase: 4, type: docs, status: done, title: "Reconcile roadmap.yaml for the Phase 4 scope correction"}


### PR DESCRIPTION
Closes #265

Phase 4 could not be executed as written. This corrects `roadmap.yaml` so the plan says what
is true before any ML-KEM code is written. **No code changes, and neither latent defect below
is fixed here.**

## PR-39 named a deleted file, and building it would have breached I-1

`implementation_plan.md:526` and #50 both read:

> Wire `PqxdhProtocol` into `messaging-service/src/crypto.rs` session establishment

Three things are wrong with that sentence:

- `messaging-service/src/crypto.rs` **does not exist.** PR-30' deleted it along with the
  server-side ratchet storage.
- [ADR-0010](../blob/main/docs/adr/ADR-0010-pure-relay-server.md) makes the server a pure relay
  holding no key material. Putting key agreement back into `messaging-service` would make the
  server a party to the encryption again — the **I-1 breach** PR-30' and PR-32a/b/c spent
  Phase 3 removing.
- There is no type called `PqxdhProtocol`. `crypto/src/pqxdh.rs` exposes free functions:
  `generate_hybrid_key_bundle`, `verify_hybrid_bundle`, `derive_sender_shared_secret`,
  `derive_recipient_shared_secret`.

Session establishment runs on the clients, so PR-39 is retitled to the desktop half and #50
rewritten to match. **The prose in `implementation_plan.md` §7.1 and
[ADR-0005](../blob/main/docs/adr/ADR-0005-hybrid-pqxdh.md) is deliberately not amended here** —
it is amended in PR-39's own branch, where the correction sits beside the work rather than a
merge away from it.

This is the second time the plan of record has aimed an agent at an I-1 breach. The first was
`AGENTS.md` §1 directing PR-32 to collapse onto the `_e2ee` handlers, corrected by PR-31d.
Both corrections are kept in the record for the same reason: a plan that has been wrong once
about which side of a boundary holds the keys will be read more carefully the next time.

## Two steps required to close I-3 did not exist

| Step | Issue | Why it is needed |
|---|---|---|
| PR-97 | #261 | `X3DHPrekeyMessage` has **no version byte** and cannot carry the 1088-byte ML-KEM ciphertext `derive_sender_shared_secret` returns. PR-39 has nowhere to put it. |
| PR-98 | #262 | `crypto-ffi` exports hybrid bundle *generation* and no *agreement*; `client-mobile` runs a pure-Dart X3DH with no ML-KEM reachable from it. I-3 stays unmet on mobile whatever the server does. |

`implementation_plan.md:531` claims *"Client integration is already ~90% complete,"* citing
`crypto_generate_hybrid_key_bundle` and `crypto_is_pq_available`. Bundle generation is not
integration — the agreement is the half that does not exist. Mobile's
`deriveHybridSharedSecret` is already on the hot path for all four DH operations and discards
the PQ half behind a `TODO` (`rust_crypto_bridge.dart:219`).

## Two latent defects found on the way — opened, not fixed

Both are the same class as #255, and both detonate on #246.

- **PR-99 (#263)** — one-time pre-key ids are written as unpadded decimal
  (`auth-service/src/db.rs:91`) and read back by a **lexicographic** TiKV scan (`:556`). At
  eleven keys the scan returns `0, 1, 10, 2, …`, so the array position an initiator names as
  the id stops matching the stored index. Safe today by exactly one:
  `PUBLISHED_ONE_TIME_PREKEY_COUNT = 10`.
- **PR-100 (#264)** — the sealed sender wire format has no known-answer vectors. It happens to
  agree (big-endian on both sides) but is pinned by nothing — the same gap that let #255 exist.

## A note on the tooling, and on convergence

`roadmap-sync` **cannot create issues**: `infra/scripts/roadmap-sync.sh:132-135` prints
`"<id> has no issue yet — would create"` and continues, in write mode as well as dry run. It
also never writes titles; the reconcile loop PATCHes only `state`, `state_reason` and
`milestone`. So the five issues were created with `gh issue create` using the title the sync
would have used, #50 was retitled with `gh issue edit`, and the numbers were then recorded
here.

**The second write run reports `1 changed`, not `0`.** That one is PR-83, which carries
`issue: null` on `main` and is untouched by this diff — the script counts a "would create" as
changed while never creating, so it can never converge while any step lacks an issue. Both
behaviours are [#180](https://github.com/guardyn/guardyn/issues/180) (PR-57), and fixing them
is **out of scope** here.

## Verification

```text
just roadmap-sync      → dry run, all six Phase 4 steps resolve to the right issue/milestone
just roadmap-sync 0    → 6 changed, 334 already correct, 0 failed
just roadmap-sync 0    → 1 changed (pre-existing PR-83), 339 already correct, 0 failed
just docs-verify       → all six checks pass, incl. STATE.md staleness
just rules-verify      → all checks pass; RS-UNWRAP 48 and NAME-SH 5 at their frozen budgets
```

## Deliberately out of scope

No code changes. Neither PR-99 nor PR-100 is fixed. `implementation_plan.md` §7.1 and ADR-0005
are amended in PR-39's branch, not here. `roadmap-sync`'s inability to create issues or detect
drift is #180's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
