### PR TITLE
feat(auth): persist and serve ML-KEM public keys

### DIFF
--- a/backend/crates/auth-service/src/db.rs
+++ b/backend/crates/auth-service/src/db.rs
@@ -54,6 +54,15 @@ pub struct KeyBundle {
     pub signed_pre_key_signature: Vec<u8>,
     pub one_time_pre_keys: Vec<Vec<u8>>,
     pub created_at: i64,
+    /// ML-KEM-768 encapsulation key, `common.KeyBundle` tag 6.
+    ///
+    /// `Option` rather than an empty `Vec` for the same reason the proto field is
+    /// `optional`: "this device published no post-quantum pre-key" and "this device
+    /// published an empty one" are different facts, and only one of them is legitimate.
+    pub ml_kem_public: Option<Vec<u8>>,
+    /// Ed25519 signature over [`Self::ml_kem_public`], `common.KeyBundle` tag 7, by the
+    /// same identity key that signs the signed pre-key.
+    pub ml_kem_public_signature: Option<Vec<u8>>,
 }
 
 impl KeyBundle {
@@ -79,6 +88,28 @@ impl KeyBundle {
         if self.signed_pre_key_signature.is_empty() {
             anyhow::bail!("refusing to store a key bundle with an unsigned signed pre-key");
         }
+
+        // SRS rule 4a: the ML-KEM key and its signature are present together or absent
+        // together. A half-pair is rejected here so the store can never hold one, and so
+        // `get_key_bundle` never has to choose between serving an unauthenticated
+        // encapsulation key and silently downgrading the bundle to classical-only - which
+        // is the downgrade an active attacker forces by stripping a single field.
+        //
+        // This is a structural check, not a cryptographic one. The server deliberately does
+        // not assert the 1184/64 byte lengths and does not verify the signature: under
+        // ADR-0010 it is a relay, and the moment it knows an algorithm's parameters, moving
+        // to ML-KEM-1024 needs a server deploy. Verification is the peer's obligation, in
+        // `pqxdh::verify_hybrid_bundle`.
+        match (&self.ml_kem_public, &self.ml_kem_public_signature) {
+            (Some(_), None) => {
+                anyhow::bail!("refusing to store an ML-KEM pre-key with no signature")
+            }
+            (None, Some(_)) => {
+                anyhow::bail!("refusing to store an ML-KEM signature with no pre-key")
+            }
+            (Some(_), Some(_)) | (None, None) => {}
+        }
+
         Ok(())
     }
 }
@@ -92,6 +123,41 @@ fn one_time_pre_key_paths(user_id: &str, device_id: &str, count: usize) -> Vec<S
     (0..count)
         .map(|i| format!("/devices/{}/{}/one_time_keys/{}", user_id, device_id, i))
         .collect()
+}
+
+/// Everything `store_key_bundle` does to a device's two ML-KEM paths, as
+/// `(path, Some(value))` for a write and `(path, None)` for a delete.
+///
+/// The material sits under the *device* prefix, beside the signed pre-key it parallels,
+/// rather than under `/users/{id}/` where the identity key lives: it is a per-device
+/// pre-key that the per-user identity key merely signs.
+///
+/// Absence deletes rather than skips, and that is the whole point of this function. A skip
+/// leaves a stale encapsulation key beside a freshly written signed pre-key - both signed
+/// by the same identity key, so every signature still verifies and nothing looks wrong,
+/// while peers encapsulate to a key whose decapsulation half the device may no longer
+/// hold. That is the shape of the `UploadPreKeys` defect in reverse, and a write set is
+/// the thing to test, because the `put` and `delete` calls around it need a cluster.
+fn ml_kem_write_set(
+    user_id: &str,
+    device_id: &str,
+    key_bundle: &KeyBundle,
+) -> Vec<(String, Option<Vec<u8>>)> {
+    let (public_path, signature_path) = ml_kem_paths(user_id, device_id);
+    vec![
+        (public_path, key_bundle.ml_kem_public.clone()),
+        (signature_path, key_bundle.ml_kem_public_signature.clone()),
+    ]
+}
+
+/// The two TiKV keys a device's ML-KEM material occupies, as `(public, signature)`.
+///
+/// One definition, so the read path cannot drift from the write path.
+fn ml_kem_paths(user_id: &str, device_id: &str) -> (String, String) {
+    (
+        format!("/devices/{}/{}/ml_kem_public", user_id, device_id),
+        format!("/devices/{}/{}/ml_kem_public_signature", user_id, device_id),
+    )
 }
 
 /// Contact relationship stored in TiKV
