### PR TITLE
fix(roadmap-sync): create issues, and make the dry run read GitHub

### DIFF
--- a/.claude/skills/issue-sync/SKILL.md
+++ b/.claude/skills/issue-sync/SKILL.md
@@ -52,10 +52,12 @@ it:
 
 | | |
 |---|---|
+| **Issue creation** | a step with `issue: null` gets one, titled `<id> · <title>`, carrying its `type:` and `gate:` labels. The number is written back onto that step's line |
 | **Issue state** | `status: done` closes with `state_reason: completed`; anything else reopens |
 | **Milestone** | from `phase: N`. Written only on mismatch |
 | **Project v2 board** | blocked - see P-1 below |
-| **`type:` and `gate:` labels** | **not reconciled.** Set them when you create the issue |
+| **Issue titles and bodies** | **not reconciled.** Set at creation; editing a title afterwards needs `gh issue edit` |
+| **`type:` and `gate:` labels** | applied at creation, **not reconciled** afterwards |
 
 ## Before you change a `status`
 
@@ -64,30 +66,51 @@ it:
 > correctly-closed issue**. This has already happened once: PR-06 through PR-18 stayed `todo`
 > after merging, and would have reopened thirteen issues on the first write-mode run.
 
-Check the file against reality before writing:
+**The dry run now checks this for you.** As of #180 it reads each issue's real state and
+names every divergence before anything is written, so `just roadmap-sync` is the check rather
+than a restatement of the file. It previously printed the *desired* state back at you and
+counted every step as "already correct", which is why the hazard above needed a separate
+command:
 
 ```sh
 gh issue list --state all --limit 200 --json number,state --jq '.[] | "\(.number) \(.state)"'
 ```
 
-## P-1 - the board half cannot run
+That command is still a fine second opinion, but the dry run is no longer blind to what it
+would answer.
 
-`project_sync_enabled: false` in the YAML. The Project v2 board needs `GUARDYN_PROJECT_TOKEN`
-with `repo` + `project` scope, which no agent can create: the organization rejects
-fine-grained PATs over a 366-day lifetime, and the fallback OAuth token has no project scope.
+## P-1 - the board half runs locally, not in CI
 
-The flag gates **the board only**. Issue state and milestones reconcile either way, because
-both are plain REST and need only the ambient token.
+Two things gate the board, and they are no longer in the same state:
 
-Do not work around this. Do not create the token, do not edit the board by hand, and do not
-flip the flag until the secret exists. It is preflight **P-1** in `implementation_plan.md`,
-and it is a human's to resolve.
+- `project_sync_enabled` is **`true`** in the YAML. This section used to say `false`.
+- `GUARDYN_PROJECT_TOKEN` must be set. In a developer's environment it is, so the board
+  reconciles from a local run. As a **repository secret** it still does not exist, so
+  `roadmap-sync.yml` skips the board half and exits 0.
+
+The flag and the token gate **the board only**. Issue creation, issue state and milestones
+reconcile either way - all three are plain REST and need only the ambient token.
+
+Do not work around this. Do not edit the board by hand, and do not treat a CI run that
+reports no board activity as a failure. The remaining half of preflight **P-1** in
+`implementation_plan.md` is a human's to resolve.
 
 ## Adding a step
 
 New steps get an issue too - one micro-step is one branch, one PR, one issue. Set
-`issue: null`, run the dry sync to see what it would create, then record the number the
-issue actually gets. Never retro-fit a second step onto an existing issue.
+`issue: null` and run the loop; the write run creates the issue and records its number back
+onto that step's line. Never retro-fit a second step onto an existing issue.
+
+**This used to be a manual step, and the instruction described a capability that did not
+exist.** Until #180 the script printed `would create` and moved on - in write mode as well as
+dry - so every number was recorded by hand, and the run still reported success for the issue
+it had not opened. If you find a step still carrying `issue: null` after a write run, that is
+a bug, not the design.
+
+Creation adopts before it creates: an issue already titled `<id> · <title>` is taken rather
+than duplicated. That is what makes the pass safe to run from CI, where the checkout is
+discarded and the write-back is lost - so a lost write-back costs an extra search, never a
+duplicate issue.
 
 ## See also
 

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -229,9 +229,31 @@ carries. Milestones are REST and work with the ambient token, so unlike the boar
 pass is never skipped.
 
 ```sh
-just roadmap-sync        # dry: print the plan, write nothing
+just roadmap-sync        # dry: read GitHub, name every divergence, write nothing
 just roadmap-sync 0      # write
+just roadmap-sync 0      # must report "0 changed" - the convergence proof
 ```
