### PR TITLE
PR-106 · Add canonicality and strict-parser coverage for the v1 X3DHPrekeyMessage

### DIFF
--- a/backend/crates/crypto/fuzz/Cargo.lock
+++ b/backend/crates/crypto/fuzz/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "ed25519-dalek",
  "guardyn-common",
  "hkdf",
+ "ml-kem",
  "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",
@@ -1043,6 +1044,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1280,6 +1290,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1393,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "rand_core",
+ "sha3",
 ]
 
 [[package]]
@@ -2227,6 +2268,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/backend/crates/crypto/fuzz/fuzz_targets/x3dh_prekey_message.rs
+++ b/backend/crates/crypto/fuzz/fuzz_targets/x3dh_prekey_message.rs
@@ -8,5 +8,15 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = guardyn_crypto::x3dh::X3DHPrekeyMessage::from_bytes(data);
+    if let Ok(message) = guardyn_crypto::x3dh::X3DHPrekeyMessage::from_bytes(data) {
+        // The v1 encoding is canonical: anything the parser accepts must re-encode to exactly
+        // the bytes it was given. Not panicking is the weaker half of what this target is for
+        // - a parser that quietly drops bytes it did not understand is the v0 defect this
+        // format version closes, and `docs/spec/SRS.md` records what that cost.
+        assert_eq!(
+            message.to_bytes(),
+            data,
+            "from_bytes accepted a frame that does not re-encode to itself"
+        );
+    }
 });

--- a/backend/crates/crypto/src/proptests.rs
+++ b/backend/crates/crypto/src/proptests.rs
@@ -126,27 +126,100 @@ proptest! {
         prop_assert!(IdentityKeyPair::verify(&identity.public_bytes(), &other, &signature).is_err());
     }
 
-    /// A prekey message round-trips for *any* one-time key id, not just the `0` every
-    /// client sends today.
+    /// A prekey message round-trips for *any* one-time key id and *any* ML-KEM ciphertext,
+    /// not just the `0` and the `None` every client sends today.
     ///
