### PR TITLE
feat(proto): carry ML-KEM key material on common.KeyBundle

### DIFF
--- a/.claude/rules/00-invariants.md
+++ b/.claude/rules/00-invariants.md
@@ -23,7 +23,7 @@ If a task appears to require it, stop and ask the user.
 | `E2EE-FLAG` | I-2 | No configuration key can turn encryption off | PASS | `rules-verify` |
 | `E2EE-DUP` | I-2 | No handler has a non-E2EE twin | PASS | `rules-verify` |
 | `PQ-DEFAULT` | I-3 | The `pq` feature is on by default in the crypto crate | FAIL | PR-38 |
-| `PQ-WIRE` | I-3 | The wire contract carries ML-KEM key material | FAIL | PR-36 |
+| `PQ-WIRE` | I-3 | The wire contract carries ML-KEM key material | PASS | reviewer |
 | `SOV-DOMAIN` | I-4 | Every hostname derives from `${DOMAIN}` | FAIL (1) | **none — tracked by #82** |
 | `SOV-STORE` | I-4 | No datastore added, replaced or removed without an accepted ADR | PASS | reviewer |
 
@@ -61,12 +61,21 @@ a deployment file that looks like a kill switch reads as one whether or not any 
 and the prod overlay's `GUARDYN_E2EE_ENABLED: "true"` was actively misleading about where
 encryption came from.
 
-`PQ-WIRE` fails while `crypto/src/pqxdh.rs` is a complete hybrid X25519 + ML-KEM-768
-implementation. It is unreached, not absent — no proto field can carry the public key.
+`PQ-WIRE` passed with PR-36, which added `ml_kem_public` and `ml_kem_public_signature` to
+`common.KeyBundle` as tags 6 and 7. The predicate asks only whether the **wire contract** can
+carry the material, and it now can. Nothing else changed: `crypto/src/pqxdh.rs` is still
+unreached, nothing populates the fields, and `auth-service` still drops them on store. Read
+this row as "the blocker is gone", not "the invariant holds" — I-3 is met when PR-40 closes,
+not here.
 
-**A known failure is not licence to patch it.** Both remaining failures have an owned step -
-`PQ-DEFAULT` (PR-38) and `PQ-WIRE` (PR-36) - and fixing one outside that step breaks the
-micro-step contract.
+**Its owner is `reviewer`, not `rules-verify`, and that is a real gap.** `PQ-WIRE` is written
+out in the shell block above but has no counterpart in
+[`rules-verify.sh`](../../infra/scripts/rules-verify.sh), so nothing in CI stops the fields
+being removed again. Every other PASS row on this table is machine-defended; this one is
+defended by somebody noticing. Automating it is unowned work.
+
+**A known failure is not licence to patch it.** The one remaining failure has an owned step -
+`PQ-DEFAULT` (PR-38) - and fixing it outside that step breaks the micro-step contract.
 
 `ZK-PII` and `SOV-DOMAIN` were both found while writing this file, with no owning step. Each had
 an issue opened before any fix. `ZK-PII` is now closed by #81 and enforced by `rules-verify`;

--- a/backend/crates/auth-service/src/handlers/key_bundle.rs
+++ b/backend/crates/auth-service/src/handlers/key_bundle.rs
@@ -25,6 +25,9 @@ pub async fn get(
                     seconds: kb.created_at,
                     nanos: 0,
                 }),
+                // PR-37 populates these; until then auth-service neither stores nor
+                // serves ML-KEM material and the bundle goes out classical-only.
+                ..Default::default()
             };
 
             let success = GetKeyBundleSuccess {
@@ -115,5 +118,114 @@ pub async fn upload(
                 result: Some(upload_pre_keys_response::Result::Error(error)),
             }))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    /// A `KeyBundle` exactly as a client built before tags 6 and 7 existed, assembled
