### PR TITLE
feat(crypto): put pq in the default feature set

### DIFF
--- a/.claude/rules/00-invariants.md
+++ b/.claude/rules/00-invariants.md
@@ -22,7 +22,7 @@ If a task appears to require it, stop and ask the user.
 | `ZK-PII` | I-1 | No log macro is passed a raw IP, email or phone number | PASS | `rules-verify` |
 | `E2EE-FLAG` | I-2 | No configuration key can turn encryption off | PASS | `rules-verify` |
 | `E2EE-DUP` | I-2 | No handler has a non-E2EE twin | PASS | `rules-verify` |
-| `PQ-DEFAULT` | I-3 | The `pq` feature is on by default in the crypto crate | FAIL | PR-38 |
+| `PQ-DEFAULT` | I-3 | The `pq` feature is on by default in the crypto crate | PASS | `rules-verify` |
 | `PQ-WIRE` | I-3 | The wire contract carries ML-KEM key material | PASS | reviewer |
 | `SOV-DOMAIN` | I-4 | Every hostname derives from `${DOMAIN}` | FAIL (1) | **none — tracked by #82** |
 | `SOV-STORE` | I-4 | No datastore added, replaced or removed without an accepted ADR | PASS | reviewer |
@@ -74,8 +74,25 @@ out in the shell block above but has no counterpart in
 being removed again. Every other PASS row on this table is machine-defended; this one is
 defended by somebody noticing. Automating it is unowned work.
 
-**A known failure is not licence to patch it.** The one remaining failure has an owned step -
-`PQ-DEFAULT` (PR-38) - and fixing it outside that step breaks the micro-step contract.
+`PQ-DEFAULT` passed with PR-38, which put `pq` in `guardyn-crypto`'s `default` set. It is
+enforced by `rules-verify` from the same PR that fixed it, rather than being added to the
+table as a second undefended PASS row beside `PQ-WIRE`.
+
+**What that step actually changed is narrower and worse than the row suggests.** A
+`cargo test --workspace` build already had `pq`, because `crypto-ffi` declares
+`default = ["full"] = ["pq"]` and Cargo unifies features across a workspace build. So CI was
+running `test_hybrid_key_exchange` and `test_hybrid_key_bundle_with_pq` the whole time, and the
+hybrid path looked exercised.
+
+Every service is deployed from `cargo build --release -p <service>`
+(`backend/crates/*/Dockerfile`), and a single-package build unifies nothing. Before PR-38
+`cargo tree -p guardyn-auth-service -i ml-kem` answered *"did not match any packages"*: the
+shipped binaries contained no post-quantum code at all, while the test build proved it worked.
+A green suite and an empty binary is the most expensive shape this class of defect takes, and
+it is worth remembering that feature unification is what hid it.
+
+**A known failure is not licence to patch it.** There is no failing predicate on this table
+with an owning step left; `SOV-DOMAIN` remains the one failure, and it has **none**.
 
 `ZK-PII` and `SOV-DOMAIN` were both found while writing this file, with no owning step. Each had
 an issue opened before any fix. `ZK-PII` is now closed by #81 and enforced by `rules-verify`;

--- a/backend/crates/crypto/Cargo.toml
+++ b/backend/crates/crypto/Cargo.toml
@@ -10,9 +10,15 @@ description = "Unified cryptography core for Guardyn - X3DH, Double Ratchet, MLS
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
-default = ["std"]
+# `pq` is on by default because I-3 makes hybrid key agreement the floor, not an option.
+# A post-quantum feature that must be opted into is one that ships off, which is how
+# pqxdh.rs sat unreachable in every backend service while the invariant read as unmet.
+# Predicate: PQ-DEFAULT in .claude/rules/00-invariants.md.
+default = ["std", "pq"]
 std = []
-# Post-quantum hybrid encryption (ML-KEM + X25519)
+# Post-quantum hybrid encryption (ML-KEM + X25519). Kept as a named feature rather than
+# folded into `std` so a `--no-default-features` consumer can still build without ml-kem;
+# nothing in this repository does, and nothing should.
 pq = ["ml-kem"]
 # FFI bindings for Flutter/Tauri
 ffi = ["chacha20poly1305"]