-    /// The unit tests in `x3dh.rs` used ids 0, 42 and 123 and asserted only the length and
-    /// field equality, so the byte order of this field went unconstrained until #255 - and
-    /// `0`, the only id ever on the wire, is byte-order invariant. The known-answer vectors
-    /// pin the encoding to one constant; this pins the parser across the whole `u32` range,
-    /// where an off-by-one slice or a width mistake would show up as a value that does not
-    /// survive the trip.
+    /// The known-answer vectors pin the encoding to a few constants; this pins the parser
+    /// across the whole `u32` range, where an off-by-one slice or a width mistake shows up as
+    /// a value that does not survive the trip. The ciphertext length is varied for the same
+    /// reason - the vectors use only 4 bytes and 1088, and a `ct_len` mistake could survive
+    /// both.
     #[test]
     fn x3dh_prekey_message_round_trips_any_one_time_key_id(
         identity in prop::collection::vec(any::<u8>(), 32),
         ephemeral in prop::collection::vec(any::<u8>(), 32),
         id in prop::option::of(any::<u32>()),
+        ct in prop::option::of(prop::collection::vec(any::<u8>(), 1..2048)),
     ) {
-        let message = X3DHPrekeyMessage::new(identity.clone(), ephemeral.clone(), id);
+        let mut message = X3DHPrekeyMessage::new(identity.clone(), ephemeral.clone(), id);
+        if let Some(ref bytes) = ct {
+            message = message.with_pq_ciphertext(bytes.clone());
+        }
         let decoded = X3DHPrekeyMessage::from_bytes(&message.to_bytes()).expect("decode");
 
         prop_assert_eq!(decoded.sender_identity_key, identity);
         prop_assert_eq!(decoded.ephemeral_key, ephemeral);
         prop_assert_eq!(decoded.used_one_time_key_id, id);
+        prop_assert_eq!(decoded.pq_ciphertext, ct);
+    }
+
+    /// The v1 encoding is canonical: every frame the parser accepts re-encodes to itself.
+    ///
+    /// This is the property that closes the v0 loophole: v0 never checked an exact length, so
+    /// a frame with anything appended decoded to a message whose re-encoding was shorter than
+    /// the input, and that silent discard is what would have let an ML-KEM ciphertext be
+    /// appended and ignored. A parser that cannot lose bytes cannot have that defect.
+    ///
+    /// The input is a *valid* frame with one byte overwritten, not random bytes: pure noise
+    /// practically never satisfies the version byte and the framing at once, so the assertion
+    /// would almost never run and the property would be decorative.
+    #[test]
+    fn x3dh_prekey_message_encoding_is_canonical(
+        id in prop::option::of(any::<u32>()),
+        ct in prop::option::of(prop::collection::vec(any::<u8>(), 1..256)),
+        index in any::<prop::sample::Index>(),
+        replacement in any::<u8>(),
+    ) {
+        let mut message = X3DHPrekeyMessage::new(vec![7u8; 32], vec![9u8; 32], id);
+        if let Some(bytes) = ct {
+            message = message.with_pq_ciphertext(bytes);
+        }
+
+        let mut frame = message.to_bytes();
+        // The unmutated frame must itself be canonical.
+        let decoded = X3DHPrekeyMessage::from_bytes(&frame).expect("decode");
+        prop_assert_eq!(decoded.to_bytes(), frame.clone());
+
+        let position = index.index(frame.len());
+        frame[position] = replacement;
+        if let Ok(decoded) = X3DHPrekeyMessage::from_bytes(&frame) {
+            prop_assert_eq!(decoded.to_bytes(), frame);
+        }
+    }
+
+    /// Appending anything to a valid frame must be refused, never silently dropped.
+    #[test]
+    fn x3dh_prekey_message_rejects_trailing_bytes(
+        id in prop::option::of(any::<u32>()),
+        ct in prop::option::of(prop::collection::vec(any::<u8>(), 1..256)),
+        suffix in prop::collection::vec(any::<u8>(), 1..16),
+    ) {
+        let mut message = X3DHPrekeyMessage::new(vec![7u8; 32], vec![9u8; 32], id);
+        if let Some(bytes) = ct {
+            message = message.with_pq_ciphertext(bytes);
+        }
+
+        let mut frame = message.to_bytes();
+        prop_assert!(X3DHPrekeyMessage::from_bytes(&frame).is_ok());
+
+        frame.extend_from_slice(&suffix);
+        prop_assert!(X3DHPrekeyMessage::from_bytes(&frame).is_err());
+    }
+
+    /// Any reserved flag bit must be an error. v0 compared its flag byte `== 1`, so `2..=255`
+    /// read as "no one-time key" - a whole byte of extension space silently ignored.
+    #[test]
+    fn x3dh_prekey_message_rejects_reserved_flag_bits(
+        id in prop::option::of(any::<u32>()),
+        reserved in 1u8..64,
+    ) {
+        let frame = X3DHPrekeyMessage::new(vec![7u8; 32], vec![9u8; 32], id).to_bytes();
+        prop_assert!(X3DHPrekeyMessage::from_bytes(&frame).is_ok());
+
+        let mut tampered = frame;
+        // Bits 0x04 and above are reserved; `reserved` is shifted into that range.
+        tampered[65] |= reserved << 2;
+        prop_assert!(X3DHPrekeyMessage::from_bytes(&tampered).is_err());
     }
 
     /// `from_bytes` is reachable from attacker-controlled bytes - the server relays the

--- a/docs/adr/ADR-0005-hybrid-pqxdh.md
+++ b/docs/adr/ADR-0005-hybrid-pqxdh.md
@@ -64,6 +64,43 @@ reads them back, because `derive_sender_shared_secret` is reached from no sessio
 path. The implementation is compiled and unreached, which is a better state than uncompiled and
 unreached, and is not the same as met. I-3 is met when PR-40 closes.
 