+    /// from the protobuf wire spec rather than from prost.
+    ///
+    /// Encoding the Rust struct and comparing against itself would prove only that prost
+    /// agrees with prost. The claim PR-36 rests on is narrower and about *other* binaries:
+    /// that a v1.0.1 peer's bytes still mean what they meant. So each record here is
+    /// written out as `(field_number << 3) | wire_type`, then a length, then the payload.
+    /// A field number that silently changed would fail here instead of in production.
+    fn v1_0_1_golden() -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(&[0x0a, 32]); // 1: identity_key
+        b.extend_from_slice(&[1u8; 32]);
+        b.extend_from_slice(&[0x12, 32]); // 2: signed_pre_key
+        b.extend_from_slice(&[2u8; 32]);
+        b.extend_from_slice(&[0x1a, 64]); // 3: signed_pre_key_signature
+        b.extend_from_slice(&[3u8; 64]);
+        b.extend_from_slice(&[0x22, 32]); // 4: one_time_pre_keys[0]
+        b.extend_from_slice(&[4u8; 32]);
+        b.extend_from_slice(&[0x2a, 2, 0x08, 1]); // 5: created_at { seconds: 1 }
+        b
+    }
+
+    /// The same bundle as a Rust value. `..Default::default()` leaves tags 6 and 7 `None`.
+    fn classical_bundle() -> KeyBundle {
+        KeyBundle {
+            identity_key: vec![1u8; 32],
+            signed_pre_key: vec![2u8; 32],
+            signed_pre_key_signature: vec![3u8; 64],
+            one_time_pre_keys: vec![vec![4u8; 32]],
+            created_at: Some(Timestamp {
+                seconds: 1,
+                nanos: 0,
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Forward compatibility: a bundle published by a client that predates PR-36 still
+    /// decodes, with every classical field intact and no ML-KEM material invented.
+    #[test]
+    fn v1_0_1_bundle_decodes_with_no_ml_kem_material() {
+        let decoded = KeyBundle::decode(v1_0_1_golden().as_slice()).expect("v1.0.1 bundle decodes");
+
+        assert_eq!(decoded, classical_bundle());
+        assert!(
+            decoded.ml_kem_public.is_none(),
+            "an absent field must stay absent, not become Some(empty)"
+        );
+        assert!(decoded.ml_kem_public_signature.is_none());
+    }
+
+    /// Absence costs nothing on the wire. This is what makes the change additive for a
+    /// deployment where no client has been updated yet: every byte is where it was.
+    #[test]
+    fn absent_ml_kem_material_costs_no_bytes() {
+        assert_eq!(classical_bundle().encode_to_vec(), v1_0_1_golden());
+    }
+
+    /// Backward compatibility, as a prefix property.
+    ///
+    /// prost emits fields in declaration order, and tags 6 and 7 are declared after 5, so a
+    /// hybrid bundle is byte-for-byte the v1.0.1 encoding followed by two further records.
+    /// That is precisely the condition under which a decoder that has never heard of those
+    /// tags skips them as unknown fields and recovers the identical old message - and it is
+    /// checkable without an old decoder, which cannot be instantiated from this tree.
+    #[test]
+    fn ml_kem_material_appends_to_the_v1_0_1_encoding() {
+        let hybrid = KeyBundle {
+            ml_kem_public: Some(vec![5u8; 1184]),
+            ml_kem_public_signature: Some(vec![6u8; 64]),
+            ..classical_bundle()
+        };
+
+        let encoded = hybrid.encode_to_vec();
+        let golden = v1_0_1_golden();
+
+        assert!(
+            encoded.starts_with(&golden),
+            "ML-KEM material must append to the v1.0.1 encoding, never reorder or displace it"
+        );
+        assert!(encoded.len() > golden.len());
+        assert_eq!(
+            KeyBundle::decode(encoded.as_slice()).expect("hybrid decodes"),
+            hybrid
+        );
+    }
+
+    /// A key without its signature is representable on the wire - nothing in protobuf can
+    /// forbid it - so rejecting it is a client obligation, not a schema guarantee. The rule
+    /// lives in `docs/spec/SRS.md` and is enforced by PR-39 (#50); `verify_hybrid_bundle`
+    /// currently returns `Ok(())` for this shape. This test pins the hazard, not the fix.
+    #[test]
+    fn a_half_pair_survives_a_round_trip_and_must_be_rejected_downstream() {
+        let half = KeyBundle {
+            ml_kem_public: Some(vec![5u8; 1184]),
+            ..classical_bundle()
+        };
+
+        let decoded = KeyBundle::decode(half.encode_to_vec().as_slice()).expect("decodes");
+        assert!(decoded.ml_kem_public.is_some());
+        assert!(decoded.ml_kem_public_signature.is_none());
     }
 }

--- a/backend/crates/e2e-tests/tests/e2e_groups.rs
+++ b/backend/crates/e2e-tests/tests/e2e_groups.rs
@@ -115,6 +115,7 @@ fn mock_key_bundle() -> KeyBundle {
             seconds: now,
             nanos: 0,
         }),
+        ..Default::default()
     }
 }
 