@@ -461,6 +527,8 @@ impl DatabaseClient {
     /// Every path is written unconditionally, so the bundle must be complete. Passing empty
     /// identity material is rejected rather than written - see [`KeyBundle::validate_for_store`].
     /// To add one-time pre-keys to an existing bundle, use [`Self::store_one_time_pre_keys`].
+    ///
+    /// "Unconditionally" extends to the optional ML-KEM material - see [`ml_kem_write_set`].
     pub async fn store_key_bundle(
         &self,
         user_id: &str,
@@ -491,6 +559,15 @@ impl DatabaseClient {
         self.client
             .put(sig_path, key_bundle.signed_pre_key_signature.clone())
             .await?;
+
+        // Both ML-KEM paths are touched on every store, present or not - see
+        // [`ml_kem_write_set`] for why absence must delete rather than skip.
+        for (path, value) in ml_kem_write_set(user_id, device_id, key_bundle) {
+            match value {
+                Some(value) => self.client.put(path.into_bytes(), value).await?,
+                None => self.client.delete(path.into_bytes()).await?,
+            }
+        }
 
         self.store_one_time_pre_keys(user_id, device_id, &key_bundle.one_time_pre_keys)
             .await
@@ -570,11 +647,23 @@ impl DatabaseClient {
             one_time_pre_keys.push(kv.1);
         }
 
+        // Optional, unlike every field above: absent ML-KEM material is a classical-only
+        // device, not a missing bundle, so it must not turn this into `Ok(None)`.
+        //
+        // Whatever is stored is served verbatim. Collapsing a half-pair to classical here
+        // would be the server performing the SRS 4a downgrade itself; the pair rule in
+        // `validate_for_store` is what makes that state unreachable through the write path.
+        let (ml_kem_public_path, ml_kem_signature_path) = ml_kem_paths(user_id, device_id);
+        let ml_kem_public = self.client.get(ml_kem_public_path.into_bytes()).await?;
+        let ml_kem_public_signature = self.client.get(ml_kem_signature_path.into_bytes()).await?;
+
         Ok(Some(KeyBundle {
             identity_key,
             signed_pre_key,
             signed_pre_key_signature: signature,
             one_time_pre_keys,
+            ml_kem_public,
+            ml_kem_public_signature,
             created_at: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -966,6 +1055,19 @@ mod tests {
             signed_pre_key_signature: vec![3; 64],
             one_time_pre_keys: vec![vec![4; 32], vec![5; 32]],
             created_at: 0,
+            ml_kem_public: None,
+            ml_kem_public_signature: None,
+        }
+    }
+
+    /// The same bundle with ML-KEM material attached. Byte values are arbitrary and the
+    /// lengths are the real ones only for readability - nothing in `db.rs` may depend on
+    /// either, which is what `test_ml_kem_material_is_stored_without_inspection` pins.
+    fn hybrid_bundle() -> KeyBundle {
+        KeyBundle {
+            ml_kem_public: Some(vec![6; 1184]),
+            ml_kem_public_signature: Some(vec![7; 64]),
+            ..complete_bundle()
         }
     }
 
@@ -990,6 +1092,8 @@ mod tests {
             signed_pre_key_signature: vec![],
             one_time_pre_keys: vec![vec![4; 32]],
             created_at: 0,
+            ml_kem_public: None,
+            ml_kem_public_signature: None,
         };
 
         let err = destructive
@@ -1062,5 +1166,121 @@ mod tests {
             one_time_pre_key_paths("u1", "d1", 1),
             vec!["/devices/u1/d1/one_time_keys/0"]
         );
+    }
+
+    /// SRS rule 4a, enforced at the edge: a bundle carrying one half of the ML-KEM pair is
+    /// refused outright, in both directions.
+    ///
+    /// Rejecting at the write is what lets `get_key_bundle` serve whatever it finds without
+    /// having to choose between handing a peer an unauthenticated encapsulation key and
+    /// silently downgrading the bundle to classical-only. Neither is acceptable, so the
+    /// state simply must not exist.
+    #[test]
+    fn test_half_an_ml_kem_pair_is_refused() {
+        let key_without_signature = KeyBundle {
+            ml_kem_public: Some(vec![6; 1184]),
+            ml_kem_public_signature: None,
+            ..complete_bundle()
+        };
+        let signature_without_key = KeyBundle {
+            ml_kem_public: None,
+            ml_kem_public_signature: Some(vec![7; 64]),
+            ..complete_bundle()
+        };
+
+        assert!(
+            key_without_signature.validate_for_store().is_err(),
+            "an ML-KEM pre-key with no signature is an unauthenticated encapsulation key"
+        );
+        assert!(
+            signature_without_key.validate_for_store().is_err(),
+            "an ML-KEM signature with no pre-key signs nothing"
+        );
+    }
+
+    /// Both halves, or neither, are the only two storable shapes.
+    #[test]
+    fn test_a_whole_pair_and_no_pair_are_both_storable() {
+        hybrid_bundle()
+            .validate_for_store()
+            .expect("a bundle with both ML-KEM halves is storable");
+        complete_bundle()
+            .validate_for_store()
+            .expect("a classical-only bundle is still storable");
+    }
+
+    /// The server stores opaque bytes and asserts nothing about them.
+    ///
+    /// Deliberate, not an oversight: under ADR-0010 auth-service is a relay, and a length
+    /// check here would hardcode ML-KEM-768's parameters into it, so moving to ML-KEM-1024
+    /// would need a server deploy before a client could publish one. Signature verification
+    /// belongs to the peer, in `pqxdh::verify_hybrid_bundle`.
+    #[test]
+    fn test_ml_kem_material_is_stored_without_inspection() {
+        let wrong_lengths = KeyBundle {
+            ml_kem_public: Some(vec![6; 7]),
+            ml_kem_public_signature: Some(vec![7; 1]),
+            ..complete_bundle()
+        };
+
+        wrong_lengths
+            .validate_for_store()
+            .expect("the relay must not know an algorithm's byte lengths");
+    }
+
+    /// A hybrid bundle writes both ML-KEM paths, under the device prefix, and touches
+    /// nothing else.
+    #[test]
+    fn test_ml_kem_write_set_puts_both_paths_under_the_device() {
+        let writes = ml_kem_write_set("u1", "d1", &hybrid_bundle());
+
+        assert_eq!(
+            writes,
+            vec![
+                (
+                    "/devices/u1/d1/ml_kem_public".to_string(),
+                    Some(vec![6; 1184])
+                ),
+                (
+                    "/devices/u1/d1/ml_kem_public_signature".to_string(),
+                    Some(vec![7; 64])
+                ),
+            ]
+        );
+        assert!(
+            !writes.iter().any(|(path, _)| path.contains("identity_key")),
+            "ML-KEM material is per-device; it must never touch the per-user identity key"
+        );
+    }
+
+    /// A classical bundle **deletes** both paths rather than skipping them.
+    ///
+    /// Skipping is the tempting implementation and it is the wrong one, for the reason
+    /// [`ml_kem_write_set`] gives. This is the test that fails if someone makes it.
+    #[test]
+    fn test_a_classical_bundle_deletes_stale_ml_kem_material() {
+        let writes = ml_kem_write_set("u1", "d1", &complete_bundle());
+
+        assert_eq!(
+            writes,
+            vec![
+                ("/devices/u1/d1/ml_kem_public".to_string(), None),
+                ("/devices/u1/d1/ml_kem_public_signature".to_string(), None),
+            ],
+            "absent ML-KEM material must delete both paths, never skip them"
+        );
+    }
+
+    /// The read path and the write path name the same two keys. They are derived from one
+    /// function so they cannot drift, and this asserts that they have not.
+    #[test]
+    fn test_ml_kem_read_and_write_paths_agree() {
+        let (public_path, signature_path) = ml_kem_paths("u1", "d1");
+        let written: Vec<String> = ml_kem_write_set("u1", "d1", &hybrid_bundle())
+            .into_iter()
+            .map(|(path, _)| path)
+            .collect();
+
+        assert_eq!(written, vec![public_path, signature_path]);
     }
 }

--- a/backend/crates/auth-service/src/handlers/key_bundle.rs
+++ b/backend/crates/auth-service/src/handlers/key_bundle.rs
@@ -2,6 +2,31 @@
 use crate::{proto::auth::*, proto::common::*, AuthServiceImpl};
 use tonic::{Request, Response, Status};
 
+/// Convert a stored bundle into the wire form.
+///
+/// Pure, so the one thing worth asserting about the read path - that it is faithful - can
+/// be asserted without a live TiKV.
+///
+/// The ML-KEM fields are carried across exactly as stored, `None` included. `None` means
+/// this device published no post-quantum pre-key: a classical-only peer, not a missing
+/// bundle and not an error. Nothing here repairs a half-pair into a classical bundle
+/// either - that would be the relay performing the very SRS 4a downgrade an attacker wants,
+/// and `KeyBundle::validate_for_store` is what makes the half-pair unreachable instead.
+fn to_proto(kb: crate::db::KeyBundle) -> KeyBundle {
+    KeyBundle {
+        identity_key: kb.identity_key,
+        signed_pre_key: kb.signed_pre_key,
+        signed_pre_key_signature: kb.signed_pre_key_signature,
+        one_time_pre_keys: kb.one_time_pre_keys,
+        created_at: Some(Timestamp {
+            seconds: kb.created_at,
+            nanos: 0,
+        }),
+        ml_kem_public: kb.ml_kem_public,
+        ml_kem_public_signature: kb.ml_kem_public_signature,
+    }
+}
+
 /// Get key bundle for a user
 pub async fn get(
     service: &AuthServiceImpl,
@@ -16,19 +41,7 @@ pub async fn get(
         .await
     {
         Ok(Some(kb)) => {
-            let key_bundle = KeyBundle {
-                identity_key: kb.identity_key,
-                signed_pre_key: kb.signed_pre_key,
-                signed_pre_key_signature: kb.signed_pre_key_signature,
-                one_time_pre_keys: kb.one_time_pre_keys,
-                created_at: Some(Timestamp {
-                    seconds: kb.created_at,
-                    nanos: 0,
-                }),
-                // PR-37 populates these; until then auth-service neither stores nor
-                // serves ML-KEM material and the bundle goes out classical-only.
-                ..Default::default()
-            };
+            let key_bundle = to_proto(kb);
 
             let success = GetKeyBundleSuccess {
                 user_id: req.user_id.clone(),
@@ -227,5 +240,62 @@ mod tests {
         let decoded = KeyBundle::decode(half.encode_to_vec().as_slice()).expect("decodes");
         assert!(decoded.ml_kem_public.is_some());
         assert!(decoded.ml_kem_public_signature.is_none());
+    }
+
+    /// A stored bundle with ML-KEM material reaches the wire with it intact.
+    #[test]
+    fn stored_ml_kem_material_reaches_the_wire() {
+        let stored = crate::db::KeyBundle {
+            identity_key: vec![1u8; 32],
+            signed_pre_key: vec![2u8; 32],
+            signed_pre_key_signature: vec![3u8; 64],
+            one_time_pre_keys: vec![vec![4u8; 32]],
+            created_at: 1,
+            ml_kem_public: Some(vec![5u8; 1184]),
+            ml_kem_public_signature: Some(vec![6u8; 64]),
+        };
+
+        let wire = to_proto(stored);
+
+        assert_eq!(wire.ml_kem_public, Some(vec![5u8; 1184]));
+        assert_eq!(wire.ml_kem_public_signature, Some(vec![6u8; 64]));
+        assert_eq!(
+            wire,
+            KeyBundle {
+                ml_kem_public: Some(vec![5u8; 1184]),
+                ml_kem_public_signature: Some(vec![6u8; 64]),
+                ..classical_bundle()
+            }
+        );
+    }
+
+    /// A classical-only device is served as a complete bundle, not as an absence.
+    ///
+    /// The distinction matters because every *classical* field missing from the store makes
+    /// `get_key_bundle` return `None` and the RPC answer `NOT_FOUND`. ML-KEM material is the
+    /// first field for which absence is a legitimate state, so the read path must not treat
+    /// it the same way.
+    #[test]
+    fn an_absent_ml_kem_pair_still_yields_a_whole_bundle() {
+        let stored = crate::db::KeyBundle {
+            identity_key: vec![1u8; 32],
+            signed_pre_key: vec![2u8; 32],
+            signed_pre_key_signature: vec![3u8; 64],
+            one_time_pre_keys: vec![vec![4u8; 32]],
+            created_at: 1,
+            ml_kem_public: None,
+            ml_kem_public_signature: None,
+        };
+
+        let wire = to_proto(stored);
+
+        assert_eq!(wire, classical_bundle());
+        assert!(wire.ml_kem_public.is_none());
+        assert!(wire.ml_kem_public_signature.is_none());
+        assert_eq!(
+            wire.encode_to_vec(),
+            v1_0_1_golden(),
+            "a classical-only device must still look exactly like a v1.0.1 bundle on the wire"
+        );
     }
 }

--- a/backend/crates/auth-service/src/handlers/login.rs
+++ b/backend/crates/auth-service/src/handlers/login.rs
@@ -102,6 +102,8 @@ pub async fn handle(
                 signed_pre_key_signature: key_bundle.signed_pre_key_signature,
                 one_time_pre_keys: key_bundle.one_time_pre_keys,
                 created_at: now,
+                ml_kem_public: key_bundle.ml_kem_public,
+                ml_kem_public_signature: key_bundle.ml_kem_public_signature,
             };
 
             if let Err(e) = service

--- a/backend/crates/auth-service/src/handlers/register.rs
+++ b/backend/crates/auth-service/src/handlers/register.rs
@@ -156,6 +156,8 @@ pub async fn handle(
             signed_pre_key_signature: key_bundle.signed_pre_key_signature,
             one_time_pre_keys: key_bundle.one_time_pre_keys,
             created_at: now,
+            ml_kem_public: key_bundle.ml_kem_public,
+            ml_kem_public_signature: key_bundle.ml_kem_public_signature,
         };
 
         if let Err(e) = service

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -44,6 +44,12 @@ micro-steps across four phases, each ending at an approval gate.
 Phases 1 and 2 touch no source code. Phase 3 carries the security-critical work. Phase 4
 closes invariant I-3.
 
+Phase 4's step list has grown past `PR-44` as defects were found while executing it —
+`PR-96`…`PR-102` are Phase 4 steps too. `roadmap.yaml` is the list; this range is the shape.
+Most recently **PR-102** ([#272](https://github.com/guardyn/guardyn/issues/272)) was split out
+of PR-37, which `implementation_plan.md` had directed to fix an unrelated MLS key-package
+defect in the same breath as the ML-KEM work.
+
 Each phase is a **GitHub Milestone** titled `Phase N — …`, naming its gate. That is the only
 place phase is recorded: the `phase:1`…`phase:4` labels were retired in PR-21, and the custom
 `Phase` field on the Project v2 board goes with them. One fact, one encoding — and the
@@ -57,7 +63,7 @@ reason phases 3 and 4 exist.
 | Invariant | State | Closed by |
 |---|---|---|
 | **I-2** Always-On E2EE | server-side encryption removed, no flag remains, no client transmits plaintext, and desktop one-to-one messaging runs over the encrypted path; **mobile groups still refuse for want of MLS** | PR-30′, PR-31a–d, PR-32a–c, PR-75–PR-81c (Phase 3) |
-| **I-3** Post-Quantum | `pq` is off by default and no proto field carries an ML-KEM key, so no server can publish one | PR-36…PR-40 (Phase 4) |
+| **I-3** Post-Quantum | the wire carries ML-KEM material (PR-36) and `auth-service` now stores and serves it (PR-37), but `pq` is still off by default, nothing populates the fields, and no client reads them | PR-36…PR-40 (Phase 4) |
 
 Until those land, **the product must not be described as always-encrypted or
 post-quantum protected.**

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1080
+tokens: 1084
 supersedes: []
 ---
 
@@ -20,14 +20,14 @@ supersedes: []
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
 | 3 | 63 | 70 | `█████████░` |
-| 4 | 2 | 18 | `█░░░░░░░░░` |
-| **all** | **91** | **114** | |
+| 4 | 3 | 19 | `██░░░░░░░░` |
+| **all** | **92** | **115** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 23 of 114
+- **Open steps:** 23 of 115
 
 ## Gates
 
@@ -61,7 +61,6 @@ supersedes: []
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
 | PR-83 | 3 | [#268](https://github.com/guardyn/guardyn/issues/268) | Clear the 314 flutter analyze info diagnostics |
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
-| PR-37 | 4 | [#48](https://github.com/guardyn/guardyn/issues/48) | Persist and serve ML-KEM public keys in auth-service |
 | PR-38 | 4 | [#49](https://github.com/guardyn/guardyn/issues/49) | Enable the pq feature across backend services |
 | PR-97 | 4 | [#261](https://github.com/guardyn/guardyn/issues/261) | Version X3DHPrekeyMessage and carry an optional ML-KEM ciphertext |
 | PR-39 | 4 | [#50](https://github.com/guardyn/guardyn/issues/50) | client-desktop negotiates hybrid PQXDH |
@@ -77,3 +76,4 @@ supersedes: []
 | PR-94 | 4 | [#253](https://github.com/guardyn/guardyn/issues/253) | Partition client-desktop SecureStorage per account |
 | PR-99 | 4 | [#263](https://github.com/guardyn/guardyn/issues/263) | One-time pre-key ids break at TiKV lexicographic index >= 10 |
 | PR-100 | 4 | [#264](https://github.com/guardyn/guardyn/issues/264) | Add known-answer vectors for the sealed sender wire format |
+| PR-102 | 4 | [#272](https://github.com/guardyn/guardyn/issues/272) | MLS key packages are stored under a hardcoded device_id of default |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -95,7 +95,7 @@ steps:
   - {id: PR-34, issue: 45, phase: 3, type: security, status: done, title: "Add proptest suites for crypto invariants"}
   - {id: PR-35, issue: 46, phase: 3, type: chore, status: done, gate: G3, title: "Add baseline test coverage for notification-service and call-service"}
   - {id: PR-36, issue: 47, phase: 4, type: feat, status: done, title: "Extend protos with ML-KEM key material fields"}
-  - {id: PR-37, issue: 48, phase: 4, type: feat, status: todo, title: "Persist and serve ML-KEM public keys in auth-service"}
+  - {id: PR-37, issue: 48, phase: 4, type: feat, status: done, title: "Persist and serve ML-KEM public keys in auth-service"}
   - {id: PR-38, issue: 49, phase: 4, type: feat, status: todo, title: "Enable the pq feature across backend services"}
   # Retitled by PR-101. The original scope - "wire PqxdhProtocol into
   # messaging-service/src/crypto.rs" - named a file PR-30' deleted, in a service ADR-0010
@@ -198,6 +198,10 @@ steps:
   # both detonate on PR-93. Opened before any fix, per .claude/rules/00-invariants.md.
   - {id: PR-99, issue: 263, phase: 4, type: fix, status: todo, title: "One-time pre-key ids break at TiKV lexicographic index >= 10"}
   - {id: PR-100, issue: 264, phase: 4, type: security, status: todo, title: "Add known-answer vectors for the sealed sender wire format"}
+  # Split out of PR-37 while executing it. implementation_plan.md folded this into that step,
+  # but it is an MLS key-package defect that shares nothing with ML-KEM except the crate, and
+  # one PR closing one issue cannot fix two unrelated things (AGENTS.md 2.2).
+  - {id: PR-102, issue: 272, phase: 4, type: fix, status: todo, title: "MLS key packages are stored under a hardcoded device_id of default"}
   # This step. The plan of record directed PR-39 at an I-1 breach for the second time; the
   # correction is recorded rather than made silently.
   - {id: PR-101, issue: 265, phase: 4, type: docs, status: done, title: "Reconcile roadmap.yaml for the Phase 4 scope correction"}

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -90,17 +90,31 @@ A replayed prekey message fails because the one-time key is already consumed.
 > Rule 0 holds on both clients as of PR-79; `common.KeyBundle` still carries no key ids, so an
 > initiator names the one-time key by the index it occupied in the published array.
 
-> **Rule 4 and 4a are expressible but not yet enforced.** PR-36 added tags 6 and 7 to
-> `common.KeyBundle`, so the wire can carry ML-KEM material — that is the whole of what it
-> did. Nothing populates the fields, `auth-service` drops them on store, and no client reads
-> them. Concretely: `pqxdh.rs::verify_hybrid_bundle` checks the signature only under
+> **Rule 4 and 4a are enforced on the server and not yet on the clients.** PR-36 added tags 6
+> and 7 to `common.KeyBundle`, so the wire can carry ML-KEM material. PR-37 made
+> `auth-service` persist and serve it: `store_key_bundle` writes both halves under
+> `/devices/{user_id}/{device_id}/`, `get_key_bundle` reads them back, and
+> `KeyBundle::validate_for_store` refuses a half-pair outright — so rule 4a holds for
+> anything that reaches the store.
+>
+> That check is **structural, not cryptographic**, and the distinction is deliberate. The
+> server asserts that the two fields are present together or absent together; it does not
+> assert their byte lengths and does not verify the signature. Under
+> [ADR-0010](../adr/ADR-0010-pure-relay-server.md) it is a relay, and a relay that knows an
+> algorithm's parameters needs a deploy before a client can move to ML-KEM-1024. Absence is a
+> legitimate state throughout: a bundle with no ML-KEM material is a classical-only device,
+> served whole rather than as a `NOT_FOUND`.
+>
+> **Nothing populates the fields and no client reads them.** Concretely:
+> `pqxdh.rs::verify_hybrid_bundle` checks the signature only under
 > `if let (Some(key), Some(signature))` **with no `else`**, so the half-pair of rule 4a
-> returns `Ok(())` today rather than an error. That path is unreachable while nothing builds
-> a hybrid bundle from the wire, and it is reachable the moment something does — so the fix,
-> with the property tests that belong to it, is owned by
-> [#50](https://github.com/guardyn/guardyn/issues/50) (PR-39) and must land with the code
-> that first reaches it. Until then, **do not describe the handshake as post-quantum
-> protected.**
+> returns `Ok(())` today rather than an error. A server that refuses to store one narrows the
+> ways that path is reached; it does not close it, because a bundle can arrive from somewhere
+> other than `GetKeyBundle`. The fix, with the property tests that belong to it, is owned by
+> [#50](https://github.com/guardyn/guardyn/issues/50) (PR-39) and must land with the code that
+> first reaches it. Until then, **do not describe the handshake as post-quantum protected** —
+> the server can now publish a post-quantum pre-key, which is not the same as agreeing a
+> post-quantum secret.
 
 ## Message encryption (Double Ratchet)
 

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -519,8 +519,18 @@ optimization — the invariant outranks speed-to-market.
   Ed25519 signature; extend `auth.proto` `UploadPreKeysRequest` to accept ML-KEM material.
   **Additive field numbers only** — wire-compatible with deployed v1.0.1 clients.
 - **PR-37** — `auth-service`: persist and serve ML-KEM public keys through `db.rs` and
-  `handlers/`. Also fixes the hardcoded `device_id = "default"` at
-  `handlers/mls_key_package.rs:57`.
+  `handlers/`. `store_key_bundle` writes both halves under `/devices/{user}/{device}/`,
+  deleting them when absent so stale material cannot outlive a re-registration;
+  `validate_for_store` refuses a half-pair. The check is **structural only** — no byte
+  lengths, no signature verification, because ADR-0010 makes the server a relay.
+
+  **This step no longer carries the `device_id` fix.** It used to read "Also fixes the
+  hardcoded `device_id = "default"` at `handlers/mls_key_package.rs:57`" — a real defect
+  (every one of a user's devices collides on one storage path) but an MLS key-package one,
+  sharing nothing with ML-KEM but the crate. Bundling it would have made one PR close one
+  issue while fixing two unrelated things, which is what §2.2 exists to prevent. Split out
+  as **PR-102** ([#272](https://github.com/guardyn/guardyn/issues/272)) during PR-37's
+  execution and recorded here rather than dropped silently.
 - **PR-38** — Enable `features = ["pq"]` on `guardyn-crypto` in `auth-service`,
   `messaging-service` and `call-service`; make `pq` part of `crypto`'s `default`.
 - **PR-39** — Wire `PqxdhProtocol` into `messaging-service/src/crypto.rs` session


### PR DESCRIPTION
## What and why

PR-36 gave `common.KeyBundle` somewhere to carry ML-KEM material. `auth-service` still
dropped it in both directions: registration and login discarded tags 6 and 7 while building
the stored bundle, and `GetKeyBundle` filled them with `..Default::default()`. A client that
published a post-quantum pre-key got a classical-only bundle back, so the server was the
reason the hybrid handshake could not complete. It no longer is.

Storage is flat TiKV keys, so this adds two, under the **device** prefix — beside the signed
pre-key the ML-KEM key parallels, rather than under `/users/{id}/` where the identity key
that merely *signs* it lives:

```
/devices/{user_id}/{device_id}/ml_kem_public
/devices/{user_id}/{device_id}/ml_kem_public_signature
```

## The three decisions worth reviewing

**1. Absence deletes, it does not skip.** `store_key_bundle`'s contract is that every path is
written, because a partial write there is a *destructive* one — that is #243. Skipping on
absence reproduces that defect in reverse: re-registering a device from a build without
post-quantum support would leave the previous encapsulation key beside the newly written
signed pre-key. Both are signed by the same identity key, so every signature a peer checks
still verifies and nothing looks wrong, while peers encapsulate to a key the device may no
longer hold the decapsulation half of. Silent, one-sided, invisible until a message cannot be
read. `test_a_classical_bundle_deletes_stale_ml_kem_material` is the test that fails if
someone makes this change.

**2. The half-pair check is structural, not cryptographic.** `validate_for_store` refuses a
bundle carrying one half of the pair, enforcing SRS rule 4a at the write so the store can
never hold one. It deliberately does **not** assert the 1184/64 byte lengths and does **not**
verify the signature. Under [ADR-0010](docs/adr/ADR-0010-pure-relay-server.md) the server is
a relay, and a relay that knows an algorithm's parameters needs a deploy before a client can
move to ML-KEM-1024. Verification is the peer's obligation, in `pqxdh::verify_hybrid_bundle`.
`test_ml_kem_material_is_stored_without_inspection` pins this as intended rather than
overlooked.

**3. The read path serves what is stored, verbatim.** Absent material is a classical-only
device, not a missing bundle, so it must not become `NOT_FOUND` — ML-KEM is the first field
for which absence is a legitimate state. Nothing repairs a half-pair into a classical bundle
either; that would be the relay performing the very SRS 4a downgrade an attacker forces by
stripping a single field.

## Tests

Eight new, all pure — no live TiKV, following the `one_time_pre_key_paths` precedent. The
proto conversion is extracted as `to_proto` so the read path is testable at all. They cover
the half-pair refusal in both directions, both storable shapes, wrong lengths being accepted,
the put and delete write sets, read/write path agreement, and both read directions —
including that a classical-only device still encodes to the v1.0.1 golden bytes.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo test --workspace --exclude guardyn-e2e-tests` (14 suites), `just rules-verify`
(`RS-UNWRAP` still at the frozen 48 — none added) and `just docs-verify` all pass locally.

No end-to-end run: nothing publishes ML-KEM material yet, so a live round trip would exercise
only the absent-material path. Same reason PR-36 proved the wire change without an old
decoder in the tree.

## Budget

**9 files, 392 lines (+360/-32).** Inside the §2.3 contract on the lines limit; no exemption
invoked and none needed. Much of `db.rs`'s +228 is doc comments and the eight tests. Stating
the real numbers rather than claiming the bulk-change carve-out.

## Scope split — PR-102 (#272)

`implementation_plan.md` directed this step to *also* fix the hardcoded
`device_id = "default"` at `handlers/mls_key_package.rs:57`. That defect is real — every one
of a user's devices collides on one storage path — but it is an MLS key-package bug sharing
nothing with ML-KEM except the crate, and bundling it would make one PR close one issue while
fixing two unrelated things. Split out as **PR-102 (#272)**, with `implementation_plan.md` and
`ROADMAP.md` amended to say so rather than dropping it silently.

## Deliberately out of scope

- `handlers/mls_key_package.rs:57` — #272, above.
- `UploadPreKeysRequest`, which carries X25519 one-time keys only. ML-KEM public is long-lived
  per-device material and arrives via `RegisterRequest.key_bundle`, already a
  `common.KeyBundle`, so no proto change is needed and none is made.
- The `pq` feature default (PR-38 #49), `verify_hybrid_bundle`'s half-pair fall-through
  (PR-39 #50), and fuzz/proptest coverage (PR-40 #51).
- `client-mobile/proto/common.proto`, still forked at tag 5 — #262.
- `client-desktop/src-tauri/src/proto/guardyn.common.rs`, stale committed codegen — PR-56 #188.
- `GetKeyBundleRequest.device_id` being unmatchable when empty, which the desktop sends today.
  Pre-existing and orthogonal, but it means the served ML-KEM material is unreachable from
  desktop until fixed. **Flagging it here; it still needs its own issue.**

## Invariants

I-3 is **not** met by this PR — it is met when PR-40 closes. The server can now publish a
post-quantum pre-key, which is not the same as agreeing a post-quantum secret. I-1 is
untouched: no new log lines, and the ML-KEM *public* key is not secret material anyway.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