--- a/docs/adr/ADR-0005-hybrid-pqxdh.md
+++ b/docs/adr/ADR-0005-hybrid-pqxdh.md
@@ -51,12 +51,26 @@ with X3DH (`x3dh.rs`) rather than carrying its own — an Ed25519 verifying key 
 X25519 public point of the same seed, and treating it as one produces two sides that silently
 derive different secrets.
 
-**The gap, narrowed by one step.** PR-36 added `ml_kem_public` (tag 6) and
-`ml_kem_public_signature` (tag 7) to `common.KeyBundle`, so the wire contract can now carry
-the material and `PQ-WIRE` passes. That removed the blocker; it did not close the gap. The
-`pq` feature is still off by default, no backend service enables it, no client populates the
-fields, and `auth-service` reads a bundle into `db::KeyBundle` — which has no ML-KEM column —
-so anything published is dropped on store. The implementation is still unreached.
+**The gap, narrowed by three steps.** PR-36 added `ml_kem_public` (tag 6) and
+`ml_kem_public_signature` (tag 7) to `common.KeyBundle`, so the wire contract can carry the
+material and `PQ-WIRE` passes. PR-37 gave `db::KeyBundle` its ML-KEM columns, so `auth-service`
+persists and serves what it is handed instead of dropping it. PR-38 put `pq` in this crate's
+`default` set, so the code is compiled into the services that depend on it and `PQ-DEFAULT`
+passes.
+
+**What remains is the whole of the client half.** No client populates the fields — the desktop
+hardcodes `pq_prekey: None` and `client-mobile`'s proto is still forked at tag 5 — and nothing
+reads them back, because `derive_sender_shared_secret` is reached from no session-establishment
+path. The implementation is compiled and unreached, which is a better state than uncompiled and
+unreached, and is not the same as met. I-3 is met when PR-40 closes.
+
+**PR-38's real finding was about the build, not the flag.** A `cargo test --workspace` build
+already enabled `pq`, because `crypto-ffi` declares `default = ["full"] = ["pq"]` and Cargo
+unifies features across a workspace. Services ship from `cargo build --release -p <service>`,
+which unifies nothing, so `cargo tree -p guardyn-auth-service -i ml-kem` found no such package:
+the hybrid tests passed in CI while every deployed binary contained no post-quantum code. When
+a feature is an invariant, `default` is the only correct place for it — an opt-in that the test
+build happens to opt into proves nothing about what ships.
 
 The fields are `optional`, not bare `bytes`, so "never published" and "published empty" stay
 distinct values. On a field whose absence is the normal case for years that distinction is

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -121,6 +121,19 @@ If `rules-verify` fails on a ratchet you did not mean to touch, you added a site
 you the count is *down*, lower the budget in the same PR - the number is a claim about the
 repository, and a stale one is worse than none.
 
+**If `PQ-DEFAULT` fails**, someone has taken `pq` out of `guardyn-crypto`'s `default` feature
+set, and every service built from `cargo build --release -p <service>` will ship with no
+post-quantum code in it. That is not hypothetical: it was the state of every deployed binary
+until PR-38. It is invisible to the test suite, because `crypto-ffi` enables `pq` and Cargo
+unifies features across a `--workspace` build, so the hybrid tests keep passing while the
+shipped artifact has none of it. Restore the feature; do not silence the check.
+
+To confirm what a service actually ships, ask Cargo rather than reading the manifest:
+
+```sh
+cargo tree -p guardyn-auth-service -i ml-kem   # must name ml-kem, not "did not match"
+```
+
 **If `ZK-INIT` fails**, a service is building its own `tracing` subscriber. That service gets
 no JSON logs, no OTel traces, and - the reason this is a hard fail rather than a style nit -
 **no redaction layer**, so any payload or key field it logs reaches the writer in clear. The

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1119
+tokens: 1090
 supersedes: []
 ---
 
@@ -20,14 +20,14 @@ supersedes: []
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
 | 3 | 63 | 70 | `█████████░` |
-| 4 | 4 | 21 | `██░░░░░░░░` |
-| **all** | **93** | **117** | |
+| 4 | 5 | 21 | `██░░░░░░░░` |
+| **all** | **94** | **117** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 24 of 117
+- **Open steps:** 23 of 117
 
 ## Gates
 