--- a/backend/crates/e2e-tests/tests/e2e_media.rs
+++ b/backend/crates/e2e-tests/tests/e2e_media.rs
@@ -105,6 +105,7 @@ fn mock_key_bundle() -> KeyBundle {
             seconds: now,
             nanos: 0,
         }),
+        ..Default::default()
     }
 }
 

--- a/backend/crates/e2e-tests/tests/e2e_mls_integration.rs
+++ b/backend/crates/e2e-tests/tests/e2e_mls_integration.rs
@@ -109,6 +109,7 @@ fn mock_key_bundle() -> KeyBundle {
             seconds: now,
             nanos: 0,
         }),
+        ..Default::default()
     }
 }
 

--- a/backend/crates/e2e-tests/tests/e2e_mvp_simplified.rs
+++ b/backend/crates/e2e-tests/tests/e2e_mvp_simplified.rs
@@ -101,6 +101,7 @@ fn mock_key_bundle() -> KeyBundle {
             seconds: now,
             nanos: 0,
         }),
+        ..Default::default()
     }
 }
 

--- a/backend/crates/e2e-tests/tests/e2e_phase2_features.rs
+++ b/backend/crates/e2e-tests/tests/e2e_phase2_features.rs
@@ -105,6 +105,7 @@ fn mock_key_bundle() -> KeyBundle {
             seconds: now,
             nanos: 0,
         }),
+        ..Default::default()
     }
 }
 

--- a/backend/crates/e2e-tests/tests/e2e_presence.rs
+++ b/backend/crates/e2e-tests/tests/e2e_presence.rs
@@ -103,6 +103,7 @@ fn mock_key_bundle() -> KeyBundle {
             seconds: now,
             nanos: 0,
         }),
+        ..Default::default()
     }
 }
 

--- a/backend/crates/e2e-tests/tests/e2e_production_readiness.rs
+++ b/backend/crates/e2e-tests/tests/e2e_production_readiness.rs
@@ -100,6 +100,7 @@ fn mock_key_bundle() -> KeyBundle {
             seconds: now,
             nanos: 0,
         }),
+        ..Default::default()
     }
 }
 
@@ -529,6 +530,7 @@ async fn test_concurrent_registrations() -> Result<(), Box<dyn std::error::Error
                             .as_secs() as i64,
                         nanos: 0,
                     }),
+                    ..Default::default()
                 }),
             });
 

--- a/backend/proto/common.proto
+++ b/backend/proto/common.proto
@@ -30,6 +30,27 @@ message KeyBundle {
   bytes signed_pre_key_signature = 3; // Ed25519 signature (64 bytes)
   repeated bytes one_time_pre_keys = 4; // X25519 public keys (32 bytes each)
   Timestamp created_at = 5;
+
+  // Hybrid PQXDH (I-3). Added by PR-36. Tags 6-7 are additive: a v1.0.1 client that
+  // predates them skips both as unknown fields and is unaffected.
+  //
+  // Present as a pair or not at all. An ml_kem_public without its signature is an
+  // unauthenticated encapsulation key: a peer that encapsulates to a substituted one
+  // gets a post-quantum half the attacker knows, while the exchange still looks
+  // healthy. A bundle carrying one without the other is rejected entirely - never
+  // degraded to the classical-only exchange, which is a downgrade an active attacker
+  // can force by stripping a single field.
+  //
+  // The signature is Ed25519 over the raw encapsulation-key bytes - no domain
+  // separator, no length prefix - matching how the key is signed in
+  // crypto/src/pqxdh.rs, and verified there by verify_hybrid_bundle against the same
+  // identity key that signs the signed pre-key.
+  //
+  // `optional` rather than a zero-length bytes so "not published" and "published
+  // empty" stay distinct: prost elides empty bytes on encode, which would collapse
+  // them into the same value.
+  optional bytes ml_kem_public = 6; // ML-KEM-768 encapsulation key (1184 bytes)
+  optional bytes ml_kem_public_signature = 7; // Ed25519 signature over ml_kem_public (64 bytes)
 }
 
 // Generic error response