+**The ciphertext now has somewhere to ride.** "Every wire structure carrying key material must
+have room for an ML-KEM key" was true of `common.KeyBundle` after PR-36, but the *handshake* has
+a second structure: `derive_sender_shared_secret` returns a 1088-byte ciphertext the responder
+must decapsulate, and that is per-handshake data rather than published key material, so it does
+not belong in a key bundle. It rides in `X3DHPrekeyMessage`, inside the opaque `x3dh_prekey`
+string the server relays without inspecting ([ADR-0010](ADR-0010-pure-relay-server.md)) — which
+is why PR-97 needed no proto change at all.
+
+That format could not grow. It had no version byte, its parser ignored trailing bytes, and its
+one-time-key flag was compared `== 1` so every other value read as "absent". Appending a
+ciphertext to it would have been *silently accepted* by an unchanged peer, which would then
+derive a classical secret against an initiator's hybrid one — an I-3 failure presenting as an
+AEAD tag rejection. PR-97 versioned it, replaced the flag byte with a flags byte, and made the
+parser strict; the layout is in [SRS.md](../spec/SRS.md#x3dh-prekey-message-wire-format).
+
+**The break was accepted, not negotiated.** Byte 0 of the old format was the first byte of an
+Ed25519 public key, so unlike the ratchet frame in
+[ADR-0011](ADR-0011-ratchet-header-authentication.md) there is no value that distinguishes old
+from new. There is deliberately no fallback path: guessing which format a frame is in would
+reintroduce exactly the ambiguity a version byte exists to remove. Rust and `client-desktop`
+moved to v1 in PR-97 and `client-mobile` in PR-105
+([#279](https://github.com/guardyn/guardyn/issues/279)).
+
+**The cost of splitting it across two PRs was a live interop break.** Between those merges the
+two clients could not establish a session with each other at all, and **no CI job detected it** -
+`mobile.yml` runs only Dart tests, `build.yml` only Rust ones, and `just
+test-two-client-messaging`, the one check that proves the two ends interoperate, needs two real
+devices and is wired into no workflow. Both suites stayed green throughout. The split was
+necessary under the `AGENTS.md` §2.3 budget and the break was signposted in both PRs, but a
+lockstep format change is the case where that budget and a green `main` genuinely conflict, and
+the honest record is that green meant nothing here. What now holds the two ends together is the
+known-answer vectors: Rust emits them, Dart asserts them, and the strict-parser cases are ported
+on both sides because a lenient parser satisfies every vector and is still wrong.
+
+Nothing populates the field yet. PR-97 made the format *capable*; PR-39 (desktop) and PR-98
+(mobile) are what put a ciphertext in it.
+
 **PR-38's real finding was about the build, not the flag.** A `cargo test --workspace` build
 already enabled `pq`, because `crypto-ffi` declares `default = ["full"] = ["pq"]` and Cargo
 unifies features across a workspace. Services ship from `cargo build --release -p <service>`,

--- a/docs/roadmap/STATE.md
+++ b/docs/roadmap/STATE.md
@@ -4,7 +4,7 @@ type: roadmap
 status: accepted
 owns: [docs/roadmap/roadmap.yaml]
 read_when: [asking where the work is, reporting at a gate]
-tokens: 1057
+tokens: 1021
 supersedes: []
 ---
 
@@ -20,14 +20,14 @@ supersedes: []
 | 1 | 19 | 19 | `██████████` |
 | 2 | 7 | 7 | `██████████` |
 | 3 | 63 | 70 | `█████████░` |
-| 4 | 8 | 23 | `███░░░░░░░` |
-| **all** | **97** | **119** | |
+| 4 | 9 | 23 | `████░░░░░░` |
+| **all** | **98** | **119** | |
 
 ## Position
 
 - **Current phase:** 3
 - **Next gate:** G4
-- **Open steps:** 22 of 119
+- **Open steps:** 21 of 119
 
 ## Gates
 
@@ -61,7 +61,6 @@ supersedes: []
 | PR-82 | 3 | [#211](https://github.com/guardyn/guardyn/issues/211) | Add an FFI-backed mobile CI job |
 | PR-83 | 3 | [#268](https://github.com/guardyn/guardyn/issues/268) | Clear the 314 flutter analyze info diagnostics |
 | PR-89 | 3 | [#235](https://github.com/guardyn/guardyn/issues/235) | group_chat_page_test renders a replica of the page, not the page |
-| PR-106 | 4 | [#280](https://github.com/guardyn/guardyn/issues/280) | Add canonicality and strict-parser coverage for the v1 X3DHPrekeyMessage |
 | PR-39 | 4 | [#50](https://github.com/guardyn/guardyn/issues/50) | client-desktop negotiates hybrid PQXDH |
 | PR-98 | 4 | [#262](https://github.com/guardyn/guardyn/issues/262) | Export the hybrid key agreement through crypto-ffi and route client-mobile through it |
 | PR-40 | 4 | [#51](https://github.com/guardyn/guardyn/issues/51) | Add fuzz, proptest and bench coverage for the hybrid PQ path |

--- a/docs/roadmap/roadmap.yaml
+++ b/docs/roadmap/roadmap.yaml
@@ -123,7 +123,7 @@ steps:
   # eleven-case rejection test, and the pre-existing round-trip and never-panics properties,
   # which still exercise the new parser unchanged. This step adds what those cannot reach -
   # canonicality over mutated frames, and the same assertion inside the fuzz target.
-  - {id: PR-106, issue: 280, phase: 4, type: security, status: todo, title: "Add canonicality and strict-parser coverage for the v1 X3DHPrekeyMessage"}
+  - {id: PR-106, issue: 280, phase: 4, type: security, status: done, title: "Add canonicality and strict-parser coverage for the v1 X3DHPrekeyMessage"}
   # Found while executing PR-37 and left out of it rather than widening that step. Must
   # precede PR-39: PR-37 made auth-service serve ML-KEM material, and this is what stops the
   # desktop reaching it, so PR-39 would negotiate hybrid against a bundle it cannot fetch.


### PR DESCRIPTION
Closes #280

The adversarial half of the v1 `X3DHPrekeyMessage` parser, split out of PR-97
([#261](https://github.com/guardyn/guardyn/issues/261)) **before** that PR was opened: the codec,
its known-answer vectors and the `SRS.md` wire-format section were already 5 files / 524 lines,
and this on top put it at 9 files / 705 lines — over both `AGENTS.md` §2.3 limits. Separating
property and fuzz coverage into its own step is the existing pattern here (PR-34, PR-40).

**PR-97 did not ship an untested parser.** It carried seven known-answer vectors, an eleven-case
rejection test and a `Debug`-redaction test, and the pre-existing round-trip and never-panics
properties exercised the new parser unchanged. What example-based tests cannot reach is the space
of frames nobody thought to write down — which is where a strict parser's mistakes live.

## The properties

| Property | What it pins |
|---|---|
| **`x3dh_prekey_message_encoding_is_canonical`** | **Every accepted frame re-encodes to itself** |
| `x3dh_prekey_message_rejects_trailing_bytes` | The v0 loophole, as a property rather than an example |
| `x3dh_prekey_message_rejects_reserved_flag_bits` | Bits `0x04`–`0x80` are an error, not a shrug |
| `..._round_trips_any_one_time_key_id` (extended) | Now varies the ciphertext length too |

Canonicality is the one that matters. v0 never checked an exact length, so a frame with anything
appended decoded to a message whose re-encoding was **shorter than the input** — and that silent
discard is exactly what would have let an ML-KEM ciphertext be appended and ignored, leaving the
responder on a classical secret against the initiator's hybrid one. *A parser that cannot lose
bytes cannot have that defect.*

It generates a **valid frame and overwrites one byte**, rather than taking random bytes. Pure
noise practically never satisfies the version byte and the framing at once, so the assertion
would almost never run and the property would be decorative — which is the failure mode this
repository keeps finding in its own tests, not a hypothetical. Mutating a real frame keeps the
parser in the region where accepting is plausible, which is where a non-canonical acceptance
would actually live.

The round-trip extension matters for a narrow reason: the vectors cover only 4 bytes and 1088, so
a `ct_len` mistake could survive both.

## Fuzzing

The target now **asserts canonicality on every accepted input** instead of discarding the result.
Not panicking is the weaker half of what it is for.

```
96,305,888 executions — no crash, no canonicality violation, artifacts/ empty
```

The corpus is gitignored so it is not in this diff, but it is worth regenerating locally: the
five seeds that were there are v0 and **every one is now rejected at byte 0**, which makes them
dead weight. The run above used v1 seeds covering the four flag combinations plus a real
1088-byte ciphertext.

## `fuzz/Cargo.lock`

Gains `ml-kem` and `hybrid-array`. Generated, and a consequence of **PR-38** making `pq` default
rather than of anything in this PR — the fuzz crate's lock had simply not been refreshed since.

## ADR-0005

Records that the ML-KEM ciphertext now has somewhere to ride, that the break was accepted rather
than negotiated, and — corrected to post-merge reality, since #279 landed while this was queued —
**what the split actually cost**:

> Between those merges the two clients could not establish a session with each other at all, and
> **no CI job detected it** — `mobile.yml` runs only Dart tests, `build.yml` only Rust ones, and
> `just test-two-client-messaging`, the one check that proves the two ends interoperate, needs two
> real devices and is wired into no workflow. Both suites stayed green throughout.

A lockstep format change is the case where the §2.3 budget and a green `main` genuinely conflict.
The split was necessary and was signposted in both PRs, but the honest record is that green meant
nothing there, and that is worth writing down rather than leaving as a thing that happened to
work out.

## Budget

**6 files, 202 lines (+186 −16).** Real numbers; no exemption invoked.

## Verification

```
cargo test --workspace --exclude guardyn-e2e-tests   pass (110 in guardyn-crypto, up from 107)
cargo fmt --all -- --check                           clean
cargo clippy --all-targets --all-features -D warnings clean
just fuzz x3dh_prekey_message 180                    96.3M execs, no crash
just rules-verify                                    pass, ratchets unchanged at 48 / 5
just docs-verify                                     all six pass, impact satisfied by ADR-0005
```

## This closes the PR-97 series

`X3DHPrekeyMessage` v1 is now implemented in Rust (PR-97), Dart (PR-105) and covered here.
Populating the ciphertext is still open: PR-39 ([#50](https://github.com/guardyn/guardyn/issues/50))
on desktop and PR-98 ([#262](https://github.com/guardyn/guardyn/issues/262)) on mobile. **I-3 is
not met until those land** — the format is capable, and nothing fills it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
