### PR TITLE
docs(roadmap): record the GetKeyBundle any-device blocker

### DIFF
--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1084
+tokens: 1119
 supersedes: []
 ---
 
@@ -20,14 +20,14 @@ supersedes: []
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
 | 3 | 63 | 70 | `█████████░` |
-| 4 | 3 | 19 | `██░░░░░░░░` |
-| **all** | **92** | **115** | |
+| 4 | 4 | 21 | `██░░░░░░░░` |
+| **all** | **93** | **117** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 23 of 115
+- **Open steps:** 24 of 117
 
 ## Gates
 
@@ -63,6 +63,7 @@ supersedes: []
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
 | PR-38 | 4 | [#49](https://github.com/guardyn/guardyn/issues/49) | Enable the pq feature across backend services |
 | PR-97 | 4 | [#261](https://github.com/guardyn/guardyn/issues/261) | Version X3DHPrekeyMessage and carry an optional ML-KEM ciphertext |
+| PR-103 | 4 | [#274](https://github.com/guardyn/guardyn/issues/274) | GetKeyBundle never implemented its documented any-device fallback |
 | PR-39 | 4 | [#50](https://github.com/guardyn/guardyn/issues/50) | client-desktop negotiates hybrid PQXDH |
 | PR-98 | 4 | [#262](https://github.com/guardyn/guardyn/issues/262) | Export the hybrid key agreement through crypto-ffi and route client-mobile through it |
 | PR-40 | 4 | [#51](https://github.com/guardyn/guardyn/issues/51) | Add fuzz, proptest and bench coverage for the hybrid PQ path |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -103,6 +103,16 @@ steps:
   # breached I-1. Session establishment runs on the clients; PR-97 gives the prekey message
   # somewhere to carry the ML-KEM ciphertext, and PR-98 is the same work on mobile.
   - {id: PR-97, issue: 261, phase: 4, type: feat, status: todo, title: "Version X3DHPrekeyMessage and carry an optional ML-KEM ciphertext"}
+  # Found while executing PR-37 and left out of it rather than widening that step. Must
+  # precede PR-39: PR-37 made auth-service serve ML-KEM material, and this is what stops the
+  # desktop reaching it, so PR-39 would negotiate hybrid against a bundle it cannot fetch.
+  #
+  # The defect is server-side despite surfacing on the client. auth.proto documents
+  # GetKeyBundleRequest.device_id as "optional, if not set returns any device"; the desktop
+  # relies on that and sends an empty string, and auth-service concatenates it into
+  # /devices/{user}//signed_pre_key, which cannot match. Fixing it on the client is not
+  # available: GetKeyBundle is how a peer's device would be learned in the first place.
+  - {id: PR-103, issue: 274, phase: 4, type: fix, status: todo, title: "GetKeyBundle never implemented its documented any-device fallback"}
   - {id: PR-39, issue: 50, phase: 4, type: feat, status: todo, title: "client-desktop negotiates hybrid PQXDH"}
   - {id: PR-98, issue: 262, phase: 4, type: feat, status: todo, title: "Export the hybrid key agreement through crypto-ffi and route client-mobile through it"}
   - {id: PR-40, issue: 51, phase: 4, type: security, status: todo, title: "Add fuzz, proptest and bench coverage for the hybrid PQ path"}
@@ -202,6 +212,9 @@ steps:
   # but it is an MLS key-package defect that shares nothing with ML-KEM except the crate, and
   # one PR closing one issue cannot fix two unrelated things (AGENTS.md 2.2).
   - {id: PR-102, issue: 272, phase: 4, type: fix, status: todo, title: "MLS key packages are stored under a hardcoded device_id of default"}
+  # This step. PR-103 was found while executing PR-37; recording it is its own micro-step
+  # rather than a rider on PR-38, for the same reason PR-102 was split out of PR-37.
+  - {id: PR-104, issue: 275, phase: 4, type: docs, status: done, title: "Record the GetKeyBundle any-device blocker in roadmap.yaml"}
   # This step. The plan of record directed PR-39 at an I-1 breach for the second time; the
   # correction is recorded rather than made silently.
   - {id: PR-101, issue: 265, phase: 4, type: docs, status: done, title: "Reconcile roadmap.yaml for the Phase 4 scope correction"}


### PR DESCRIPTION
## What

Records **PR-103 ([#274](https://github.com/guardyn/guardyn/issues/274))** in `roadmap.yaml`,
sequenced before PR-39.

## Why this is server-side, not a desktop bug

It surfaces on the client, so the obvious framing is "the desktop sends an empty
`device_id`". That framing is wrong and the correction matters for who fixes it.

`auth.proto:236` documents the field as *"Target device (optional, if not set returns any
device)"*. `client-desktop` relies on exactly that contract and sends `String::new()` with the
comment `// Request any available device` (`auth_client.rs:272`). `auth-service` then
concatenates it into `/devices/{user}//signed_pre_key`, which cannot match, so
`get_key_bundle` returns `Ok(None)` and the RPC answers `NOT_FOUND`.

The contract is written down and was never implemented. Fixing it on the client is not
available either: `GetKeyBundle` is how a peer's `device_id` would be learned in the first
place, so there is nothing for the desktop to send instead.

This is also why it is **not** a wire contract change — the proto is already correct.

## Why it must precede PR-39

PR-37 made `auth-service` store and serve ML-KEM material. This is what stops any desktop
client reaching it. PR-39 has `client-desktop` negotiate hybrid PQXDH — against a bundle it
cannot fetch. Landing PR-39 first would mean debugging a hybrid handshake whose first step
returns `NOT_FOUND`.

## Why this is its own micro-step

It was found while executing PR-37 and deliberately left out of it rather than widening that
step. Recording it is not a rider on PR-38 either, for the same reason PR-102 was split out of
PR-37: PR-38 enables the `pq` feature across the backend services and shares nothing with this
but the milestone. Roadmap reconciliation as its own step follows PR-52, PR-58, PR-66, PR-86
and PR-101.

## Budget

**2 files, 22 lines (+18/-4)**, one of them the generated `STATE.md`. Inside §2.3 on both
limits.

## Verification

`just docs-verify` passes all six checks, including staleness — `STATE.md` was regenerated
with `just docs-state`, not hand-edited.

## Deliberately out of scope

- The fix itself — #274.
- Any change to `auth.proto`. The proto is correct; the implementation does not match it.
- PR-102 (#272) and PR-38 (#49), both untouched.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