--- a/client-desktop/src-tauri/src/commands/auth.rs
+++ b/client-desktop/src-tauri/src/commands/auth.rs
@@ -70,6 +70,9 @@ fn generate_key_bundle() -> Result<KeyBundle, String> {
             seconds: chrono::Utc::now().timestamp(),
             nanos: 0,
         }),
+        // PR-39 fills these in once the desktop negotiates hybrid PQXDH. Publishing an
+        // ml_kem_public without its signature would be worse than publishing neither.
+        ..Default::default()
     })
 }
 

--- a/client-desktop/src-tauri/src/commands/crypto.rs
+++ b/client-desktop/src-tauri/src/commands/crypto.rs
@@ -1592,6 +1592,7 @@ mod tests {
             signed_pre_key_signature: vec![3; 64],
             one_time_pre_keys: one_time,
             created_at: None,
+            ..Default::default()
         }
     }
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -52,12 +52,12 @@ the installation record.
 
 | Term | Code symbol | Meaning | forbidden_aliases |
 |---|---|---|---|
-| **KeyBundle** | `KeyBundle` (`common.proto`), `X3DHKeyBundle`, `HybridKeyBundle` | The published public key material a peer needs to start a session. | PreKeyBundle |
+| **KeyBundle** | `KeyBundle` (`common.proto`), `X3DHKeyBundle`, `HybridKeyBundle` | The published public key material a peer needs to start a session. Carries `ml_kem_public` and `ml_kem_public_signature` since PR-36 — present together or not at all. | PreKeyBundle |
 | **IdentityKeyPair** | `IdentityKeyPair` (`crypto`) | A Device's long-term key pair. Never leaves the Device. | MasterKey |
 | **SignedPreKey** | `SignedPreKey` (`crypto`) | Medium-term key, signed by the identity key. | — |
 | **OneTimePreKey** | `OneTimePreKey`, `OneTimePreKeyPublic` | Single-use key consumed by one session handshake. | OTK |
 | **X3DH** | `X3DHProtocol`, `X3DHKeyMaterial`, `X3DHPrekeyMessage` | The asynchronous handshake establishing a shared secret. | — |
-| **PQXDH** | `HybridKeyBundle`, `HybridSharedSecret`, `HybridPrivateKeys` | X3DH extended with ML-KEM-768. **Implemented, not yet enabled** — see I-3. | PostQuantumX3DH |
+| **PQXDH** | `HybridKeyBundle`, `HybridSharedSecret`, `HybridPrivateKeys` | X3DH extended with ML-KEM-768. **Expressible on the wire since PR-36; not yet published or negotiated** — see I-3. | PostQuantumX3DH |
 | **DoubleRatchet** | `DoubleRatchet`, `MessageHeader` | Per-message forward-secret key evolution after the handshake. | — |
 | **MLS** | `MlsGroupManager`, `MlsGroupState`, `MlsKeyPackage` | OpenMLS group encryption. The Group counterpart to Double Ratchet. | GroupCrypto |
 | **SealedSender** | `SealedSender`, `SealedSenderEnvelope`, `SenderCertificate` | Hides sender identity from the server. | AnonymousSender |

--- a/docs/adr/ADR-0005-hybrid-pqxdh.md
+++ b/docs/adr/ADR-0005-hybrid-pqxdh.md
@@ -51,17 +51,31 @@ with X3DH (`x3dh.rs`) rather than carrying its own — an Ed25519 verifying key 
 X25519 public point of the same seed, and treating it as one produces two sides that silently
 derive different secrets.
 