+
+**The dry run reads the platform.** It has to: the difference between the file and GitHub is
+the whole of what there is to report. Before #180 it printed the *desired* state back at the
+reader and counted every step as "already correct", so it agreed with itself no matter what
+GitHub held - and the one mistake it exists to catch is a stale `status:` that reopens a
+correctly-closed issue. Dry and write now differ only in whether the write executes, and both
+count an action into `changed`, so `0 changed` means the same thing either way.
+
+### A step with no issue
+
+`issue: null` means "this step wants an issue and has not got one". A write run creates it,
+titled `<id> · <title>`, with the step's `type:` and `gate:` labels and its phase milestone,
+then records the number back onto that step's line in `roadmap.yaml`.
+
+Creation **adopts before it creates**: if an issue already carries that exact title it is
+taken rather than duplicated. That is the property that holds in CI, where the checkout is
+thrown away and the write-back is lost - so a lost write-back costs one extra search on the
+next run, never a duplicate issue. Commit the recorded number when you run the sync locally.
+
+Before #180 this path printed `would create` and moved on, in write mode as well as dry,
+while still counting the issue it had not opened as a success.
 
 ### Regenerating STATE.md
 

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1029
+tokens: 1012
 supersedes: []
 ---
 
@@ -19,15 +19,15 @@ supersedes: []
 |---|---|---|---|
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
-| 3 | 61 | 70 | `█████████░` |
+| 3 | 62 | 70 | `█████████░` |
 | 4 | 0 | 13 | `░░░░░░░░░░` |
-| **all** | **87** | **109** | |
+| **all** | **88** | **109** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 22 of 109
+- **Open steps:** 21 of 109
 
 ## Gates
 