@@ -61,7 +61,6 @@ supersedes: []
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
 | PR-83 | 3 | [#268](https://github.com/guardyn/guardyn/issues/268) | Clear the 314 flutter analyze info diagnostics |
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
-| PR-38 | 4 | [#49](https://github.com/guardyn/guardyn/issues/49) | Enable the pq feature across backend services |
 | PR-97 | 4 | [#261](https://github.com/guardyn/guardyn/issues/261) | Version X3DHPrekeyMessage and carry an optional ML-KEM ciphertext |
 | PR-103 | 4 | [#274](https://github.com/guardyn/guardyn/issues/274) | GetKeyBundle never implemented its documented any-device fallback |
 | PR-39 | 4 | [#50](https://github.com/guardyn/guardyn/issues/50) | client-desktop negotiates hybrid PQXDH |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -96,7 +96,7 @@ steps:
   - {id: PR-35, issue: 46, phase: 3, type: chore, status: done, gate: G3, title: "Add baseline test coverage for notification-service and call-service"}
   - {id: PR-36, issue: 47, phase: 4, type: feat, status: done, title: "Extend protos with ML-KEM key material fields"}
   - {id: PR-37, issue: 48, phase: 4, type: feat, status: done, title: "Persist and serve ML-KEM public keys in auth-service"}
-  - {id: PR-38, issue: 49, phase: 4, type: feat, status: todo, title: "Enable the pq feature across backend services"}
+  - {id: PR-38, issue: 49, phase: 4, type: feat, status: done, title: "Enable the pq feature across backend services"}
   # Retitled by PR-101. The original scope - "wire PqxdhProtocol into
   # messaging-service/src/crypto.rs" - named a file PR-30' deleted, in a service ADR-0010
   # made a pure relay. Following it would have put key agreement back on the server and

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -105,6 +105,10 @@ A replayed prekey message fails because the one-time key is already consumed.
 > legitimate state throughout: a bundle with no ML-KEM material is a classical-only device,
 > served whole rather than as a `NOT_FOUND`.
 >
+> `pq` is in `guardyn-crypto`'s `default` set as of PR-38, so the hybrid code is compiled into
+> every service that depends on it rather than only into a workspace test build. That closes
+> `PQ-DEFAULT`; it adds no behaviour on its own.
+>
 > **Nothing populates the fields and no client reads them.** Concretely:
 > `pqxdh.rs::verify_hybrid_bundle` checks the signature only under
 > `if let (Some(key), Some(signature))` **with no `else`**, so the half-pair of rule 4a

--- a/infra/scripts/rules-verify.sh
+++ b/infra/scripts/rules-verify.sh
@@ -157,6 +157,26 @@ check_e2ee_flag() {
   fi
 }
 
+# --------------------------------------------------------------- PQ-DEFAULT
+# The `pq` feature must be in guardyn-crypto's default set. I-3 makes hybrid key
+# agreement the floor, and a post-quantum feature that must be opted into is one
+# that ships off - which is exactly how pqxdh.rs sat unreachable in every backend
+# service while the invariant read as unmet.
+#
+# Machine-defended from the moment it first passed, deliberately. PQ-WIRE was left
+# to "somebody noticing" and .claude/rules/00-invariants.md has carried a paragraph
+# admitting that gap ever since; there is no reason to open a second one.
+check_pq_default() {
+  local line
+  line="$(grep -E '^default = ' backend/crates/crypto/Cargo.toml 2>/dev/null || true)"
+  if printf '%s' "$line" | grep -q '"pq"'; then
+    pass "PQ-DEFAULT: the pq feature is on by default in the crypto crate"
+  else
+    fail "PQ-DEFAULT: the pq feature is not in the crypto crate's default set"
+    show "backend/crates/crypto/Cargo.toml: ${line:-no default = line found}"
+  fi
+}
+
 # -------------------------------------------------------------------- ZK-PII
 # A log macro handed a raw IP, email or phone number. AGENTS.md §4 lists all
 # three as PII, and I-1 forbids PII in any log, span or metric.
@@ -264,6 +284,7 @@ check_rs_unsafe
 check_zk_init
 check_e2ee_dup
 check_e2ee_flag
+check_pq_default
 check_zk_pii
 check_proto_edit
 check_lang_md


### PR DESCRIPTION
## What

`backend/crates/crypto/Cargo.toml`: `default = ["std"]` → `default = ["std", "pq"]`.
Closes the `PQ-DEFAULT` predicate, the last failing row on
`.claude/rules/00-invariants.md` that had an owning step.

I-3 makes hybrid key agreement the floor, not an option, so the feature providing it cannot be
opt-in.

## The finding: a green suite over an empty binary

The one-line diff understates this, and the reason is worth reading before approving.

**A `cargo test --workspace` build already had `pq`.** `crypto-ffi` declares
`default = ["full"] = ["pq"]`, and Cargo unifies features across a workspace build, so
`guardyn-crypto` was compiled with `ml-kem` whenever anything in the workspace pulled it in. CI
has been running `test_hybrid_key_exchange` and `test_hybrid_key_bundle_with_pq` all along.

**Services do not ship from a workspace build.** `backend/crates/*/Dockerfile` runs
`cargo build --release -p <service>`, and a single-package build unifies nothing:

```
# on main
$ cargo tree -p guardyn-auth-service -i ml-kem
error: package ID specification `ml-kem` did not match any packages

# on this branch
$ cargo tree -p guardyn-auth-service -i ml-kem
ml-kem v0.2.1
└── guardyn-crypto v0.1.0
    └── guardyn-auth-service v0.1.0
```

Every deployed binary contained no post-quantum code whatsoever, while the test suite proved it
worked. When a feature is an invariant, `default` is the only correct place for it — an opt-in
that the test build happens to opt into proves nothing about what ships.

## Why there are no per-service `features = ["pq"]` lines

`implementation_plan.md` asks for them on `auth-service`, `messaging-service` and
`call-service`. None of those sets `default-features = false`, so the default set already
reaches them and the line would be a **no-op that reads like a requirement** — the next person
to touch a service `Cargo.toml` could not tell whether it was load-bearing. The one change does
the whole job.

`pq` stays a named feature rather than folding into `std`, so a `--no-default-features`
consumer can still build without `ml-kem`. Nothing in this repository does, and nothing should.

## Why the CI check ships in this PR

`.claude/rules/00-invariants.md` already carries a paragraph admitting `PQ-WIRE` is the one
PASS row nothing in CI defends. Flipping a second row to PASS and leaving it equally undefended
would widen exactly the gap that file complains about, so `check_pq_default` is added to
`infra/scripts/rules-verify.sh` here.

It was verified to **fail** when the feature is removed, not merely to pass today:

```
FAIL PQ-DEFAULT: the pq feature is not in the crypto crate's default set
1 check(s) failed
```

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo test --workspace --exclude guardyn-e2e-tests` (14 suites), `just rules-verify` (13 checks
now, `RS-UNWRAP` still frozen at 48) and `just docs-verify` (all six) pass locally. The
`client-desktop` workspace also compiles — it pulls `guardyn-crypto` with default features on,
so this reaches it too.

## Budget

**7 files, 95 lines (+78/-17).** Inside §2.3 on both limits; no exemption invoked.

## No behaviour change

Nothing populates the ML-KEM fields and nothing reads them back — the desktop hardcodes
`pq_prekey: None` and `client-mobile`'s proto is still forked at tag 5. The code is now
compiled and unreached, which is better than uncompiled and unreached, and is **not** the same
as met. **I-3 is met when PR-40 closes, not here.**

## Deliberately out of scope

- Per-service `features = ["pq"]`, for the reason above.
- `crypto-ffi`'s own `pq`/`full` features — redundant for a default build now, still meaningful
  to a `--no-default-features` consumer.
- The client halves: PR-39 (#50), PR-98 (#262). Bench and fuzz coverage: PR-40 (#51).
- `PQ-WIRE`'s missing CI check. Still unowned work; not this step's to claim.
- `is_pq_available()` in `client-desktop`, which returns a hardcoded `true` and is only now not
  a lie. Structurally wrong either way — it belongs with PR-39.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)