-**The gap.** The `pq` feature is off by default, no backend service enables it, and —
-decisively — `backend/proto/` contains **zero** ML-KEM fields, so a server cannot publish a
-PQ public key at all. The implementation is unreached, not absent.
+**The gap, narrowed by one step.** PR-36 added `ml_kem_public` (tag 6) and
+`ml_kem_public_signature` (tag 7) to `common.KeyBundle`, so the wire contract can now carry
+the material and `PQ-WIRE` passes. That removed the blocker; it did not close the gap. The
+`pq` feature is still off by default, no backend service enables it, no client populates the
+fields, and `auth-service` reads a bundle into `db::KeyBundle` — which has no ML-KEM column —
+so anything published is dropped on store. The implementation is still unreached.
+
+The fields are `optional`, not bare `bytes`, so "never published" and "published empty" stay
+distinct values. On a field whose absence is the normal case for years that distinction is
+load-bearing: conflating the two is how a stripped field becomes a silent classical-only
+session instead of a rejected bundle.
+
+**`client-mobile/proto/common.proto` was byte-identical to the backend copy and PR-36 forks
+them.** Nothing syncs or checks the two trees, and `PROTO-EDIT` matches only `.rs`, so the
+Dart side will not notice. Recorded here rather than fixed, because routing `client-mobile`
+through the hybrid path is [#262](https://github.com/guardyn/guardyn/issues/262) (PR-98) —
+but an undeclared fork of a wire contract is worse than a declared one.
 
 This ADR previously described `pqxdh.rs` as a complete implementation. That was measured
 against the code compiling, not against it agreeing: the identity-key conversion above was
 missing on both sides, so `test_classical_key_exchange` and `test_hybrid_key_exchange` had
 never passed. Being unreachable end to end is what kept that invisible.
 
-Repair is owned by PR-36 (proto fields) through PR-40 (fuzz, proptest, bench). Until then,
-**do not describe the product as post-quantum protected.**
+Repair is owned by PR-36 (proto fields — **landed**) through PR-40 (fuzz, proptest, bench).
+Until the rest land, **do not describe the product as post-quantum protected.**
 
 ## Alternatives rejected
 

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1109
+tokens: 1080
 supersedes: []
 ---
 
@@ -20,14 +20,14 @@ supersedes: []
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
 | 3 | 63 | 70 | `█████████░` |
-| 4 | 1 | 18 | `█░░░░░░░░░` |
-| **all** | **90** | **114** | |
+| 4 | 2 | 18 | `█░░░░░░░░░` |
+| **all** | **91** | **114** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 24 of 114
+- **Open steps:** 23 of 114
 
 ## Gates
 
@@ -61,7 +61,6 @@ supersedes: []
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
 | PR-83 | 3 | [#268](https://github.com/guardyn/guardyn/issues/268) | Clear the 314 flutter analyze info diagnostics |
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
-| PR-36 | 4 | [#47](https://github.com/guardyn/guardyn/issues/47) | Extend protos with ML-KEM key material fields |
 | PR-37 | 4 | [#48](https://github.com/guardyn/guardyn/issues/48) | Persist and serve ML-KEM public keys in auth-service |
 | PR-38 | 4 | [#49](https://github.com/guardyn/guardyn/issues/49) | Enable the pq feature across backend services |
 | PR-97 | 4 | [#261](https://github.com/guardyn/guardyn/issues/261) | Version X3DHPrekeyMessage and carry an optional ML-KEM ciphertext |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -94,7 +94,7 @@ steps:
   - {id: PR-33, issue: 44, phase: 3, type: security, status: done, title: "Add cargo-fuzz targets for attacker-controlled parsers"}
   - {id: PR-34, issue: 45, phase: 3, type: security, status: done, title: "Add proptest suites for crypto invariants"}
   - {id: PR-35, issue: 46, phase: 3, type: chore, status: done, gate: G3, title: "Add baseline test coverage for notification-service and call-service"}
-  - {id: PR-36, issue: 47, phase: 4, type: feat, status: todo, title: "Extend protos with ML-KEM key material fields"}
+  - {id: PR-36, issue: 47, phase: 4, type: feat, status: done, title: "Extend protos with ML-KEM key material fields"}
   - {id: PR-37, issue: 48, phase: 4, type: feat, status: todo, title: "Persist and serve ML-KEM public keys in auth-service"}
   - {id: PR-38, issue: 49, phase: 4, type: feat, status: todo, title: "Enable the pq feature across backend services"}
   # Retitled by PR-101. The original scope - "wire PqxdhProtocol into

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -64,7 +64,17 @@ it is recorded here so nobody "fixes" it.
 3. Three or four DH operations produce the shared secret. A consumed one-time pre-key is
    never reissued.
 4. Under **I-3** the same handshake also encapsulates to an ML-KEM-768 public key, and both
-   secrets feed the KDF. Classical strength is the floor, never the ceiling.
+   secrets feed the KDF. Classical strength is the floor, never the ceiling. The key is
+   `common.KeyBundle.ml_kem_public` (tag 6), a 1184-byte encapsulation key, and what makes it
+   trustworthy is `ml_kem_public_signature` (tag 7): Ed25519 over the raw encapsulation-key
+   bytes, by the **same identity key that signs the signed pre-key**. One identity, one
+   signer, both pre-keys.
+4a. The two fields are **present together or absent together**. A bundle carrying
+   `ml_kem_public` without its signature is rejected **in whole** — not degraded to the
+   classical-only exchange. Degrading is what an attacker wants: stripping one field is
+   cheaper than breaking either primitive, and a silent fallback converts a tampered bundle
+   into a session the post-quantum half no longer protects. This is rule 2's prohibition
+   applied to the second pre-key.
 
 **Edge cases.** No one-time pre-keys left: proceed with the three-DH variant — never refuse,
 never fall back to an unauthenticated exchange. Bundle from an unknown device: `NOT_FOUND`.
@@ -79,6 +89,18 @@ A replayed prekey message fails because the one-time key is already consumed.
 >
 > Rule 0 holds on both clients as of PR-79; `common.KeyBundle` still carries no key ids, so an
 > initiator names the one-time key by the index it occupied in the published array.
+
+> **Rule 4 and 4a are expressible but not yet enforced.** PR-36 added tags 6 and 7 to
+> `common.KeyBundle`, so the wire can carry ML-KEM material — that is the whole of what it
+> did. Nothing populates the fields, `auth-service` drops them on store, and no client reads
+> them. Concretely: `pqxdh.rs::verify_hybrid_bundle` checks the signature only under
+> `if let (Some(key), Some(signature))` **with no `else`**, so the half-pair of rule 4a
+> returns `Ok(())` today rather than an error. That path is unreachable while nothing builds
+> a hybrid bundle from the wire, and it is reachable the moment something does — so the fix,
+> with the property tests that belong to it, is owned by
+> [#50](https://github.com/guardyn/guardyn/issues/50) (PR-39) and must land with the code
+> that first reaches it. Until then, **do not describe the handshake as post-quantum
+> protected.**
 
 ## Message encryption (Double Ratchet)
 


### PR DESCRIPTION
## What

Adds `ml_kem_public` (tag 6) and `ml_kem_public_signature` (tag 7) to `common.KeyBundle`.

This flips `PQ-WIRE` in [`.claude/rules/00-invariants.md`](.claude/rules/00-invariants.md)
from FAIL to PASS. `crypto/src/pqxdh.rs` has been a complete hybrid X25519 + ML-KEM-768
implementation — with `verify_hybrid_bundle` already written — the whole time; it was
unreachable because no proto field could carry an encapsulation key.

**This does not make the product post-quantum protected**, and the ADR language saying so is
kept verbatim. It removes the blocker. I-3 closes at PR-40.

## Design decisions

**`optional bytes`, not bare `bytes`.** prost elides empty `bytes` on encode, so with a plain
field `Some(empty)` and `None` are the same bytes on the wire. On a field whose absence is
the normal case for years, that conflation is how a stripped field becomes a silent
classical-only session instead of a rejected bundle. It is also the shape `pqxdh.rs` already
expects — `Option<Vec<u8>>` maps straight onto `pq_prekey`. Zero wire cost; precedent at
`calls.proto:476,481`.

**Present as a pair or not at all.** A key without its signature is an unauthenticated
encapsulation key. The rule is written into `docs/spec/SRS.md` as rule 4a.

**Signature is Ed25519 over the raw encapsulation-key bytes** — no domain separator, no
length prefix — matching what `pqxdh.rs` already signs and verifies.

## Why 17 files

Nine exist only because prost struct literals are exhaustive. Adding two fields breaks every
literal that omits `..`, and `build.yml` runs `cargo clippy --all-targets`, which compiles
`e2e-tests` even though `cargo test` excludes it. Splitting them out would put a compile
break on `main` between the halves.

`AGENTS.md` §2.3 is a disjunction — ≤400 lines **or** ≤8 files — and `GIT-BUDGET` fires only
when both are exceeded. **231 lines / 17 files.** The generated/vendored exemption is *not*
invoked; these are the real numbers.

## Tests

The four tests in `handlers/key_bundle.rs` are the **first prost round-trip tests in the
repository**. Without them, "additive, wire-compatible with v1.0.1" was an unverified claim
in the change whose entire thesis is that claim.

- Forward compat: a v1.0.1-shaped encoding decodes with classical fields intact and no
  ML-KEM material invented.
- Absence costs zero bytes.
- Backward compat as a prefix property: a hybrid bundle is byte-for-byte the v1.0.1 encoding
  followed by the tag-6/7 records — exactly the condition under which an old decoder skips
  them as unknown fields. Checkable without an old decoder, which cannot be instantiated here.
- A half-pair survives a round trip, pinning that rejection is a client obligation and not a
  schema guarantee.

The golden vector is assembled from the protobuf wire spec, not re-encoded with prost —
re-encoding proves only that prost agrees with itself.

## Deliberately out of scope

- **`auth.proto UploadPreKeysRequest`** — `implementation_plan.md` §7.1 scopes it into PR-36.
  Deferred: rotation semantics are unsettled while PR-92 and PR-93 (#246) are in flight, and
  the roadmap SSOT does not name it.
- **Persisting/serving the field** (PR-37). `register.rs` and `login.rs` read the proto into
  `db::KeyBundle`, which has no ML-KEM column, so published material is dropped on store.
  That is a decision, not an oversight.
- **Enabling `pq`** (PR-38) · **client negotiation** (PR-39) · **fuzz/proptest/bench for the
  hybrid path** (PR-40).
- **`pqxdh.rs` is untouched.** Its `verify_hybrid_bundle` checks the signature under
  `if let (Some, Some)` with no `else`, so a key with no signature returns `Ok(())`. Still
  unreachable — nothing builds a hybrid bundle from the wire — and recorded in `SRS.md`,
  owned by #50 (PR-39) together with the property tests that belong with it.
- **`client-mobile/proto/common.proto`** was byte-identical to the backend copy and this
  forks them. Nothing syncs or checks the two trees and `PROTO-EDIT` matches only `.rs`.
  Recorded in ADR-0005; owned by #262 (PR-98).

## Note for reviewers

`client-desktop/src-tauri/build.rs` writes generated protobuf **into the tracked tree**
(`.out_dir("src/proto")`), so any local `cargo build|check|test` there rewrites
`guardyn.common.rs` and `guardyn.media.rs` in place — and `PROTO-EDIT` hard-fails on
committing them. Run `git checkout -- client-desktop/src-tauri/src/proto/` before committing.
Owned by #188 (PR-56). Those committed files are never actually compiled (build.rs overwrites
them first), which is why `..Default::default()` is right at `auth.rs:59` even though the
committed struct still shows five fields.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo test --workspace --exclude guardyn-e2e-tests`, desktop `cargo test --all-features`
(131 tests), `just docs-verify` (6/6), `just rules-verify` (12/12, both ratchets unmoved).

Acceptance test — `grep -rL 'ml_kem' backend/proto/common.proto` now prints nothing.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