@@ -55,13 +55,12 @@ supersedes: []
 | Step | Phase | Issue | Title |
 |---|---|---|---|
 | PR-56 | 3 | [#188](https://github.com/guardyn/guardyn/issues/188) | Regenerate or drop the stale client-desktop protobuf |
-| PR-57 | 3 | [#180](https://github.com/guardyn/guardyn/issues/180) | Make roadmap-sync detect drift and create issues |
 | PR-62 | 3 | [#191](https://github.com/guardyn/guardyn/issues/191) | Clear the 132 client-desktop clippy errors |
 | PR-63 | 3 | [#192](https://github.com/guardyn/guardyn/issues/192) | Reconcile the desktop coverage thresholds with reality |
 | PR-65 | 3 | [#199](https://github.com/guardyn/guardyn/issues/199) | Stop Build Linux flaking in linuxdeploy |
 | PR-95 | 3 | [#255](https://github.com/guardyn/guardyn/issues/255) | X3DHPrekeyMessage one-time key id endianness differs between Rust and Dart |
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
-| PR-83 | 3 | — | Clear the 314 flutter analyze info diagnostics |
+| PR-83 | 3 | [#268](https://github.com/guardyn/guardyn/issues/268) | Clear the 314 flutter analyze info diagnostics |
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
 | PR-36 | 4 | [#47](https://github.com/guardyn/guardyn/issues/47) | Extend protos with ML-KEM key material fields |
 | PR-37 | 4 | [#48](https://github.com/guardyn/guardyn/issues/48) | Persist and serve ML-KEM public keys in auth-service |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -117,7 +117,7 @@ steps:
   - {id: PR-54, issue: 186, phase: 3, type: fix, status: done, title: "Add the missing icon.icns bundle asset"}
   - {id: PR-55, issue: 182, phase: 3, type: chore, status: done, title: "Remove continue-on-error from the desktop workflows"}
   - {id: PR-56, issue: 188, phase: 3, type: fix, status: todo, title: "Regenerate or drop the stale client-desktop protobuf"}
-  - {id: PR-57, issue: 180, phase: 3, type: fix, status: todo, title: "Make roadmap-sync detect drift and create issues"}
+  - {id: PR-57, issue: 180, phase: 3, type: fix, status: done, title: "Make roadmap-sync detect drift and create issues"}
   - {id: PR-58, issue: 189, phase: 3, type: chore, status: done, title: "Reconcile roadmap.yaml after the G3 merge wave"}
   # The ciphertext format break. #105 and #106 were Phase-3 security issues with no step,
   # so G3 would have passed over them; folding them in was a G3 sign-off decision.
@@ -162,7 +162,7 @@ steps:
   - {id: PR-96, issue: 257, phase: 4, type: fix, status: todo, title: "kube-bootstrap races the cert-manager webhook CA"}
   # Deferred deliberately, each with a stated reason in its step above.
   - {id: PR-82, issue: 211, phase: 3, type: chore, status: todo, title: "Add an FFI-backed mobile CI job"}
-  - {id: PR-83, issue: null, phase: 3, type: chore, status: todo, title: "Clear the 314 flutter analyze info diagnostics"}
+  - {id: PR-83, issue: 268, phase: 3, type: chore, status: todo, title: "Clear the 314 flutter analyze info diagnostics"}
   - {id: PR-84, issue: 205, phase: 3, type: chore, status: done, title: "Record the client-side E2EE repair steps in roadmap.yaml"}
   - {id: PR-85, issue: 208, phase: 3, type: fix, status: done, title: "Pin the Flutter toolchain to 3.47.3 so flutter pub get resolves"}
   # The fail-closed wave. Every remaining path where a client would rather emit or display

--- a/infra/scripts/roadmap-sync.sh
+++ b/infra/scripts/roadmap-sync.sh
@@ -4,7 +4,8 @@
 # and the Project v2 board. The YAML is the machine source of truth; this script moves the
 # world toward it.
 #
-# Three passes, in descending order of how reliably they can run:
+# Four passes, in descending order of how reliably they can run:
+#   issue create - REST, ambient token. Only for a step whose `issue:` is null.
 #   issue state  - REST, ambient token. Always runs.
 #   milestone    - REST, ambient token. Always runs. `phase: N` maps to milestone "Phase N".
 #   board        - GraphQL, needs a project scope no available token has yet (P-1). Guarded.
@@ -12,6 +13,12 @@
 # Reconciling, not appending: every action is derived from the difference between the file
 # and the platform, so running it twice changes nothing the second time. That property is
 # what lets it run on every push to main without supervision.
+#
+# A dry run reads the platform too. It has to: the difference is what there is to report,
+# and a dry run that only restates the file cannot find the one mistake the issue-sync skill
+# warns about - a stale `status` that reopens a correctly-closed issue. Dry and write differ
+# in whether `apply` executes, nothing else, and both count an action into `changed`, so
+# "the second run reports 0 changed" means the same thing either way. See #180.
 #
 # Bash, git, gh and jq only - the same constraint docs-verify.sh works under. Adding a YAML
 # parser would mean a runtime this repository does not otherwise depend on, and I-4 makes
@@ -24,6 +31,12 @@
 #                           if GH_TOKEN can write them. Never fails CI for a missing secret.
 #   GITHUB_REPOSITORY       owner/repo. Default: guardyn/guardyn
 #   ROADMAP_SYNC_DRY_RUN    1 = print the plan, change nothing. Default when no token.
+#
+# Writes to the repository: creating an issue records its number onto that step's line in
+# the roadmap file, so the file converges and the next run takes the ordinary path. That
+# write is best-effort - `roadmap-sync.yml` runs with `contents: read` and cannot commit it -
+# so creation does not depend on it. Idempotency comes from adopting an issue that already
+# carries the title the step would use.
 #
 # Exit codes: 0 always, unless the roadmap file itself is unreadable or malformed. A missing
 # credential is a documented state, not a build failure.
@@ -38,12 +51,34 @@ REPO="${GITHUB_REPOSITORY:-guardyn/guardyn}"
 DRY_RUN="${ROADMAP_SYNC_DRY_RUN:-0}"
 
 RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; RESET=$'\033[0m'
-changed=0; skipped=0; failed=0
+changed=0; skipped=0; failed=0; unknown=0
 
 say()  { printf '%s\n' "$*"; }
 ok()   { printf '%s%s%s %s\n' "$GREEN" "sync" "$RESET" "$*"; changed=$((changed + 1)); }
+plan() { printf '%s%s%s %s\n' "$YELLOW" "plan" "$RESET" "$*"; changed=$((changed + 1)); }
 noop() { printf '%s%s%s %s\n' "$YELLOW" "same" "$RESET" "$*"; skipped=$((skipped + 1)); }
 bad()  { printf '%s%s%s %s\n' "$RED" "FAIL" "$RESET" "$*" >&2; failed=$((failed + 1)); }
+
+# Perform one reconciling write, or describe the write a dry run would perform.
+#
+# Dry and write differ in exactly one thing - whether the command runs - so they share this
+# function rather than living in two branches that drift apart. **Both count the action into
+# `changed`**, which is what makes "the second run reports 0 changed" a convergence proof.
+# Before #180 a dry run counted every step into `skipped` and printed it as "already
+# correct", so it agreed with itself no matter what GitHub held.
+apply() {
+  local what="$1"; shift
+  if [ "$DRY_RUN" = "1" ]; then
+    plan "$what"
+    return 0
+  fi
+  if "$@" >/dev/null 2>&1; then
+    ok "$what"
+    return 0
+  fi
+  bad "$what"
+  return 1
+}
 
 [ -r "$ROADMAP" ] || { bad "$ROADMAP is not readable"; exit 1; }
 
@@ -61,9 +96,20 @@ if [ -z "${GUARDYN_PROJECT_TOKEN:-}" ]; then
   BOARD_ENABLED=0
 fi
 
+# Whether the platform can be *read*. Distinct from DRY_RUN, which is about writing: a dry
+# run still has to read, or it cannot report a divergence. When this is 0 the script can only
+# restate the file, and says so rather than reporting a comparison it never made.
+GH_READY=1
 if ! command -v gh >/dev/null 2>&1; then
-  say "${YELLOW}note${RESET} gh is not installed - dry run only."
+  say "${YELLOW}note${RESET} gh is not installed - dry run only, and nothing can be compared."
   DRY_RUN=1
+  GH_READY=0
+elif ! gh api "repos/$REPO" --jq .full_name >/dev/null 2>&1; then
+  # One probe, so an unusable token produces one honest line instead of a "#N does not
+  # exist" for every step in the file.
+  say "${YELLOW}note${RESET} $REPO is not readable with the ambient token - nothing can be compared."
+  DRY_RUN=1
+  GH_READY=0
 fi
 
 # project_sync_enabled governs the PROJECT BOARD, and nothing else. It used to force a global
@@ -118,6 +164,133 @@ fi
 milestone_for() { printf '%s\n' "$MILESTONE_MAP" | awk -F'\t' -v p="$1" '$1 == p { print $2; exit }'; }
 
 # ---------------------------------------------------------------------------------------
+# Creating an issue for a step that has none
+# ---------------------------------------------------------------------------------------
+# `issue: null` means "this step wants an issue and has not got one yet". Until #180 the
+# script printed `would create` and `continue`d - in write mode as well as dry - so the
+# capability the issue-sync skill describes did not exist, every number was recorded by
+# hand, and the unexecuted branch still incremented `changed`, so a run that created nothing
+# reported success.
+#
+# Creation has to reconcile like every other action here, or a second run appends a
+# duplicate. Two things make it idempotent, and the order matters:
+#
+#   1. **Adopt before creating.** If an issue already carries the exact title this step
+#      would use, take its number instead of opening a second one. This is the property that
+#      holds in CI, where the checkout is thrown away and the write-back below is lost.
+#   2. **Record the number into the YAML**, so the file converges and the next run takes the
+#      ordinary path. Best effort only: `roadmap-sync.yml` runs with `contents: read` and
+#      cannot commit, which is precisely why (1) rather than (2) is the safety property.
+#
+# Titles are `<id> · <title>`, the same string the old `would create` line printed, so an
+# issue opened by hand under that convention is adopted rather than duplicated.
+ISSUE_INDEX=""
+ISSUE_INDEX_READY=0
+
+# Read every issue once, lazily - only a file with a null step pays for it.
+load_issue_index() {
+  [ "$ISSUE_INDEX_READY" = "1" ] && return 0
+  ISSUE_INDEX_READY=1
+  ISSUE_INDEX="$(gh api "repos/$REPO/issues?state=all&per_page=100" --paginate \
+    --jq '.[] | select(.pull_request == null) | "\(.number)\t\(.title)"' 2>/dev/null)"
+}
+
+issue_with_title() {
+  printf '%s\n' "$ISSUE_INDEX" | awk -F'\t' -v t="$1" '$2 == t { print $1; exit }'
+}
+
+# The branch name the micro-step contract asks for: `feat/<issue>-pr36`.
+branch_slug() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '-'; }
+
+issue_body() {
+  local id="$1" type="${2:-chore}"
+  cat <<BODY
+Opened by \`roadmap-sync\` from \`docs/roadmap/roadmap.yaml\` step $id.
+
+That file is the source of truth for this step. Change it there and let the sync move this
+issue - editing state here is reverted by the next run.
+
+---
+**Micro-step contract**
+- Branch: \`$type/<issue>-$(branch_slug "$id")\`
+- Budget: <=400 hand-written changed lines, or <=8 files. Split before opening if exceeded.
+- Leaves \`main\` green and is independently revertable.
+- Source of truth: \`docs/roadmap/roadmap.yaml\` step $id.
+BODY
+}
+
+# Write the assigned number back onto this step's line, and nothing else on it.
+#
+# Matched on `{id: <id>,` including the comma, so `PR-8` cannot claim `PR-83`'s line, and
+# the substitution touches only a literal `issue: null` - a line that already carries a
+# number is left alone even if the id somehow matched twice.
+record_issue_number() {
+  local id="$1" number="$2" tmp
+  tmp="$(mktemp)" || return 1
+  awk -v id="$id" -v num="$number" '
+    index($0, "{id: " id ",") && /issue:[[:space:]]*null/ {
+      sub(/issue:[[:space:]]*null/, "issue: " num)
+    }
+    { print }
+  ' "$ROADMAP" >"$tmp" || { rm -f "$tmp"; return 1; }
+
+  # Copy through rather than `mv`: mktemp creates 0600, and moving it over a tracked file
+  # would silently change that file's mode.
+  cat "$tmp" >"$ROADMAP" || { rm -f "$tmp"; return 1; }
+  rm -f "$tmp"
+}
+
+# Resolve a step with no issue to a number, adopting an existing issue or creating one.
+#
+# Sets RESOLVED_ISSUE and returns 0, or returns 1 when nothing could be resolved. It is
+# deliberately NOT a function whose output is captured: `$( )` runs a subshell, and every
+# `ok`/`noop`/`plan` inside one increments a counter that dies with it, so the summary would
+# under-report exactly the actions this function exists to perform.
+RESOLVED_ISSUE=""
+resolve_issue() {
+  local id="$1" title="$2" type="$3" gate="$4"
+  local full="$id · $title" existing number
+  local labels=()
+  RESOLVED_ISSUE=""
+
+  load_issue_index
+  existing="$(issue_with_title "$full")"
+  if [ -n "$existing" ]; then
+    noop "$id adopted existing #$existing"
+    RESOLVED_ISSUE="$existing"
+    record_issue_number "$id" "$existing" \
+      || say "${YELLOW}note${RESET} could not record #$existing into $ROADMAP - do it by hand."
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    plan "$id has no issue -> would create \"$full\""
+    return 1
+  fi
+
+  [ -n "$type" ] && labels+=(--label "type:$type")
+  [ -n "$gate" ] && labels+=(--label "gate:$gate")
+
+  # `gh issue create` prints the issue URL; the number is its last path segment. The
+  # milestone is deliberately not passed here - the caller falls through to the milestone
+  # pass below, so one implementation serves a new issue and an existing one alike.
+  number="$(gh issue create --repo "$REPO" --title "$full" \
+    --body "$(issue_body "$id" "$type")" ${labels[@]+"${labels[@]}"} 2>/dev/null \
+    | sed -n 's|.*/\([0-9][0-9]*\)$|\1|p' | head -1)"
+
+  if [ -z "$number" ]; then
+    bad "$id could not create \"$full\""
+    return 1
+  fi
+
+  ok "$id created #$number"
+  RESOLVED_ISSUE="$number"
+  record_issue_number "$id" "$number" \
+    || say "${YELLOW}note${RESET} could not record #$number into $ROADMAP - do it by hand."
+  return 0
+}
+
+# ---------------------------------------------------------------------------------------
 # Reconcile issues
 # ---------------------------------------------------------------------------------------
 # status -> issue state. `done` closes with a reason; anything else must be open.
@@ -129,24 +302,36 @@ while IFS= read -r step; do
   phase="$(field "$step" phase)"
   title="$(field "$step" title | sed 's/^"//; s/"$//')"
 
-  if [ -z "$issue" ] || [ "$issue" = "null" ]; then
-    ok "$id has no issue yet - would create: \"$id · $title\""
-    continue
-  fi
+  type="$(field "$step" type)"
+  gate="$(field "$step" gate)"
 
   want_state="open"
   [ "$status" = "done" ] && want_state="closed"
 
   want_ms="$(milestone_for "$phase")"
 
-  if [ "$DRY_RUN" = "1" ]; then
-    say "  $id -> #$issue want=$want_state phase=$phase milestone=${want_ms:-none}"
-    skipped=$((skipped + 1))
+  # Nothing below can be compared without a readable platform, so restate the desired state
+  # and count it as neither correct nor changed. Counting these into `skipped` is what let
+  # the old dry run print "already correct" for a step it had never looked at.
+  if [ "$GH_READY" = "0" ]; then
+    say "  $id -> #${issue:-none} want=$want_state phase=$phase milestone=${want_ms:-none}"
+    unknown=$((unknown + 1))
     continue
+  fi
+
+  if [ -z "$issue" ] || [ "$issue" = "null" ]; then
+    resolve_issue "$id" "$title" "$type" "$gate" || continue
+    issue="$RESOLVED_ISSUE"
   fi
 
   # One read serves both passes. `0` stands for "no milestone", which no real milestone
   # number can collide with, so it compares safely against an empty want_ms.
+  #
+  # This read sits ABOVE the dry-run branch as of #180. A dry run that never asked GitHub
+  # anything printed the file back at the reader, and the issue-sync skill calls the dry run
+  # "the only place a mistake is free" - the one mistake it warns about being a stale
+  # `status` that reopens a correctly-closed issue, which is exactly what this comparison
+  # now surfaces before anything is written.
   read -r have have_ms <<<"$(gh api "repos/$REPO/issues/$issue" \
     --jq '"\(.state) \(.milestone.number // 0)"' 2>/dev/null)"
   if [ -z "$have" ]; then
@@ -157,18 +342,11 @@ while IFS= read -r step; do
   if [ "$have" = "$want_state" ]; then
     noop "$id #$issue already $want_state"
   elif [ "$want_state" = "closed" ]; then
-    if gh api -X PATCH "repos/$REPO/issues/$issue" \
-        -f state=closed -f state_reason=completed >/dev/null 2>&1; then
-      ok "$id #$issue closed as completed"
-    else
-      bad "$id #$issue could not be closed"
-    fi
+    apply "$id #$issue -> closed as completed" \
+      gh api -X PATCH "repos/$REPO/issues/$issue" -f state=closed -f state_reason=completed
   else
-    if gh api -X PATCH "repos/$REPO/issues/$issue" -f state=open >/dev/null 2>&1; then
-      ok "$id #$issue reopened"
-    else
-      bad "$id #$issue could not be reopened"
-    fi
+    apply "$id #$issue -> reopened (status is '$status', not done)" \
+      gh api -X PATCH "repos/$REPO/issues/$issue" -f state=open
   fi
 
   # Milestone. Written only on mismatch, so the second run of any pair reports `same`.
@@ -176,10 +354,9 @@ while IFS= read -r step; do
     :
   elif [ "$have_ms" = "$want_ms" ]; then
     noop "$id #$issue already on milestone $want_ms"
-  elif gh api -X PATCH "repos/$REPO/issues/$issue" -F milestone="$want_ms" >/dev/null 2>&1; then
-    ok "$id #$issue moved to milestone $want_ms"
   else
-    bad "$id #$issue could not be moved to milestone $want_ms"
+    apply "$id #$issue -> milestone $want_ms" \
+      gh api -X PATCH "repos/$REPO/issues/$issue" -F milestone="$want_ms"
   fi
 done <<<"$steps_raw"
 
@@ -234,6 +411,9 @@ else
 fi
 
 say ""
-say "roadmap-sync: ${changed} changed, ${skipped} already correct, ${failed} failed"
+summary="roadmap-sync: ${changed} changed, ${skipped} already correct, ${failed} failed"
+[ "$unknown" -gt 0 ] && summary="$summary, ${unknown} not compared"
+say "$summary"
+[ "$DRY_RUN" = "1" ] && say "${YELLOW}note${RESET} dry run: 'changed' counts what a write would do."
 [ "$failed" -eq 0 ] || say "${YELLOW}note${RESET} failures above did not fail the build - see P-1."
 exit 0

--- a/infra/scripts/roadmap-sync.sh
+++ b/infra/scripts/roadmap-sync.sh
@@ -147,17 +147,39 @@ say "roadmap-sync: $total step(s) in $ROADMAP, repo $REPO"
 #
 # A repository with no such milestones is a documented state, not an error - say so and let
 # the issue pass run alone.
+# **`gh api` writes its error body to STDOUT, not stderr.** `2>/dev/null` therefore does not
+# stop a failure from being captured as data: against a revoked token this assignment took
+# five lines of `{"message":"Bad credentials"...}` as its result, and the count below reported
+# `5 phase milestone(s) resolved` while zero were resolved. Same failure class as the rest of
+# #180 - the script reporting success for work it had not done - so it is fixed here.
+#
+# Two independent guards, because either alone leaves a gap:
+#   1. the exit status, which catches a failed call whatever it printed;
+#   2. a shape filter, which catches anything that is not a `phase<TAB>number` pair however it
+#      got there - a future gh diagnostic, a deprecation warning, a partial page.
 MILESTONE_MAP=""
-if command -v gh >/dev/null 2>&1; then
-  MILESTONE_MAP="$(gh api "repos/$REPO/milestones?state=all" --paginate \
-    --jq '.[] | select(.title | test("^Phase [0-9]+ ")) |
-          "\(.title | capture("^Phase (?<p>[0-9]+) ").p)\t\(.number)"' 2>/dev/null)"
+milestone_read_failed=0
+if [ "$GH_READY" = "1" ]; then
+  if ! MILESTONE_MAP="$(gh api "repos/$REPO/milestones?state=all" --paginate \
+      --jq '.[] | select(.title | test("^Phase [0-9]+ ")) |
+            "\(.title | capture("^Phase (?<p>[0-9]+) ").p)\t\(.number)"' 2>/dev/null)"; then
+    milestone_read_failed=1
+    MILESTONE_MAP=""
+  fi
+  MILESTONE_MAP="$(printf '%s\n' "$MILESTONE_MAP" \
+    | awk -F'\t' 'NF == 2 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/')"
 fi
 
-if [ -z "$MILESTONE_MAP" ]; then
+if [ "$milestone_read_failed" = "1" ]; then
+  bad "the milestone list could not be read from $REPO - milestone pass skipped"
+elif [ "$GH_READY" = "0" ]; then
+  say "${YELLOW}note${RESET} milestones not read - the platform is not readable."
+elif [ -z "$MILESTONE_MAP" ]; then
   say "${YELLOW}note${RESET} no \"Phase N\" milestone found in $REPO - milestone pass skipped."
 else
-  say "milestones: $(printf '%s\n' "$MILESTONE_MAP" | wc -l | tr -d ' ') phase milestone(s) resolved"
+  # `grep -c .` rather than `wc -l`: an empty string is zero lines, not the one newline
+  # `printf` gives it.
+  say "milestones: $(printf '%s\n' "$MILESTONE_MAP" | grep -c .) phase milestone(s) resolved"
 fi
 
 # phase number -> milestone number. Empty output means "no milestone for this phase".
@@ -186,13 +208,29 @@ milestone_for() { printf '%s\n' "$MILESTONE_MAP" | awk -F'\t' -v p="$1" '$1 == p
 # issue opened by hand under that convention is adopted rather than duplicated.
 ISSUE_INDEX=""
 ISSUE_INDEX_READY=0
+ISSUE_INDEX_OK=0
 
 # Read every issue once, lazily - only a file with a null step pays for it.
+#
+# The exit status is load-bearing here, more than anywhere else in this script. `gh api`
+# prints its error body to stdout, so a failed read lands in ISSUE_INDEX as JSON; that JSON
+# contains no tabs, `issue_with_title` matches nothing, and creation would conclude the issue
+# does not exist and **open a duplicate**. An unreadable index must therefore stop creation
+# rather than fall back to it - the one thing worse than not creating an issue is creating a
+# second one for a step that already has one.
 load_issue_index() {
   [ "$ISSUE_INDEX_READY" = "1" ] && return 0
   ISSUE_INDEX_READY=1
-  ISSUE_INDEX="$(gh api "repos/$REPO/issues?state=all&per_page=100" --paginate \
-    --jq '.[] | select(.pull_request == null) | "\(.number)\t\(.title)"' 2>/dev/null)"
+  if ISSUE_INDEX="$(gh api "repos/$REPO/issues?state=all&per_page=100" --paginate \
+      --jq '.[] | select(.pull_request == null) | "\(.number)\t\(.title)"' 2>/dev/null)"; then
+    ISSUE_INDEX_OK=1
+  else
+    ISSUE_INDEX=""
+    ISSUE_INDEX_OK=0
+  fi
+  # Same shape filter as the milestone map: a line is an issue only if it starts with a
+  # number and a tab.
+  ISSUE_INDEX="$(printf '%s\n' "$ISSUE_INDEX" | awk -F'\t' 'NF >= 2 && $1 ~ /^[0-9]+$/')"
 }
 
 issue_with_title() {
@@ -254,6 +292,11 @@ resolve_issue() {
   RESOLVED_ISSUE=""
 
   load_issue_index
+  if [ "$ISSUE_INDEX_OK" = "0" ]; then
+    bad "$id has no issue and the issue list could not be read - refusing to create a possible duplicate"
+    return 1
+  fi
+
   existing="$(issue_with_title "$full")"
   if [ -n "$existing" ]; then
     noop "$id adopted existing #$existing"


### PR DESCRIPTION
Closes #180

Three defects in `infra/scripts/roadmap-sync.sh`, all of the same class: the script reporting
success for work it had not done. The third was found mid-review and #180 was explicitly
widened to cover it.

## 1 · The dry run could not detect drift

It printed the *desired* state back at the reader and `continue`d, never asking GitHub
anything, then counted every step into `skipped` — which the summary prints as **"already
correct"**. The [`issue-sync`](.claude/skills/issue-sync/SKILL.md) skill calls the dry run
*"the only place a mistake is free"*, and the mistake it warns about is a stale `status:` that
reopens a correctly-closed issue. The dry run was structurally incapable of seeing it.

Measured, with `PR-95` flipped to `done` while #255 is open:

```text
old:  PR-95 -> #255 want=closed phase=3 milestone=3
      roadmap-sync: 1 changed, 108 already correct, 0 failed

new:  plan PR-95 #255 -> closed as completed
      roadmap-sync: 2 changed, 215 already correct, 0 failed
```

The old run **counted the one diverging step as correct**. Note also `108 already correct` out
of 109 steps against `215` — the old dry run made no API calls at all, so its "correct" count
was a count of lines in a file.

The read moved above the dry-run branch, and `apply()` now carries both modes so they cannot
drift: they differ in whether the command executes and in nothing else, and **both count into
`changed`**. That is what makes "the second run reports 0 changed" mean the same thing in
either mode.

`GH_READY` is deliberately separate from `DRY_RUN` — they are different questions, writing
versus reading. When `gh` is absent or the token cannot read the repo, the script says so once
and counts those steps as `not compared` rather than as correct. One probe replaces what would
otherwise be a cascade of false `#N does not exist` lines.

## 2 · It could not create issues

`continue` ran in write mode too, so the capability the skill describes did not exist and every
number was recorded by hand — while `ok()` still incremented `changed`, so a run that created
nothing reported success. **That is the false positive on PR-83 reported in #266.**

Creation has to reconcile or a second run appends duplicates. Two mechanisms, in order of which
one is load-bearing:

1. **Adopt before creating.** An issue already titled `<id> · <title>` is taken rather than
   duplicated. This is the property that holds in CI, where the checkout is discarded.
2. **Record the number** back onto that step's line in `roadmap.yaml`. Best-effort only:
   `roadmap-sync.yml` runs with `contents: read` and cannot commit it — which is exactly why
   (1) and not (2) is the safety property. A lost write-back costs one extra search on the next
   run, never a duplicate issue.

Two implementation notes worth the reviewer's attention:

- `resolve_issue` sets a global rather than printing a number for the caller to capture.
  `$( )` is a subshell, and every `ok`/`noop`/`plan` inside one increments a counter that dies
  with it — the summary would have under-reported the very actions the function exists to
  perform.
- `record_issue_number` copies through its temp file rather than `mv`-ing it. `mktemp` creates
  `0600`, and moving that over a tracked file would silently change the file's mode.

## 3 · A failed API read was taken as data

**Scope of #180 expanded deliberately** to cover this, rather than fixed ad hoc. It is the
same failure class as the two above — the script reporting success for work it had not done —
and it lives in the same block. Found by the revoked credential that broke this environment,
not by reading the code.

`gh api` writes its error body to **stdout**, not stderr, so `2>/dev/null` suppresses nothing
that matters: the JSON lands in the variable as data. Against a dead token the milestone
lookup captured five lines of `{"message":"Bad credentials"...}` and reported:

```text
milestones: 5 phase milestone(s) resolved
```

There are **four** milestones in this repository. The five was the line count of the error.

Two independent guards, because either alone leaves a gap — the **exit status** catches a
failed call whatever it printed, and a **shape filter** catches anything that is not a
`phase<TAB>number` pair however it got there (a future `gh` diagnostic, a deprecation warning,
a partial page). Verified directly:

```text
error body lines: 5
through the milestone shape filter:    0
through the issue-index shape filter:  0
real milestone data still passes:      2
```

`grep -c .` replaces `wc -l` for the count, because an empty string is zero lines rather than
the one newline `printf` gives it.

### The same hazard in `load_issue_index`, where it was much worse

That function is introduced by this branch, and there a failed read did not merely mislead. The
error JSON contains no tabs, so `issue_with_title` matches nothing, creation concludes the
issue does not exist — and **opens a duplicate**. Adoption-by-title is the single property that
makes creation safe to run from CI, and it silently inverted the moment the read failed.

An unreadable index now stops creation instead. The only thing worse than not creating an issue
is creating a second one for a step that already has one.

## Validation — end to end against the real API

A temporary `PR-999` step, exactly as directed:

```text
dry    plan PR-999 has no issue -> would create "PR-999 · roadmap-sync end-to-end creation test - close me"
write  sync PR-999 created #269
       sync PR-999 #269 -> milestone 4
```

[#269](https://github.com/guardyn/guardyn/issues/269) was opened with the correct title,
`type:chore` label, `Phase 4` milestone and the micro-step contract body, and `269` was written
back into the YAML.

**Idempotency**, the property that matters most — the step was reset to `issue: null` and the
sync re-run:

```text
same PR-999 adopted existing #269
same PR-999 #269 already open
same PR-999 #269 already on milestone 4
roadmap-sync: 0 changed, 330 already correct, 0 failed
```

It adopted rather than opening `#270`, and the run reported a genuine **`0 changed`** — a
convergence the old script could never report while any step carried a null issue. #269 is
closed as *not planned* and the temporary step is removed.

## One real issue was created, and is kept

`PR-83` was the single legitimate step sitting at `issue: null`. The validation write run
opened [#268](https://github.com/guardyn/guardyn/issues/268) for it and recorded the number.
**That line is kept rather than reverted:** the issue exists now, and putting `null` back would
leave `roadmap.yaml` disagreeing with the platform — the precise failure mode this file exists
to prevent.

## Documentation

- `SKILL.md` — the "record the number the issue actually gets" instruction described a
  capability that did not exist; it now describes the one that does. The reconcile table gains
  issue creation and states plainly that titles and labels are **not** reconciled after
  creation.
- `SKILL.md` P-1 section said `project_sync_enabled: false`. It is `true`, and has been for
  some time. Corrected to the real split: the board reconciles from a developer's machine
  because the token is in their environment, and is skipped in CI because the **repository
  secret** still does not exist.
- `RUNBOOK.md` — required by `docs/.manifest.yaml` (`infra/scripts/` → `RUNBOOK.md`), and gains
  the three-command loop with the convergence proof spelled out.

## Verification

```text
bash -n infra/scripts/roadmap-sync.sh     → clean
just roadmap-sync                          → 217 real comparisons, names every divergence
just roadmap-sync 0 (×3)                   → converges to 0 changed, 330 already correct
just docs-verify                           → all six checks pass
just rules-verify                          → all pass, ratchets unchanged
```

The unreadable-platform path was exercised for real, against the revoked token:

```text
note guardyn/guardyn is not readable with the ambient token - nothing can be compared.
note milestones not read - the platform is not readable.
roadmap-sync: 0 changed, 0 already correct, 0 failed, 109 not compared
```

One honest line, no false milestone count, and nothing claimed correct. The old script reported
`109 already correct` in this exact situation, because in dry mode it never read anything.

5 files, 373 changed lines — inside the §2.3 budget on both limits.

## Deliberately out of scope

The board pass is untouched. Reconciling issue **titles or bodies** after creation is not
added — `gh issue edit` remains the way to retitle, and the skill and RUNBOOK now say so rather
than leaving it implied. The missing `GUARDYN_PROJECT_TOKEN` repository secret is still
preflight P-1 and still a human's to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
