### PR TITLE
fix(auth): implement the documented any-device key bundle lookup

### DIFF
--- a/backend/crates/auth-service/src/db.rs
+++ b/backend/crates/auth-service/src/db.rs
@@ -150,6 +150,33 @@ fn ml_kem_write_set(
     ]
 }
 
+/// The device ids under `/devices/{user_id}/`, read out of a raw key scan.
+///
+/// The prefix is shared by two kinds of key: the device record itself at
+/// `/devices/{user}/{device}`, and its key material one or more segments deeper
+/// (`.../signed_pre_key`, `.../one_time_keys/0`). A device id is therefore exactly a
+/// remainder with no further `/` in it, and everything else is that device's contents.
+///
+/// Sorted and deduplicated, so "any device" is a deterministic device. That matters more
+/// than it looks: an initiator that fetched a different device on each retry would open
+/// sessions against devices its peer may not be reading, and the failure would look like
+/// dropped messages rather than a lookup bug.
+///
+/// Pure, so the selection rule can be tested without a live TiKV - the same reason
+/// [`one_time_pre_key_paths`] is a function.
+fn device_ids_from_scan(user_id: &str, keys: &[String]) -> Vec<String> {
+    let prefix = format!("/devices/{}/", user_id);
+    let mut ids: Vec<String> = keys
+        .iter()
+        .filter_map(|key| key.strip_prefix(&prefix))
+        .filter(|rest| !rest.is_empty() && !rest.contains('/'))
+        .map(str::to_string)
+        .collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
 /// The two TiKV keys a device's ML-KEM material occupies, as `(public, signature)`.
 ///
 /// One definition, so the read path cannot drift from the write path.
@@ -598,6 +625,68 @@ impl DatabaseClient {
         }
 
         Ok(())
+    }
+
+    /// List this user's device ids, in deterministic order.
+    ///
+    /// A range scan over `/devices/{user_id}/`, filtered by [`device_ids_from_scan`]. The
+    /// scan necessarily returns key material as well as device records - one prefix, two
+    /// kinds of key - so the filtering is not optional.
+    pub async fn list_device_ids(&self, user_id: &str) -> Result<Vec<String>> {
+        let prefix = format!("/devices/{}/", user_id);
+        let start_key = prefix.into_bytes();
+        let mut end_key = start_key.clone();
+        if let Some(last) = end_key.last_mut() {
+            *last += 1;
+        }
+
+        let kvs = self.client.scan(start_key..end_key, 1000).await?;
+        let keys: Vec<String> = kvs
+            .into_iter()
+            .filter_map(|kv| String::from_utf8(Vec::<u8>::from(kv.0)).ok())
+            .collect();
+
+        Ok(device_ids_from_scan(user_id, &keys))
+    }
+
+    /// Resolve a key bundle, honouring the any-device contract, and report which device
+    /// answered.
+    ///
+    /// `auth.proto` documents `GetKeyBundleRequest.device_id` as *"optional, if not set
+    /// returns any device"*. That was never implemented: an empty id was concatenated
+    /// straight into `/devices/{user}//signed_pre_key`, which matches nothing, so every
+    /// caller relying on the documented behaviour got `NOT_FOUND`. `client-desktop` is one
+    /// such caller and has no alternative - this RPC is how a peer's device would be
+    /// learned in the first place.
+    ///
+    /// The device id is returned rather than echoed by the handler, because with an empty
+    /// request the caller genuinely does not know which device it is now talking to, and a
+    /// ratchet is per-device.
+    ///
+    /// A device record without a usable bundle is skipped rather than refused. `create_device`
+    /// and `store_key_bundle` are separate writes and registration only *logs* a failure of
+    /// the second, so a device with no key material is a state the store really reaches;
+    /// letting the first such device mask a later complete one would be a lookup bug
+    /// presenting as an unreachable account.
+    pub async fn get_key_bundle_for_any_device(
+        &self,
+        user_id: &str,
+        device_id: &str,
+    ) -> Result<Option<(String, KeyBundle)>> {
+        if !device_id.is_empty() {
+            return Ok(self
+                .get_key_bundle(user_id, device_id)
+                .await?
+                .map(|bundle| (device_id.to_string(), bundle)));
+        }
+
+        for candidate in self.list_device_ids(user_id).await? {
+            if let Some(bundle) = self.get_key_bundle(user_id, &candidate).await? {
+                return Ok(Some((candidate, bundle)));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Get key bundle
@@ -1282,5 +1371,101 @@ mod tests {
             .collect();
 
         assert_eq!(written, vec![public_path, signature_path]);
+    }
+
+    /// The defect this step exists for, as a unit: a device id must be separable from the
+    /// key material stored beneath it, because both live under the same prefix.
+    ///
+    /// Before PR-103 nothing separated them, because nothing enumerated devices at all - an
+    /// empty `device_id` went straight into `/devices/{user}//signed_pre_key` and matched
+    /// nothing.
+    #[test]
+    fn test_device_ids_are_separated_from_their_key_material() {
+        let scanned = vec![
+            "/devices/u1/dA".to_string(),
+            "/devices/u1/dA/signed_pre_key".to_string(),
+            "/devices/u1/dA/signed_pre_key_signature".to_string(),
+            "/devices/u1/dA/one_time_keys/0".to_string(),
+            "/devices/u1/dA/ml_kem_public".to_string(),
+            "/devices/u1/dB".to_string(),
+            "/devices/u1/dB/signed_pre_key".to_string(),
+        ];
+
+        assert_eq!(
+            device_ids_from_scan("u1", &scanned),
+            vec!["dA".to_string(), "dB".to_string()],
+            "only the one-segment remainders are device ids"
+        );
+    }
+
+    /// "Any device" must mean the *same* device every time.
+    ///
+    /// A scan returns whatever order the store hands back. If that leaked through, an
+    /// initiator retrying a fetch could open a session against a different device than the
+    /// one it first addressed, and a ratchet is per-device - the symptom would be dropped
+    /// messages, not a visible lookup error.
+    #[test]
+    fn test_any_device_is_a_deterministic_device() {
+        let one_order = vec![
+            "/devices/u1/dC".to_string(),
+            "/devices/u1/dA".to_string(),
+            "/devices/u1/dB".to_string(),
+        ];
+        let other_order = vec![
+            "/devices/u1/dB".to_string(),
+            "/devices/u1/dC".to_string(),
+            "/devices/u1/dA".to_string(),
+        ];
+
+        assert_eq!(
+            device_ids_from_scan("u1", &one_order),
+            device_ids_from_scan("u1", &other_order)
+        );
+        assert_eq!(
+            device_ids_from_scan("u1", &one_order).first(),
+            Some(&"dA".to_string())
+        );
+    }
+
+    /// A scan is a prefix match, so a different user's keys cannot appear - but a user id
+    /// that is a prefix of another (`u1` and `u10`) is exactly the case a naive
+    /// `starts_with` on the id alone would get wrong. The trailing `/` in the prefix is what
+    /// prevents it, and this pins that.
+    #[test]
+    fn test_a_prefix_sharing_user_is_not_confused_for_a_device() {
+        let scanned = vec!["/devices/u1/dA".to_string(), "/devices/u10/dZ".to_string()];
+
+        assert_eq!(device_ids_from_scan("u1", &scanned), vec!["dA".to_string()]);
+        assert_eq!(
+            device_ids_from_scan("u10", &scanned),
+            vec!["dZ".to_string()]
+        );
+    }
+
+    /// A user with no devices resolves to no device, not to an empty-string device id.
+    ///
+    /// The empty id is the whole defect; producing one here would re-enter it by another
+    /// route, with `get_key_bundle` then reading `/devices/{user}//signed_pre_key` again.
+    #[test]
+    fn test_no_devices_yields_no_device_id() {
+        assert!(device_ids_from_scan("u1", &[]).is_empty());
+        assert!(
+            device_ids_from_scan("u1", &["/devices/u1/".to_string()]).is_empty(),
+            "a bare prefix is not a device"
+        );
+    }
+
+    /// Duplicates collapse. Every device contributes several scanned keys, and its record
+    /// and its material must not make it look like two devices.
+    #[test]
+    fn test_a_device_is_counted_once() {
+        let scanned = vec![
+            "/devices/u1/dA".to_string(),
+            "/devices/u1/dA/signed_pre_key".to_string(),
+            "/devices/u1/dA/one_time_keys/0".to_string(),
+            "/devices/u1/dA/one_time_keys/1".to_string(),
+        ];
+
+        assert_eq!(device_ids_from_scan("u1", &scanned), vec!["dA".to_string()]);
     }
 }

--- a/backend/crates/auth-service/src/handlers/key_bundle.rs
+++ b/backend/crates/auth-service/src/handlers/key_bundle.rs
@@ -34,18 +34,21 @@ pub async fn get(
 ) -> Result<Response<GetKeyBundleResponse>, Status> {
     let req = request.into_inner();
 
-    // Get key bundle from database
+    // An empty device_id means "any device", which auth.proto has documented since this RPC
+    // existed. The resolved id comes back with the bundle rather than being echoed from the
+    // request: with an empty request the caller does not know which device answered, and it
+    // needs to, because a ratchet is per-device.
     match service
         .db
-        .get_key_bundle(&req.user_id, &req.device_id)
+        .get_key_bundle_for_any_device(&req.user_id, &req.device_id)
         .await
     {
-        Ok(Some(kb)) => {
+        Ok(Some((device_id, kb))) => {
             let key_bundle = to_proto(kb);
 
             let success = GetKeyBundleSuccess {
                 user_id: req.user_id.clone(),
-                device_id: req.device_id.clone(),
+                device_id,
                 key_bundle: Some(key_bundle),
             };
             Ok(Response::new(GetKeyBundleResponse {

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1090
+tokens: 1055
 supersedes: []
 ---
 
@@ -20,14 +20,14 @@ supersedes: []
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
 | 3 | 63 | 70 | `█████████░` |
-| 4 | 5 | 21 | `██░░░░░░░░` |
-| **all** | **94** | **117** | |
+| 4 | 6 | 21 | `███░░░░░░░` |
+| **all** | **95** | **117** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 23 of 117
+- **Open steps:** 22 of 117
 
 ## Gates
 
@@ -62,7 +62,6 @@ supersedes: []
 | PR-83 | 3 | [#268](https://github.com/guardyn/guardyn/issues/268) | Clear the 314 flutter analyze info diagnostics |
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
 | PR-97 | 4 | [#261](https://github.com/guardyn/guardyn/issues/261) | Version X3DHPrekeyMessage and carry an optional ML-KEM ciphertext |
-| PR-103 | 4 | [#274](https://github.com/guardyn/guardyn/issues/274) | GetKeyBundle never implemented its documented any-device fallback |
 | PR-39 | 4 | [#50](https://github.com/guardyn/guardyn/issues/50) | client-desktop negotiates hybrid PQXDH |
 | PR-98 | 4 | [#262](https://github.com/guardyn/guardyn/issues/262) | Export the hybrid key agreement through crypto-ffi and route client-mobile through it |
 | PR-40 | 4 | [#51](https://github.com/guardyn/guardyn/issues/51) | Add fuzz, proptest and bench coverage for the hybrid PQ path |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -112,7 +112,7 @@ steps:
   # relies on that and sends an empty string, and auth-service concatenates it into
   # /devices/{user}//signed_pre_key, which cannot match. Fixing it on the client is not
   # available: GetKeyBundle is how a peer's device would be learned in the first place.
-  - {id: PR-103, issue: 274, phase: 4, type: fix, status: todo, title: "GetKeyBundle never implemented its documented any-device fallback"}
+  - {id: PR-103, issue: 274, phase: 4, type: fix, status: done, title: "GetKeyBundle never implemented its documented any-device fallback"}
   - {id: PR-39, issue: 50, phase: 4, type: feat, status: todo, title: "client-desktop negotiates hybrid PQXDH"}
   - {id: PR-98, issue: 262, phase: 4, type: feat, status: todo, title: "Export the hybrid key agreement through crypto-ffi and route client-mobile through it"}
   - {id: PR-40, issue: 51, phase: 4, type: security, status: todo, title: "Add fuzz, proptest and bench coverage for the hybrid PQ path"}

--- a/docs/spec/SRS.md
+++ b/docs/spec/SRS.md
@@ -80,6 +80,21 @@ it is recorded here so nobody "fixes" it.
 never fall back to an unauthenticated exchange. Bundle from an unknown device: `NOT_FOUND`.
 A replayed prekey message fails because the one-time key is already consumed.
 
+**An unset `device_id` means any device, and the response names the one that answered.**
+`GetKeyBundleRequest.device_id` is optional; when it is empty the server picks a device the
+user actually has and returns its id in `GetKeyBundleSuccess.device_id`. The choice is
+deterministic — the lexicographically first device with a usable bundle — because an
+initiator that retried and got a different device would open a session against a device its
+peer may not be reading, and a ratchet is per-device. A device record with no key material is
+skipped rather than refused: `create_device` and `store_key_bundle` are separate writes and
+registration only logs a failure of the second, so such a device is a state the store reaches.
+
+**This is a single-device simplification, not the end state.** Signal-family protocols fan a
+session out to *every* device a user has; serving one means a message reaches one. That is the
+behaviour `auth.proto` documents today and all this RPC can express, and changing it is a
+protocol change rather than a fix. It has **no step and no issue** — record one before
+multi-device delivery is promised to anyone.
+
 > **Rules 3 and the replay edge case are not implemented.** `auth-service` serves the
 > one-time pre-keys with a range scan and deletes nothing, so every initiator is handed index
 > `0` for ever, the fourth DH contributes the same secret to every session, and a replayed


### PR DESCRIPTION
## The defect

`auth.proto:236` has documented `GetKeyBundleRequest.device_id` as *"Target device (optional,
if not set returns any device)"* since this RPC existed. **Nothing implemented it.** An empty
id was concatenated straight into `/devices/{user}//signed_pre_key`, which matches nothing, so
`get_key_bundle` returned `Ok(None)` and every caller relying on the documented behaviour got
`NOT_FOUND`.

`client-desktop` is one such caller — `device_id: String::new(), // Request any available
device` (`auth_client.rs:272`) — and has **no alternative**: this RPC is how a peer's
`device_id` would be learned in the first place, so there is nothing else it could send.

The contract was written down and never honoured. That makes this a server fix, not a client
one, and **not a wire contract change** — the proto is already correct.

## Why it blocks Phase 4

PR-37 made `auth-service` serve ML-KEM material. This is what stopped any desktop client
reaching it. PR-39 (#50) has `client-desktop` negotiate hybrid PQXDH — against a bundle it
cannot fetch. Landing PR-39 first would mean debugging a handshake whose first step returns
`NOT_FOUND`.

## The two properties worth reviewing

**1. "Any device" is a *deterministic* device.** A scan returns whatever order the store hands
back. If that leaked through, an initiator retrying a fetch could open a session against a
different device than the one it first addressed — and a ratchet is per-device, so the symptom
would be dropped messages, not a visible lookup error. Resolution is lexicographically first.

**2. A device record with no key material is skipped, not refused.** `create_device` and
`store_key_bundle` are separate writes, and registration only *logs* a failure of the second
(`register.rs:167`), so a device with no bundle is a state the store really reaches. Letting
the first such device mask a later complete one would be a lookup bug presenting as an
unreachable account.

The resolved id is returned with the bundle rather than echoed by the handler from the request:
with an empty request the caller does not know which device answered, and it needs to.

## Tests

`device_ids_from_scan` is pure, following the `one_time_pre_key_paths` precedent — the
selection rule is what is worth asserting, and the scan around it needs a cluster. The scan
prefix carries a trailing `/` so a user id that is a prefix of another (`u1`, `u10`) cannot
cross-match.

Five tests, and **each was verified to fail against a mutated implementation** rather than
merely to pass today:

| Mutation | Caught by |
|---|---|
| drop `ids.sort()` | `test_any_device_is_a_deterministic_device` |
| drop the `!rest.contains('/')` filter | `test_device_ids_are_separated_from_their_key_material`, `test_a_device_is_counted_once` |

Plus prefix-sharing users, and the empty case — which asserts no devices yields *no* device id
rather than an empty-string one, since producing one would re-enter the original defect by
another route.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo test --workspace --exclude guardyn-e2e-tests` (14 suites, 51 in auth-service),
`just rules-verify` and `just docs-verify` all pass — the docs checks re-run **after**
committing, since the impact check reads committed state.

## Budget

**5 files, 222 lines (+212/-10).** Inside §2.3 on both limits; no exemption invoked.

## Deliberately out of scope

- **Multi-device fan-out.** Serving one device is a single-device simplification;
  Signal-family protocols fan a session out to *every* device a user has. That is what the
  proto expresses today, and changing it is a protocol change rather than a fix. Recorded in
  `docs/spec/SRS.md` as having **no step and no issue** — worth one before multi-device
  delivery is promised to anyone.
- **`client-desktop` discards `success.device_id`** (`auth_client.rs:286-290`). The server now
  says which device answered and the client throws it away, so it cannot key a ratchet
  per-device. That is session establishment — PR-39 (#50).
- One-time pre-key consumption (#246) and the lexicographic index defect (#263). Both touch
  the same scan; neither is this step.

## Note for the merge order

Branched from `65bef7b7` while #277 (PR-38) was still open. `roadmap.yaml` edits are on
different lines and auto-merge; `docs/roadmap/STATE.md` will conflict and is resolved by
regenerating with `just docs-state`, never by hand. Say the word and I'll rebase once #277
lands.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)
